### PR TITLE
fix(infra): reject loopback addresses in Consul service registration

### DIFF
--- a/isA_common/isa_common/consul_client.py
+++ b/isA_common/isa_common/consul_client.py
@@ -11,9 +11,19 @@ import socket
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Optional
 
+import ipaddress
+
 import consul
 
 logger = logging.getLogger(__name__)
+
+
+def _is_loopback(host: str) -> bool:
+    """Return True if *host* is a loopback address (127.x.x.x, ::1, localhost)."""
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host.lower() == "localhost"
 
 
 class ConsulRegistry:
@@ -55,20 +65,37 @@ class ConsulRegistry:
 
         # Only set these if we're registering (have service_name and service_port)
         if service_name and service_port is not None:
-            # Handle 0.0.0.0 which is invalid for Consul service registration
-            # Priority: 1. Explicit service_host, 2. HOSTNAME env var, 3. socket.gethostname()
-            # In Docker, HOSTNAME is set to the container name which is DNS resolvable
+            # Resolve the address that Consul advertises to APISIX / other consumers.
+            # Loopback (127.x.x.x / ::1) and unspecified (0.0.0.0) are never
+            # routable from a gateway context, so we skip them and fall through
+            # to hostname-based detection.
             import os
 
-            if service_host and service_host != "0.0.0.0":
+            def _usable(addr: str | None) -> bool:
+                return bool(addr) and addr != "0.0.0.0" and not _is_loopback(addr)
+
+            if _usable(service_host):
                 self.service_host = service_host
             else:
                 # Priority: SERVICE_HOST (K8s Service DNS) > HOSTNAME (Docker container name) > hostname
-                # In K8s: SERVICE_HOST = "service.namespace.svc.cluster.local" (resolvable by Consul)
-                # In Docker: SERVICE_HOST not set, falls back to HOSTNAME (container name, also resolvable)
-                self.service_host = os.getenv("SERVICE_HOST") or os.getenv(
-                    "HOSTNAME", socket.gethostname()
+                env_host = os.getenv("SERVICE_HOST")
+                if _usable(env_host):
+                    self.service_host = env_host
+                else:
+                    self.service_host = os.getenv(
+                        "HOSTNAME", socket.gethostname()
+                    )
+
+            # Final guard: warn if the resolved address is still loopback
+            if _is_loopback(self.service_host):
+                logger.warning(
+                    f"Consul will register {service_name} at loopback address "
+                    f"'{self.service_host}'. This is unreachable from APISIX/gateway "
+                    f"context and will cause 502 errors. Set SERVICE_HOST to a "
+                    f"routable address (container hostname, K8s service DNS, or "
+                    f"host-reachable IP)."
                 )
+
             self.service_id = f"{service_name}-{self.service_host}-{service_port}"
         else:
             import os


### PR DESCRIPTION
## Summary
- Consul `ConsulRegistry.__init__` now skips loopback addresses (`127.x.x.x`, `::1`, `localhost`) when resolving `service_host`, same as it already skips `0.0.0.0`
- Falls through to hostname-based detection (`HOSTNAME` env var → `socket.gethostname()`) which gives routable container names in Docker/K8s
- Emits a warning if the final resolved address is still loopback (e.g., when hostname itself resolves to loopback)
- Adds `_is_loopback()` helper using `ipaddress.ip_address` for robust detection

## Context
Services registering with `ServiceAddress=127.0.0.1` in Consul are unreachable from APISIX/gateway pods, causing `502 Bad Gateway` for auth, MCP, and other gateway-routed services.

## Cross-repo follow-ups (not in this PR)
- `isA_user/deployment/environments/dev.env` — comment out `SERVICE_HOST=127.0.0.1`
- `isA_Model/deployment/environments/dev.env` — comment out `SERVICE_HOST=127.0.0.1`
- `isA_MCP/deployment/environments/dev.env` — comment out `SERVICE_HOST=127.0.0.1`
- `isA_user/microservices/location_service/routes_registry.py` — fix `base_path=/api/v1` → `/api/v1/locations` (tracked in #17)

## Testing
- Verified `_is_loopback()` correctly identifies `127.0.0.1`, `::1`, `localhost` as loopback
- Verified non-loopback addresses (`192.168.x.x`, container names, K8s DNS) pass through

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)