### PR TITLE
fix(infra): add NATS consumer resilience, observability, and runbook

### DIFF
--- a/docs/runbooks/nats-consumer-lag.md
+++ b/docs/runbooks/nats-consumer-lag.md
@@ -1,0 +1,113 @@
+# Runbook: NATS Consumer Lag / Billing Event Delays
+
+## Symptoms
+
+- Billing records not appearing after model invocations
+- Growing gap between usage events published and billing records created
+- Logs show repeated `NATS pull messages failed` or `connection closed` errors
+- Health check shows `consecutive_errors > 0` or high `reconnect_count`
+
+## Quick Health Check
+
+```bash
+# Check billing consumer health (from billing_service)
+curl -s http://localhost:8225/health | jq '.nats'
+
+# Check NATS server health
+nats server check connection --server nats://localhost:4222
+
+# Check stream info and consumer lag
+nats stream info USAGE_EVENTS --server nats://localhost:4222
+nats consumer info USAGE_EVENTS billing-consumer --server nats://localhost:4222
+```
+
+Key metrics to check:
+- **Unprocessed Messages**: `num_pending` in consumer info (should be near 0)
+- **Redeliveries**: `num_redelivered` (high value = processing failures)
+- **Ack Floor**: `ack_floor` vs stream's last sequence (gap = lag)
+
+## Common Failure Modes
+
+### 1. Consumer disconnected / reconnect loop
+
+**Symptoms**: Logs show `NATS disconnected` followed by `NATS reconnected` repeatedly.
+
+**Diagnosis**:
+```bash
+# Check health endpoint for reconnect stats
+curl -s http://localhost:8225/health | jq '{
+  reconnect_count: .nats.reconnect_count,
+  consecutive_errors: .nats.consecutive_errors,
+  total_messages_pulled: .nats.total_messages_pulled
+}'
+```
+
+**Resolution**:
+1. Check NATS server is healthy: `nats server check connection`
+2. Check network between consumer pod and NATS: `nats rtt`
+3. If NATS server restarted, consumer should auto-recover (exponential backoff in consumer loop)
+4. If stuck, restart billing_service pod
+
+### 2. Messages published but not consumed
+
+**Symptoms**: Stream message count grows, consumer `num_pending` grows.
+
+**Diagnosis**:
+```bash
+# Compare stream last seq vs consumer ack floor
+nats stream info USAGE_EVENTS -j | jq '.state.last_seq'
+nats consumer info USAGE_EVENTS billing-consumer -j | jq '.ack_floor.stream_seq'
+```
+
+**Resolution**:
+1. Check consumer is running: look for `Starting consumer` log in billing_service
+2. Check for handler errors: `grep "Error processing message" billing_service.log`
+3. If consumer is stuck on a poison message, check `num_redelivered` count
+4. Last resort: delete and recreate consumer (messages will replay from stream)
+
+### 3. Ack failures
+
+**Symptoms**: `total_ack_failures` incrementing in health check, messages redelivered.
+
+**Diagnosis**: Ack failures usually mean the NATS connection dropped between fetch and ack.
+
+**Resolution**:
+1. Messages are auto-acked after fetch; handlers are idempotent
+2. Redelivered messages will be processed again (at-least-once delivery)
+3. If ack failures are sustained, check NATS server stability
+
+### 4. High latency between publish and consume
+
+**Symptoms**: Billing records created with delay, but eventually consistent.
+
+**Diagnosis**:
+```bash
+# Check consumer loop timing
+grep "total_processed=" billing_service.log | tail -5
+```
+
+**Resolution**:
+1. Check consumer batch size (default 10) and poll interval
+2. If consumer loop is in backoff (error recovery), wait for it to reset
+3. Scale billing consumers horizontally if throughput is the bottleneck
+
+## Preventive Monitoring
+
+### Alerts to set up
+- `num_pending > 1000` for more than 5 minutes
+- `consecutive_errors > 10` in health check
+- `reconnect_count` increasing faster than 1/minute
+
+### Periodic checks
+- Weekly: review `total_ack_failures` trend
+- After deployments: verify consumer reconnects and catches up within 60s
+
+## Recovery Procedure
+
+If billing consumer is completely stuck:
+
+1. **Check NATS server**: `nats server check connection`
+2. **Check stream exists**: `nats stream ls`
+3. **Check consumer exists**: `nats consumer ls USAGE_EVENTS`
+4. **Restart billing_service**: Consumer will reconnect and resume from last ack position
+5. **If consumer state is corrupted**: Delete consumer (`nats consumer rm USAGE_EVENTS billing-consumer`) and restart — it will be recreated and replay from stream

--- a/isA_common/isa_common/async_nats_client.py
+++ b/isA_common/isa_common/async_nats_client.py
@@ -13,6 +13,7 @@ providing full support for all NATS operations including:
 """
 
 import os
+import time
 import asyncio
 from typing import List, Dict, Optional, AsyncIterator, Any
 
@@ -71,6 +72,13 @@ class AsyncNATSClient(AsyncBaseClient):
         self._subscriptions: Dict[str, Any] = {}
         self._reconnect_lock = asyncio.Lock()
 
+        # Reconnect observability
+        self._reconnect_count: int = 0
+        self._last_reconnect_ts: float = 0.0
+        self._consecutive_errors: int = 0
+        self._total_messages_pulled: int = 0
+        self._total_ack_failures: int = 0
+
     def _get_subject_prefix(self) -> str:
         """Get subject prefix for multi-tenant isolation (NATS uses '.' separator)."""
         return f"{self.organization_id}.{self.user_id}."
@@ -119,9 +127,14 @@ class AsyncNATSClient(AsyncBaseClient):
 
     async def _recover_connection(self, operation: str, error: Exception) -> None:
         """Force reconnect after connection-level failures."""
-        self._logger.warning(f"NATS {operation} hit connection error, forcing reconnect: {error}")
+        self._consecutive_errors += 1
+        self._logger.warning(
+            f"NATS {operation} hit connection error, forcing reconnect: {error} "
+            f"(consecutive_errors={self._consecutive_errors})"
+        )
         async with self._reconnect_lock:
             if self._connection_healthy():
+                self._consecutive_errors = 0
                 return
             try:
                 await self._disconnect()
@@ -129,6 +142,9 @@ class AsyncNATSClient(AsyncBaseClient):
                 self._logger.debug(f"NATS disconnect during recovery failed: {disconnect_error}")
             await self._connect()
             self._connected = True
+            self._reconnect_count += 1
+            self._last_reconnect_ts = time.monotonic()
+            self._consecutive_errors = 0
 
     async def _ensure_connected(self) -> None:
         """Ensure NATS connection is healthy; reconnect when stale/closed."""
@@ -152,19 +168,32 @@ class AsyncNATSClient(AsyncBaseClient):
 
         async def _on_disconnected():
             if self._connected:
-                self._logger.warning("NATS disconnected")
+                self._consecutive_errors += 1
+                self._logger.warning(
+                    f"NATS disconnected (reconnects={self._reconnect_count}, "
+                    f"consecutive_errors={self._consecutive_errors})"
+                )
             self._connected = False
 
         async def _on_reconnected():
             self._connected = True
-            self._logger.info("NATS reconnected")
+            self._reconnect_count += 1
+            self._last_reconnect_ts = time.monotonic()
+            self._consecutive_errors = 0
+            self._logger.info(
+                f"NATS reconnected (total_reconnects={self._reconnect_count})"
+            )
 
         async def _on_closed():
             self._connected = False
             self._logger.warning("NATS connection closed")
 
         async def _on_error(error):
-            self._logger.warning(f"NATS async error: {error}")
+            self._consecutive_errors += 1
+            self._logger.warning(
+                f"NATS async error: {error} "
+                f"(consecutive_errors={self._consecutive_errors})"
+            )
 
         connect_opts = {
             'servers': [server_url],
@@ -224,6 +253,10 @@ class AsyncNATSClient(AsyncBaseClient):
                 'nats_status': 'connected' if healthy else 'disconnected',
                 'jetstream_enabled': jetstream_enabled,
                 'connections': 1 if healthy else 0,
+                'reconnect_count': self._reconnect_count,
+                'consecutive_errors': self._consecutive_errors,
+                'total_messages_pulled': self._total_messages_pulled,
+                'total_ack_failures': self._total_ack_failures,
                 'message': 'NATS server is reachable'
             }
 
@@ -558,12 +591,17 @@ class AsyncNATSClient(AsyncBaseClient):
                         'sequence': msg.metadata.sequence.stream,
                         'num_delivered': msg.metadata.num_delivered
                     })
+                    self._total_messages_pulled += 1
                     # Auto-ack after fetch so durable consumers can advance.
                     # Event handlers are idempotent and should tolerate at-least-once delivery.
                     try:
                         await msg.ack()
                     except Exception as ack_error:
-                        self._logger.warning(f"Failed to ack message {msg.subject}: {ack_error}")
+                        self._total_ack_failures += 1
+                        self._logger.warning(
+                            f"Failed to ack message {msg.subject}: {ack_error} "
+                            f"(total_ack_failures={self._total_ack_failures})"
+                        )
             except NATSTimeoutError:
                 pass  # No messages available
             except Exception as fetch_error:

--- a/isA_common/tests/nats/test_async_nats_reconnect.py
+++ b/isA_common/tests/nats/test_async_nats_reconnect.py
@@ -6,7 +6,7 @@ Guards against stale/closed connection loops in consumers.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from nats.errors import ConnectionClosedError
@@ -19,6 +19,19 @@ class _FakeNC:
         self.is_connected = connected
         self.is_closed = closed
         self.publish = AsyncMock()
+
+
+class _FakeMsg:
+    """Fake JetStream message with metadata and ack."""
+
+    def __init__(self, subject="test.subject", data=b"{}"):
+        self.subject = subject
+        self.data = data
+        self.metadata = SimpleNamespace(
+            sequence=SimpleNamespace(stream=1),
+            num_delivered=1,
+        )
+        self.ack = AsyncMock()
 
 
 @pytest.mark.asyncio
@@ -76,3 +89,91 @@ async def test_publish_retries_once_after_connection_error():
     assert result is not None and result.get("success") is True
     assert client._nc.publish.await_count == 2
     client._recover_connection.assert_awaited_once()
+
+
+# ============================================
+# Reconnect stats tracking
+# ============================================
+
+
+@pytest.mark.asyncio
+async def test_recover_connection_increments_reconnect_count():
+    """Recover connection should bump reconnect_count and reset consecutive_errors."""
+    client = AsyncNATSClient(host="localhost", port=4222, user_id="u1", organization_id="o1")
+    client._connected = False
+    client._nc = _FakeNC(connected=False, closed=True)
+    client._js = None
+
+    async def _fake_connect():
+        client._nc = _FakeNC(connected=True, closed=False)
+        client._js = object()
+        client._connected = True
+
+    client._disconnect = AsyncMock()
+    client._connect = AsyncMock(side_effect=_fake_connect)
+
+    assert client._reconnect_count == 0
+    assert client._consecutive_errors == 0
+
+    await client._recover_connection("test_op", ConnectionClosedError())
+
+    assert client._reconnect_count == 1
+    assert client._consecutive_errors == 0
+    assert client._last_reconnect_ts > 0
+
+
+@pytest.mark.asyncio
+async def test_recover_connection_skips_if_already_healthy():
+    """Recover should not bump counts when the connection is already healthy."""
+    client = AsyncNATSClient(host="localhost", port=4222, user_id="u1", organization_id="o1")
+    client._connected = True
+    client._nc = _FakeNC(connected=True, closed=False)
+    client._js = object()
+    client._disconnect = AsyncMock()
+    client._connect = AsyncMock()
+
+    await client._recover_connection("test_op", ConnectionClosedError())
+
+    # Connection was already healthy inside the lock, so no reconnect triggered
+    client._connect.assert_not_awaited()
+    assert client._consecutive_errors == 0
+
+
+@pytest.mark.asyncio
+async def test_health_check_includes_reconnect_stats():
+    """Health check should return reconnect and message processing stats."""
+    client = AsyncNATSClient(host="localhost", port=4222, user_id="u1", organization_id="o1")
+    client._connected = True
+    client._nc = _FakeNC(connected=True, closed=False)
+    client._js = object()
+    client._reconnect_count = 3
+    client._total_messages_pulled = 42
+    client._total_ack_failures = 1
+
+    health = await client.health_check()
+
+    assert health["reconnect_count"] == 3
+    assert health["total_messages_pulled"] == 42
+    assert health["total_ack_failures"] == 1
+    assert health["consecutive_errors"] == 0
+
+
+@pytest.mark.asyncio
+async def test_pull_messages_tracks_message_and_ack_stats():
+    """Pull messages should increment total_messages_pulled and track ack failures."""
+    client = AsyncNATSClient(host="localhost", port=4222, user_id="u1", organization_id="o1")
+    client._connected = True
+    client._nc = _FakeNC(connected=True, closed=False)
+
+    msg_ok = _FakeMsg(subject="billing.usage.recorded.ok")
+    msg_ack_fail = _FakeMsg(subject="billing.usage.recorded.fail")
+    msg_ack_fail.ack = AsyncMock(side_effect=Exception("ack timeout"))
+
+    pull_sub = SimpleNamespace(fetch=AsyncMock(return_value=[msg_ok, msg_ack_fail]))
+    client._js = SimpleNamespace(pull_subscribe=AsyncMock(return_value=pull_sub))
+
+    messages = await client.pull_messages("USAGE_EVENTS", "billing-consumer", batch_size=10)
+
+    assert len(messages) == 2
+    assert client._total_messages_pulled == 2
+    assert client._total_ack_failures == 1


### PR DESCRIPTION
## Summary
- Added reconnect observability to `AsyncNATSClient`: tracks `reconnect_count`, `consecutive_errors`, `total_messages_pulled`, `total_ack_failures`
- Connection callbacks now log structured metrics for monitoring
- `health_check()` returns reconnect and processing stats for alerting
- `_recover_connection()` resets error counters on successful recovery
- Created runbook for diagnosing NATS consumer lag and billing event delays

## Changes
- `isA_common/isa_common/async_nats_client.py`: Reconnect stats tracking + structured logging
- `isA_common/tests/nats/test_async_nats_reconnect.py`: 4 new tests (7 total)
- `docs/runbooks/nats-consumer-lag.md`: Ops runbook covering health checks, failure modes, alerts, recovery

## Cross-repo
- isA_user PR adds exponential backoff to the NATS consumer loop (`core/nats_client.py`)

## Testing
- All 7 reconnect regression tests pass (3 existing + 4 new)

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)