### PR TITLE
docs: rewrite core docs to reflect Python-native architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# isA Cloud - 云原生基础设施平台
+# isA Cloud - Cloud-Native Infrastructure Platform
 
 <div align="center">
 
-**Kubernetes 基础设施 + 服务网格 + API 网关**
+**Kubernetes Infrastructure + Service Mesh + API Gateway**
 
-[![Go Version](https://img.shields.io/badge/Go-1.23-00ADD8?logo=go)](https://go.dev/)
+[![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python)](https://python.org/)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-1.34-326CE5?logo=kubernetes)](https://kubernetes.io/)
 [![Apache APISIX](https://img.shields.io/badge/APISIX-3.x-F04C23?logo=apache)](https://apisix.apache.org/)
 [![Consul](https://img.shields.io/badge/Consul-1.21-F24C53?logo=consul)](https://www.consul.io/)
@@ -14,559 +14,307 @@
 
 ---
 
-## 📖 目录
+## Overview
 
-- [概述](#概述)
-- [架构](#架构)
-- [仓库职责](#仓库职责)
-- [核心组件](#核心组件)
-- [快速开始](#快速开始)
-- [服务列表](#服务列表)
-- [部署指南](#部署指南)
-- [运维管理](#运维管理)
-- [文档索引](#文档索引)
+**isA Cloud** is the isA platform's cloud-native infrastructure center, providing:
 
----
+### This Repository Provides
 
-## 🎯 概述
+**isa_common Python Library** (native async clients)
+  - Direct async connections to 8 infrastructure backends
+  - No intermediate gRPC layer — clients connect to native ports
+  - Source in `isA_common/isa_common/`
 
-**isA Cloud** 是 isA 平台的云原生基础设施中心，负责：
-
-### 本仓库提供
-
-✅ **基础设施层**  
+**Infrastructure Deployment** (Kubernetes)
   - PostgreSQL, Redis, Neo4j, MinIO, NATS, Mosquitto, Loki, Grafana, Qdrant
-  - Consul (服务发现), APISIX (API 网关)
+  - Consul (service discovery), APISIX (API gateway)
 
-✅ **gRPC 包装服务** (9 个 Go 服务)  
-  - 为基础设施提供统一的 gRPC 接口
-  - 源码位于 `cmd/` 目录
+**GitOps Configuration**
+  - Kubernetes deployment configs (Kustomize)
+  - ArgoCD application definitions
+  - Multi-environment management (dev/staging/production)
 
-✅ **GitOps 配置**  
-  - Kubernetes 部署配置 (Kustomize)
-  - ArgoCD 应用定义
-  - 多环境管理 (dev/staging/production)
+**CI/CD Pipeline**
+  - GitHub Actions automated builds
+  - Image push to ECR
+  - Automated deployment config updates
 
-✅ **CI/CD 流水线**  
-  - GitHub Actions 自动构建
-  - 镜像推送到 ECR
-  - 自动更新部署配置
+### External Business Services (other repositories)
 
-### 外部业务服务 (其他仓库)
+These services have **source code in their own repos**; isA_Cloud contains only their **Kubernetes deployment configs**:
 
-这些服务的**源码在各自仓库**，isA_Cloud 只包含其 **Kubernetes 部署配置**：
-
-- **isA_user** → 27 个用户微服务 (account, auth, session, organization...)
-- **isA_Agent** → AI 智能代理服务
-- **isA_MCP** → 模型控制协议服务
-- **isA_Model** → AI 模型服务
-- **isa-data** → 数据服务
-- **web-service** → Web 服务
+- **isA_user** — 27 user microservices (account, auth, session, organization...)
+- **isA_Agent** — AI agent service
+- **isA_MCP** — Model Control Protocol service
+- **isA_Model** — AI model service
+- **isa-data** — Data service
+- **web-service** — Web service
 
 ---
 
-## 🏗️ 架构
+## Architecture
 
-### 整体架构
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         外部流量                                  │
-└──────────────────────────┬──────────────────────────────────────┘
-                           │
-                           ▼
-                   ┌───────────────┐
-                   │ Apache APISIX │  API 网关 (Port: 9080)
-                   │   (Gateway)   │  - 动态路由（自动同步 Consul）
-                   └───────┬───────┘  - 认证/授权/限流/CORS
-                           │
-                           ▼
-                   ┌───────────────┐
-                   │    Consul     │  服务发现中心
-                   │ (注册 42 服务) │  - 健康检查
-                   └───────┬───────┘  - KV 存储
-                           │
-        ┌──────────────────┼──────────────────┐
-        │                  │                  │
-        ▼                  ▼                  ▼
-┌──────────────┐   ┌──────────────┐   ┌──────────────┐
-│ 基础设施层    │   │ gRPC 服务层  │   │ 业务服务层    │
-│ (本仓库部署) │   │ (本仓库源码) │   │ (外部仓库)   │
-├──────────────┤   ├──────────────┤   ├──────────────┤
-│ PostgreSQL   │   │ postgres-grpc│   │ isA_user     │
-│ Redis        │   │ redis-grpc   │   │  ├─ auth     │
-│ Neo4j        │   │ neo4j-grpc   │   │  ├─ account  │
-│ MinIO        │   │ nats-grpc    │   │  ├─ session  │
-│ NATS         │   │ mqtt-grpc    │   │  └─ ... (27) │
-│ Mosquitto    │   │ duckdb-grpc  │   │              │
-│ Loki         │   │ minio-grpc   │   │ isA_Agent    │
-│ Grafana      │   │ loki-grpc    │   │ isA_MCP      │
-│ Qdrant       │   │ qdrant-grpc  │   │ isA_Model    │
-└──────────────┘   └──────────────┘   │ isa-data     │
-                                       │ isa-os  │
-                                       └──────────────┘
-```
-
-### GitOps 工作流
+### Overall Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│ 1. 开发者提交代码                                             │
-│    ├─ isA_Cloud: 修改 gRPC 服务源码                          │
-│    └─ 外部仓库: 修改业务服务源码                              │
-└────────────────────┬────────────────────────────────────────┘
+                         External Traffic
+                              │
+                              ▼
+                      ┌───────────────┐
+                      │ Apache APISIX │  API Gateway (Port: 9080)
+                      │   (Gateway)   │  - Dynamic routing (auto-sync Consul)
+                      └───────┬───────┘  - Auth/rate-limit/CORS
+                              │
+                              ▼
+                      ┌───────────────┐
+                      │    Consul     │  Service Discovery
+                      │ (42 services) │  - Health checks
+                      └───────┬───────┘  - KV storage
+                              │
+       ┌──────────────────────┼──────────────────────┐
+       │                      │                      │
+       ▼                      ▼                      ▼
+┌──────────────┐     ┌───────────────┐      ┌──────────────┐
+│ Infrastructure│     │  isa_common   │      │ Business     │
+│ (this repo   │     │  Python SDK   │      │ Services     │
+│  deploys)    │     │ (this repo)   │      │ (other repos)│
+├──────────────┤     ├───────────────┤      ├──────────────┤
+│ PostgreSQL   │◄────│ AsyncPostgres │      │ isA_user     │
+│ Redis        │◄────│ AsyncRedis    │      │  ├─ auth     │
+│ Neo4j        │◄────│ AsyncNeo4j    │      │  ├─ account  │
+│ MinIO        │◄────│ AsyncMinIO    │      │  └─ ... (27) │
+│ NATS         │◄────│ AsyncNATS     │      │              │
+│ Mosquitto    │◄────│ AsyncMQTT     │      │ isA_Agent    │
+│ Loki         │     │ AsyncDuckDB   │      │ isA_MCP      │
+│ Grafana      │     │ AsyncQdrant   │      │ isA_Model    │
+│ Qdrant       │     │ ConsulRegistry│      │ isa-data     │
+└──────────────┘     └───────────────┘      └──────────────┘
+      Native Ports         Direct
+   (5432,6379,7687,        Connection
+    4222,9000,1883,        (no gRPC
+    6333,3100)              layer)
+```
+
+### GitOps Workflow
+
+```
+1. Developer commits code
+   ├─ isA_Cloud: modify isa_common library or deployment configs
+   └─ External repo: modify business service code
                      │
                      ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 2. CI 流水线 (GitHub Actions)                                │
-│    本仓库:                                                   │
-│    ├─ 检测变更的 gRPC 服务                                   │
-│    ├─ Lint & Test                                           │
-│    ├─ 构建 Docker 镜像                                       │
-│    ├─ 推送到 ECR                                             │
-│    └─ 安全扫描 (Trivy)                                       │
-│                                                              │
-│    外部仓库:                                                 │
-│    ├─ 构建镜像 → ECR                                         │
-│    └─ 触发 repository_dispatch → isA_Cloud                  │
-└────────────────────┬────────────────────────────────────────┘
+2. CI Pipeline (GitHub Actions)
+   ├─ Lint & Test (pytest for Python, security scans)
+   ├─ Build Docker images
+   ├─ Push to ECR
+   └─ External repos trigger repository_dispatch → isA_Cloud
                      │
                      ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 3. 更新 GitOps 配置 (自动)                                   │
-│    ├─ 本仓库服务: 直接更新 deployment.yaml                   │
-│    ├─ 外部服务: CD workflow 更新 deployment.yaml             │
-│    └─ Git Commit & Push                                     │
-└────────────────────┬────────────────────────────────────────┘
+3. Update GitOps config (automatic)
+   ├─ CD workflow updates deployment.yaml with new image tag
+   └─ Git commit & push
                      │
                      ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 4. ArgoCD 自动同步 (30秒内)                                  │
-│    ├─ 检测 Git 变化                                          │
-│    ├─ 执行同步计划                                           │
-│    └─ 应用到 Kubernetes                                      │
-└────────────────────┬────────────────────────────────────────┘
+4. ArgoCD auto-sync (within 30 seconds)
+   ├─ Detects Git changes
+   └─ Applies to Kubernetes
                      │
                      ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 5. Kubernetes 滚动更新                                       │
-│    ├─ 创建新 Pod                                             │
-│    ├─ 健康检查                                               │
-│    ├─ 服务自动注册到 Consul                                  │
-│    └─ 替换旧 Pod                                             │
-└────────────────────┬────────────────────────────────────────┘
-                     │
-                     ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 6. APISIX 路由同步 (CronJob 每5分钟)                         │
-│    ├─ 从 Consul 获取服务列表                                 │
-│    ├─ 自动创建/更新路由                                      │
-│    └─ 流量路由到新版本 ✅                                    │
-└─────────────────────────────────────────────────────────────┘
+5. Kubernetes rolling update
+   ├─ Creates new Pods → health check → Consul registration
+   └─ APISIX route sync (CronJob every 5 minutes)
 ```
 
 ---
 
-## 📦 仓库职责
-
-### isA_Cloud (本仓库)
+## Repository Structure
 
 ```
 isA_Cloud/
-├── cmd/                          # gRPC 服务源码 (9个 Go 服务)
-│   ├── postgres-service/
-│   ├── redis-service/
-│   ├── neo4j-service/
-│   ├── nats-service/
-│   ├── mqtt-service/
-│   ├── duckdb-service/
-│   ├── minio-service/
-│   ├── loki-service/
-│   └── qdrant-service/
+├── isA_common/                   # Python infrastructure library
+│   ├── isa_common/
+│   │   ├── __init__.py           # Exports (v0.3.1)
+│   │   ├── async_base_client.py  # Abstract base for all clients
+│   │   ├── async_client_config.py
+│   │   ├── async_redis_client.py
+│   │   ├── async_postgres_client.py
+│   │   ├── async_nats_client.py
+│   │   ├── async_neo4j_client.py
+│   │   ├── async_minio_client.py
+│   │   ├── async_qdrant_client.py
+│   │   ├── async_duckdb_client.py
+│   │   ├── async_mqtt_client.py
+│   │   ├── consul_client.py      # Service discovery
+│   │   └── events/               # Event-driven billing architecture
+│   ├── tests/                    # pytest test suite
+│   └── pyproject.toml
 │
-├── deployments/kubernetes/
-│   ├── base/
-│   │   ├── infrastructure/       # 基础设施部署配置
-│   │   │   ├── consul/
-│   │   │   ├── apisix/
-│   │   │   ├── postgres/
-│   │   │   ├── redis/
-│   │   │   ├── neo4j/
-│   │   │   ├── minio/
-│   │   │   ├── nats/
-│   │   │   ├── mosquitto/
-│   │   │   ├── loki/
-│   │   │   ├── grafana/
-│   │   │   └── qdrant/
-│   │   │
-│   │   ├── grpc-services/        # gRPC 服务部署配置
-│   │   │   ├── postgres-grpc/
-│   │   │   ├── redis-grpc/
-│   │   │   └── ...
-│   │   │
-│   │   └── applications/         # 外部服务部署配置（源码在其他仓库）
-│   │       └── kustomization.yaml
-│   │
-│   └── overlays/                 # 多环境配置
-│       ├── dev/
-│       ├── staging/
-│       └── production/
+├── deployments/
+│   ├── kubernetes/               # Kustomize configs
+│   │   ├── local/                # KIND cluster
+│   │   ├── staging/              # Staging K8s
+│   │   └── production/           # Production K8s (HA)
+│   ├── argocd/                   # ArgoCD app-of-apps
+│   ├── terraform/                # AWS IaC (staging)
+│   └── charts/isa-service/       # Generic Helm chart
 │
-├── argocd/                       # ArgoCD 应用定义
-│   ├── bootstrap/
-│   └── applications/
-│       ├── isa-cloud-dev.yaml
-│       ├── isa-cloud-staging.yaml
-│       └── isa-cloud-production.yaml
-│
-├── .github/workflows/            # CI/CD 流水线
-│   ├── ci-golang.yaml            # gRPC 服务 CI
-│   └── cd-update-images.yaml     # 外部服务镜像更新 CD
-│
-├── tests/                        # 测试脚本
+├── .github/workflows/            # CI/CD pipelines
+├── tests/                        # Integration test scripts
+│   ├── contracts/                # Logic contracts (8 services)
 │   ├── test_auth_via_apisix.sh
-│   ├── test_mcp_via_apisix.sh
 │   └── ...
 │
-└── docs/                         # 文档
-    ├── cicd.md
-    ├── how_to_consul.md
-    ├── apisix_route_consul_sync.md
-    └── production_deployment_guide.md
+└── docs/                         # Documentation
 ```
 
-### 外部仓库
-
-| 仓库 | 服务数量 | 技术栈 | CI/CD |
-|------|---------|--------|-------|
-| **isA_user** | 27 个用户微服务 | Python/FastAPI | CI 构建 → 通知 isA_Cloud → ArgoCD 部署 |
-| **isA_Agent** | 1 个 AI 代理 | Python | 同上 |
-| **isA_MCP** | 1 个协议服务 | Python | 同上 |
-| **isA_Model** | 1 个模型服务 | Python | 同上 |
-
 ---
 
-## 🔧 核心组件
+## Core Components
 
-### 1. Apache APISIX (API 网关)
+### 1. isa_common — Python Infrastructure SDK
 
-**功能**:
-- ✅ 统一流量入口 (Port: 9080)
-- ✅ 动态路由（自动同步 Consul 服务）
-- ✅ 认证授权 (JWT/Key Auth)
-- ✅ 流量控制 (限流/熔断/超时)
-- ✅ CORS/安全策略
-- ✅ Prometheus 监控
+Native async clients connecting directly to backend services on their native ports:
 
-**访问**:
-- Gateway: `http://localhost:9080`
+| Client | Backend | Port | Methods | Status |
+|--------|---------|------|---------|--------|
+| **AsyncRedisClient** | Redis | 6379 | 53 | Complete |
+| **AsyncPostgresClient** | PostgreSQL | 5432 | 19 | Complete |
+| **AsyncNATSClient** | NATS | 4222 | 33 | Complete |
+| **AsyncNeo4jClient** | Neo4j | 7687 | 37 | Partial |
+| **AsyncMinIOClient** | MinIO | 9000 | 35 | Complete |
+| **AsyncQdrantClient** | Qdrant | 6333 | 25 | Complete |
+| **AsyncDuckDBClient** | DuckDB | embedded | 27 | Complete |
+| **AsyncMQTTClient** | Mosquitto | 1883 | 29 | Complete |
+
+Additional local-mode clients: `AsyncSQLiteClient`, `AsyncLocalStorageClient`, `AsyncChromaClient`, `AsyncMemoryClient`
+
+**Usage:**
+
+```python
+from isa_common import AsyncRedisClient, AsyncPostgresClient, AsyncNATSClient
+
+# Direct connection to Redis on native port
+async with AsyncRedisClient(host="localhost", port=6379) as redis:
+    await redis.set("session:user_123", session_data, ttl=3600)
+    session = await redis.get("session:user_123")
+
+# Direct connection to PostgreSQL
+async with AsyncPostgresClient(host="localhost", port=5432, database="mydb") as pg:
+    rows = await pg.query("SELECT * FROM users WHERE org_id = $1", "org_123")
+
+# Direct connection to NATS with JetStream
+async with AsyncNATSClient(host="localhost", port=4222) as nats:
+    await nats.publish("orders.created", {"order_id": "123"})
+    messages = await nats.pull_messages("USAGE_EVENTS", "billing-consumer")
+```
+
+### 2. Apache APISIX (API Gateway)
+
+- Unified traffic entry (Port: 9080)
+- Dynamic routing (auto-sync from Consul)
+- Auth (JWT/Key Auth), rate limiting, CORS
 - Admin API: `http://localhost:9180`
 
-**文档**: [APISIX 路由同步](./docs/apisix_route_consul_sync.md)
+### 3. Consul (Service Discovery)
 
-### 2. Consul (服务发现)
+- Service registration/discovery, health checks, KV config
+- 42 registered services (33 business + 9 infrastructure)
+- UI: `http://localhost:8500`
 
-**功能**:
-- ✅ 服务注册/发现
-- ✅ 健康检查 (TCP/HTTP)
-- ✅ KV 配置存储
-- ✅ DNS 接口
+### 4. ArgoCD (GitOps)
 
-**架构**:
-- Server (StatefulSet, 1 副本)
-- Agent (Deployment, 1 副本)
-
-**注册服务**: 42 个
-- 9 个 gRPC 服务（静态预注册）
-- 33 个业务服务（动态注册）
-
-**访问**: `http://localhost:8500`
-
-**文档**: [Consul 完整指南](./docs/how_to_consul.md)
-
-### 3. ArgoCD (GitOps)
-
-**功能**:
-- ✅ Git → Kubernetes 自动同步
-- ✅ 声明式部署
-- ✅ 回滚和审计
-- ✅ 多环境管理
-
-**配置**: `argocd/applications/`
-
-**文档**: [CI/CD 流程](./docs/cicd.md)
+- Git → Kubernetes auto-sync, declarative deployments
+- Multi-environment: dev (auto-sync), staging (auto-sync), production (manual sync)
 
 ---
 
-## 🚀 快速开始
+## Quick Start
 
-### 前置要求
+### Prerequisites
 
-| 工具 | 版本 | 安装 |
-|------|------|------|
+| Tool | Version | Install |
+|------|---------|---------|
 | **Docker** | 20.10+ | [Docker Desktop](https://www.docker.com/products/docker-desktop) |
 | **kubectl** | 1.28+ | `brew install kubectl` |
 | **kind** | 0.20+ | `brew install kind` |
-| **Go** | 1.23+ | `brew install go` |
+| **Python** | 3.12+ | `brew install python` |
 
-### 本地部署 (KIND)
+### Install isa_common
 
 ```bash
-# 1. 创建 KIND 集群
+cd isA_common
+pip install -e ".[dev]"
+```
+
+### Run Tests
+
+```bash
+cd isA_common/tests
+python -m pytest -v                          # All tests
+python -m pytest redis/ -v                   # Redis client tests
+python -m pytest smoke/ -m smoke -v          # Billing pipeline smoke tests
+```
+
+### Local Kubernetes Deployment (KIND)
+
+```bash
 cd deployments/kubernetes/scripts
-./kind-setup.sh
+./kind-setup.sh          # Create KIND cluster
+./kind-deploy.sh         # Deploy all services
+./check-services.sh      # Check status
 
-# 2. 构建 gRPC 服务镜像并加载
-./kind-build-load.sh
-
-# 3. 部署所有服务
-./kind-deploy.sh
-
-# 4. 检查服务状态
-./check-services.sh
-
-# 5. 访问服务
-# APISIX Gateway
-open http://localhost:9080
-
-# Consul UI
-open http://localhost:8500
-```
-
-### 验证部署
-
-```bash
-# 查看 Pod
-kubectl get pods -n isa-cloud-staging
-
-# 查看 Consul 注册的服务
-kubectl exec -n isa-cloud-staging consul-0 -- consul catalog services
-
-# 查看 APISIX 路由
-kubectl exec -n isa-cloud-staging deploy/apisix -- \
-  curl -s http://localhost:9180/apisix/admin/routes \
-  -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" | jq '.list | length'
-```
-
-### 测试 API
-
-```bash
-# 测试认证服务
-./tests/test_auth_via_apisix.sh
-
-# 测试 MCP 服务
-./tests/test_mcp_via_apisix.sh
-
-# 或者手动测试
-curl http://localhost:9080/api/v1/auth/info
-curl http://localhost:9080/api/v1/mcp/health
+# Access services
+open http://localhost:9080    # APISIX Gateway
+open http://localhost:8500    # Consul UI
+open http://localhost:3000    # Grafana
 ```
 
 ---
 
-## 📋 服务列表
+## Infrastructure Services
 
-### gRPC 包装服务 (本仓库 `cmd/`)
-
-为基础设施提供统一的 gRPC 接口：
-
-| 服务 | 端口 | 后端 | 功能 |
-|------|------|------|------|
-| **postgres-grpc** | 50061 | PostgreSQL:5432 | 关系型数据库 gRPC 接口 |
-| **redis-grpc** | 50055 | Redis:6379 | 缓存服务 gRPC 接口 |
-| **neo4j-grpc** | 50063 | Neo4j:7687 | 图数据库 gRPC 接口 |
-| **nats-grpc** | 50056 | NATS:4222 | 消息队列 gRPC 接口 |
-| **duckdb-grpc** | 50052 | DuckDB | 分析数据库 gRPC 接口 |
-| **mqtt-grpc** | 50053 | Mosquitto:1883 | IoT 消息 gRPC 接口 |
-| **loki-grpc** | 50054 | Loki:3100 | 日志聚合 gRPC 接口 |
-| **minio-grpc** | 50051 | MinIO:9000 | 对象存储 gRPC 接口 |
-| **qdrant-grpc** | 50062 | Qdrant:6333 | 向量数据库 gRPC 接口 |
-
-### 基础设施服务 (本仓库 `deployments/`)
-
-| 服务 | 端口 | 功能 |
-|------|------|------|
-| **APISIX** | 9080, 9180 | API 网关 |
-| **Consul** | 8500, 8600 | 服务发现 |
-| **PostgreSQL** | 5432 | 关系型数据库 |
-| **Redis** | 6379 | 缓存/会话 |
-| **Neo4j** | 7474, 7687 | 图数据库 |
-| **MinIO** | 9000, 9001 | 对象存储 |
-| **NATS** | 4222, 8222 | 消息队列 |
-| **Mosquitto** | 1883, 9001 | MQTT Broker |
-| **Loki** | 3100 | 日志聚合 |
-| **Grafana** | 3000 | 可视化 |
-| **Qdrant** | 6333 | 向量数据库 |
-
-### 业务服务 (外部仓库)
-
-#### isA_user 仓库 (27 个服务)
-
-<details>
-<summary><b>展开查看 27 个用户微服务</b></summary>
-
-- **account_service** - 账户管理
-- **auth_service** - 认证服务  
-- **authorization_service** - 授权服务
-- **session_service** - 会话管理
-- **organization_service** - 组织管理
-- **device_service** - 设备管理
-- **location_service** - 位置服务
-- **invitation_service** - 邀请管理
-- **album_service** - 相册服务
-- **memory_service** - 记忆存储
-- **media_service** - 媒体处理
-- **order_service** - 订单管理
-- **product_service** - 产品管理
-- **payment_service** - 支付服务
-- **billing_service** - 账单服务
-- **wallet_service** - 钱包服务
-- **notification_service** - 通知服务
-- **event_service** - 事件管理
-- **calendar_service** - 日历服务
-- **task_service** - 任务管理
-- **audit_service** - 审计日志
-- **telemetry_service** - 遥测数据
-- **compliance_service** - 合规检查
-- **ota_service** - OTA 更新
-- **weather_service** - 天气服务
-- **storage_service** - 存储服务
-- **vault_service** - 保险箱服务
-
-</details>
-
-#### 其他外部服务
-
-| 服务 | 仓库 | 功能 |
-|------|------|------|
-| **agent_service** | isA_Agent | AI 智能代理 |
-| **mcp_service** | isA_MCP | 模型控制协议 |
-| **model_service** | isA_Model | AI 模型服务 |
-| **isa-data** | - | 数据服务 |
-| **web_service** | - | Web 服务 |
-
-**总计**: 33 个业务服务在 Consul 注册
+| Service | Port | Purpose |
+|---------|------|---------|
+| **APISIX** | 9080, 9180 | API Gateway |
+| **Consul** | 8500, 8600 | Service Discovery |
+| **PostgreSQL** | 5432 | Relational Database |
+| **Redis** | 6379 | Cache/Sessions |
+| **Neo4j** | 7474, 7687 | Graph Database |
+| **MinIO** | 9000, 9001 | Object Storage |
+| **NATS** | 4222, 8222 | Message Queue |
+| **Mosquitto** | 1883 | MQTT Broker |
+| **Loki** | 3100 | Log Aggregation |
+| **Grafana** | 3000 | Visualization |
+| **Qdrant** | 6333 | Vector Database |
 
 ---
 
-## 📦 部署指南
+## Deployment
 
-### 环境
+### Environments
 
-| 环境 | 集群 | 命名空间 | 分支 |
-|------|------|---------|------|
-| **dev** | KIND 本地 | isa-cloud-dev | develop |
+| Environment | Cluster | Namespace | Branch |
+|-------------|---------|-----------|--------|
+| **dev** | KIND local | isa-cloud-dev | develop |
 | **staging** | KIND/EKS | isa-cloud-staging | main |
 | **production** | EKS/GKE | isa-cloud-production | production |
 
-### 部署到 Staging (EKS)
-
-<details>
-<summary><b>点击展开完整步骤</b></summary>
-
-```bash
-# 1. 创建 EKS 集群
-eksctl create cluster \
-  --name isa-cloud-staging \
-  --region us-east-1 \
-  --nodegroup-name workers \
-  --node-type m5.xlarge \
-  --nodes 3 \
-  --managed
-
-# 2. 配置 kubectl
-aws eks update-kubeconfig --name isa-cloud-staging
-
-# 3. 安装 ArgoCD
-kubectl create namespace argocd
-kubectl apply -n argocd -f \
-  https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
-
-# 4. 获取 ArgoCD 密码
-kubectl -n argocd get secret argocd-initial-admin-secret \
-  -o jsonpath="{.data.password}" | base64 -d
-
-# 5. 访问 ArgoCD
-kubectl port-forward svc/argocd-server -n argocd 8080:443
-# 浏览器: https://localhost:8080 (admin / <密码>)
-
-# 6. 部署应用
-kubectl apply -f argocd/applications/isa-cloud-staging.yaml
-
-# 7. 查看状态
-kubectl get pods -n isa-cloud-staging -w
-```
-
-</details>
-
-**详细文档**: [生产部署指南](./docs/production_deployment_guide.md)
+See [Production Deployment Guide](./docs/production_deployment_guide.md) for EKS/GKE setup.
 
 ---
 
-## 🛠️ 运维管理
+## Documentation
 
-### 查看服务
+### Core Docs
+- **[CI/CD Pipeline](./docs/cicd.md)** — GitHub Actions + ArgoCD workflow
+- **[Consul Guide](./docs/how_to_consul.md)** — Service discovery operations
+- **[APISIX Route Sync](./docs/apisix_route_consul_sync.md)** — Auto route sync
+- **[Production Deploy](./docs/production_deployment_guide.md)** — EKS/GKE + HPA
 
-```bash
-# 所有 Pod
-kubectl get pods -n isa-cloud-staging
+### Runbooks
+- **[NATS Consumer Lag](./docs/runbooks/nats-consumer-lag.md)** — Billing event delays
 
-# Consul 服务
-kubectl exec -n isa-cloud-staging consul-0 -- consul catalog services
-
-# APISIX 路由数量
-kubectl exec -n isa-cloud-staging deploy/apisix -- \
-  curl -s http://localhost:9180/apisix/admin/routes \
-  -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" | jq '.list | length'
-```
-
-### 查看日志
-
-```bash
-# 特定服务
-kubectl logs -f -n isa-cloud-staging -l app=postgres-grpc
-
-# Consul
-kubectl logs -n isa-cloud-staging consul-0 --tail=100
-
-# APISIX
-kubectl logs -n isa-cloud-staging deploy/apisix --tail=100
-```
-
-### 扩缩容
-
-```bash
-# 手动扩容
-kubectl scale deployment postgres-grpc -n isa-cloud-staging --replicas=3
-
-# 自动扩缩容
-kubectl autoscale deployment postgres-grpc -n isa-cloud-staging \
-  --cpu-percent=80 --min=2 --max=10
-```
-
-### 访问 UI
-
-```bash
-# Consul UI
-kubectl port-forward -n isa-cloud-staging svc/consul-ui 8500:8500
-# http://localhost:8500
-
-# Grafana
-kubectl port-forward -n isa-cloud-staging svc/grafana 3000:3000
-# http://localhost:3000 (admin / admin)
-```
-
----
-
-## 📚 文档索引
-
-### 核心文档
-- **[CI/CD 流程](./docs/cicd.md)** - GitHub Actions + ArgoCD 完整流程
-- **[Consul 指南](./docs/how_to_consul.md)** - 服务发现、健康检查、运维
-- **[APISIX 路由同步](./docs/apisix_route_consul_sync.md)** - 自动路由同步
-- **[生产部署](./docs/production_deployment_guide.md)** - EKS/GKE 部署和 HPA
-
-### 测试脚本
+### Test Scripts
 - [test_auth_via_apisix.sh](./tests/test_auth_via_apisix.sh)
 - [test_mcp_via_apisix.sh](./tests/test_mcp_via_apisix.sh)
 - [test_agent_via_apisix.sh](./tests/test_agent_via_apisix.sh)
@@ -574,23 +322,22 @@ kubectl port-forward -n isa-cloud-staging svc/grafana 3000:3000
 
 ---
 
-## 🤝 贡献
+## Contributing
 
-### Commit 规范
+### Commit Conventions
 
 ```
-feat: 新功能
-fix: Bug 修复
-docs: 文档
-refactor: 重构
-perf: 性能优化
-test: 测试
-chore: 构建/工具
+feat: New feature
+fix: Bug fix
+docs: Documentation
+refactor: Refactoring
+test: Tests
+chore: Build/tooling
 ```
 
 ---
 
-## 📄 许可证
+## License
 
 MIT License
 
@@ -598,6 +345,6 @@ MIT License
 
 <div align="center">
 
-**Made with ❤️ by the isA Team**
+**Made with care by the isA Team**
 
 </div>

--- a/docs/current_status.md
+++ b/docs/current_status.md
@@ -1,160 +1,137 @@
-# isA_Cloud (Go gRPC Services) - CDD Progress Tracker
+# isA_Cloud (Python Async Clients) - Implementation Status
 
 ## Overview
 
-Go gRPC infrastructure services providing backend infrastructure access (Redis, PostgreSQL, NATS, MQTT, MinIO, Neo4j, Qdrant, DuckDB).
+Native async Python clients providing direct infrastructure access (Redis, PostgreSQL, NATS, MQTT, MinIO, Neo4j, Qdrant, DuckDB).
 
 **Reference Documents**:
-- `docs/cdd_guide.md` - CDD methodology for Go services
-- `tests/contracts/shared_system_contract.md` - System contract (HOW to test)
-- `docs/GO_MICROSERVICE_DEVELOPMENT_GUIDE.md` - Implementation guide
+- `isA_common/isa_common/async_base_client.py` - Base client interface
+- `tests/contracts/shared_system_contract.md` - System contract (test methodology)
+- Logic contracts in `tests/contracts/{service}/logic_contract.md`
+
+> **Note**: The Go gRPC layer was removed in January 2026 (commits 3386a37, db7e4a1, ed150e2). All infrastructure access now uses direct Python async clients via native drivers.
 
 ---
 
-## Progress Summary
+## Client Implementation Status
 
-| Category | Complete | Partial | Missing |
-|----------|----------|---------|---------|
-| Logic Contracts | 8/8 | 0 | 0 |
-| Fixtures (Go) | 8/8 | 0 | 0 |
-| Unit Golden Tests | 8/8 | 0 | 0 |
-| Integration Golden Tests | 8/8 | 0 | 0 |
-| API Tests | 8/8 | 0 | 0 |
-| Smoke Tests (E2E) | 8/8 | 0 | 0 |
-| System Contract | 1/1 | 0 | 0 |
+| Client | Lines | Methods | Status | Notes |
+|--------|-------|---------|--------|-------|
+| **AsyncRedisClient** | 790 | 53 | Complete | Full: strings, hashes, sets, pub/sub, locks |
+| **AsyncPostgresClient** | 657 | 19 | Complete | Full: queries, transactions, pooling, builder |
+| **AsyncNATSClient** | 869 | 33 | Complete | Full: pub/sub, JetStream, KV, reconnect stats |
+| **AsyncMinIOClient** | 948 | 35 | Complete | Full: buckets, objects, presigned URLs, streaming |
+| **AsyncQdrantClient** | 764 | 25 | Complete | Full: collections, vectors, search, recommend |
+| **AsyncDuckDBClient** | 905 | 27 | Complete | Full: queries, Parquet/CSV I/O, analytics |
+| **AsyncMQTTClient** | 676 | 29 | Complete | Full: pub/sub, QoS, device management |
+| **AsyncNeo4jClient** | 1686 | 37 | Partial | Connection lifecycle done; some query methods incomplete |
 
-**Last Updated**: 2025-12-17
+### Local-Mode Alternatives (for desktop/ICP mode)
 
----
-
-## Test Layer Targets (per CDD Guide)
-
-| Layer | Build Tag | Dependencies | Status |
-|-------|-----------|--------------|--------|
-| Unit | `//go:build unit` | None (mocked) | 8/8 services |
-| Component | `//go:build component` | Mocked infra | 0/8 services |
-| Integration | `//go:build integration` | Real DB/Cache | 8/8 services |
-| E2E/Smoke | Bash scripts | Running services | 8/8 services |
+| Client | Replaces | Lines | Status |
+|--------|----------|-------|--------|
+| **AsyncSQLiteClient** | AsyncPostgresClient | 669 | Complete |
+| **AsyncLocalStorageClient** | AsyncMinIOClient | 683 | Complete |
+| **AsyncChromaClient** | AsyncQdrantClient | 736 | Complete |
+| **AsyncMemoryClient** | AsyncRedisClient | 671 | Complete |
 
 ---
 
-## Detailed Service Status
+## Test Coverage
 
-| Service | Logic Contract | Fixtures | Unit | Integration | API | Smoke | Status |
-|---------|:--------------:|:--------:|:----:|:-----------:|:---:|:-----:|:------:|
-| **redis** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **postgres** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **nats** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **mqtt** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **minio** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **neo4j** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **qdrant** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **duckdb** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Layer | Count | Status |
+|-------|-------|--------|
+| Unit (mocked) | 7 | Needs expansion — only NATS reconnect |
+| Component (golden) | 15 | Base client + channel health TDD |
+| Integration (live services) | 144 | Excellent — 15-19 per client |
+| E2E/Smoke | 12 | Billing pipeline + health checks |
 
----
+### Test Files by Service
 
-## Directory Structure
-
-```
-isA_Cloud/
-├── tests/
-│   ├── contracts/
-│   │   ├── README.md
-│   │   ├── shared_system_contract.md    # System Contract
-│   │   ├── redis/
-│   │   │   ├── logic_contract.md        # Logic Contract
-│   │   │   └── fixtures.go              # Test Factories
-│   │   ├── postgres/
-│   │   ├── nats/
-│   │   ├── mqtt/
-│   │   ├── minio/
-│   │   ├── neo4j/
-│   │   ├── qdrant/
-│   │   └── duckdb/
-│   │
-│   ├── unit/golden/                     # Unit Tests
-│   │   ├── redis_test.go
-│   │   ├── postgres_test.go
-│   │   └── ...
-│   │
-│   ├── integration/golden/              # Integration Tests
-│   │   ├── redis_integration_test.go
-│   │   ├── postgres_integration_test.go
-│   │   └── ...
-│   │
-│   ├── api/golden/                      # API Tests (all 8 services)
-│   │   ├── redis_api_test.go
-│   │   ├── postgres_api_test.go
-│   │   ├── nats_api_test.go
-│   │   ├── mqtt_api_test.go
-│   │   ├── minio_api_test.go
-│   │   ├── neo4j_api_test.go
-│   │   ├── qdrant_api_test.go
-│   │   └── duckdb_api_test.go
-│   │
-│   └── smoke/                           # E2E Smoke Tests
-│       ├── run_all_smoke_tests.sh
-│       ├── redis_e2e.sh
-│       ├── postgres_e2e.sh
-│       └── ...
-```
+| Service | Test File | Functions | Type |
+|---------|-----------|-----------|------|
+| Redis | `tests/redis/test_async_redis.py` | 18 | Integration |
+| PostgreSQL | `tests/postgres/test_async_postgres.py` | 15 | Integration |
+| NATS | `tests/nats/test_async_nats.py` | 15 | Integration |
+| NATS | `tests/nats/test_async_nats_reconnect.py` | 7 | Unit (mocked) |
+| MQTT | `tests/mqtt/test_async_mqtt.py` | 19 | Integration |
+| MinIO | `tests/minio/test_async_minio.py` | 19 | Integration |
+| Qdrant | `tests/qdrant/test_async_qdrant.py` | 18 | Integration |
+| Neo4j | `tests/neo4j/test_async_neo4j.py` | 18 | Integration |
+| DuckDB | `tests/duck/test_async_duckdb.py` | 15 | Integration |
+| Billing pipeline | `tests/smoke/test_billing_pipeline.py` | 9 | E2E smoke |
+| Base client | `tests/component/golden/` | 15 | Component |
 
 ---
 
-## Legend
+## Event System Status
 
-| Symbol | Meaning |
-|--------|---------|
-| ✅ | Complete and verified |
-| ⚠️ | Partially complete |
-| ❌ | Missing |
+| Component | Status |
+|-----------|--------|
+| `BaseEvent` / `EventMetadata` | Complete |
+| `BaseEventPublisher` | Complete |
+| `BaseEventSubscriber` (with retry/idempotency) | Complete |
+| `BillingEventPublisher` | Complete |
+| Billing events (Usage, Calculated, Deducted, Insufficient, Error) | Complete |
 
 ---
 
-## Next Priority
+## Logic Contracts
 
-1. **Component Tests** - Add component layer tests with mocked infrastructure
-2. **TDD Tests** - Add TDD tests for bug fixes and new features
-3. **Contract Test Coverage** - Expand test scenarios per logic contracts
+All 8 contracts exist in `tests/contracts/`:
+
+| Service | Contract | BR/EC/ER IDs | Tests Mapped |
+|---------|----------|--------------|--------------|
+| Redis | `redis/logic_contract.md` | Yes | No |
+| PostgreSQL | `postgres/logic_contract.md` | Yes | No |
+| NATS | `nats/logic_contract.md` | Yes | No |
+| MQTT | `mqtt/logic_contract.md` | Yes | No |
+| MinIO | `minio/logic_contract.md` | Yes | No |
+| Neo4j | `neo4j/logic_contract.md` | Yes | No |
+| Qdrant | `qdrant/logic_contract.md` | Yes | No |
+| DuckDB | `duckdb/logic_contract.md` | Yes | No |
 
 ---
 
 ## Running Tests
 
 ```bash
-# Run unit tests only
-go test -tags=unit ./tests/unit/...
+cd isA_common/tests
 
-# Run integration tests (requires port-forward)
-go test -tags=integration ./tests/integration/...
+# Run all tests (integration tests auto-skip if services unavailable)
+python -m pytest -v
 
-# Run API tests (requires port-forward)
-go test -v -tags=api ./tests/api/golden/... -timeout 300s
+# Run specific client tests
+python -m pytest redis/ -v
+python -m pytest nats/ -v
+python -m pytest smoke/ -m smoke -v
 
-# Run API health checks only
-go test -v -tags=api ./tests/api/golden/... -run "HealthCheck"
-
-# Run specific service API tests
-go test -v -tags=api ./tests/api/golden/... -run "TestRedis"
-go test -v -tags=api ./tests/api/golden/... -run "TestQdrant"
-
-# Run all smoke tests
-./tests/smoke/run_all_smoke_tests.sh
-
-# Run specific service smoke test
-./tests/smoke/redis_e2e.sh
+# Run unit tests only (no infrastructure needed)
+python -m pytest nats/test_async_nats_reconnect.py -v
+python -m pytest component/ -v
 ```
 
-## API Test Port Configuration
+## Native Port Configuration
 
-| Service | gRPC Port | Environment Variable |
-|---------|-----------|---------------------|
-| MinIO | 50051 | MINIO_GRPC_ADDR |
-| DuckDB | 50052 | DUCKDB_GRPC_ADDR |
-| MQTT | 50053 | MQTT_GRPC_ADDR |
-| Loki | 50054 | LOKI_GRPC_ADDR |
-| Redis | 50055 | REDIS_GRPC_ADDR |
-| NATS | 50056 | NATS_GRPC_ADDR |
-| PostgreSQL | 50061 | POSTGRES_GRPC_ADDR |
-| Qdrant | 50062 | QDRANT_GRPC_ADDR |
-| Neo4j | 50063 | NEO4J_GRPC_ADDR |
+| Service | Port | Environment Variable |
+|---------|------|---------------------|
+| PostgreSQL | 5432 | POSTGRES_HOST / POSTGRES_PORT |
+| Redis | 6379 | REDIS_HOST / REDIS_PORT |
+| Neo4j | 7687 | NEO4J_HOST / NEO4J_PORT |
+| NATS | 4222 | NATS_HOST / NATS_PORT |
+| MinIO | 9000 | MINIO_HOST / MINIO_PORT |
+| Qdrant | 6333 | QDRANT_HOST / QDRANT_PORT |
+| MQTT | 1883 | MQTT_HOST / MQTT_PORT |
+| DuckDB | embedded | (no port) |
+
+---
+
+## Next Priority
+
+1. **Fix AsyncNeo4jClient** — Implement remaining query/write methods
+2. **Add unit tests** — Mocked tests for all 8 clients (fix inverted pyramid)
+3. **Map contract IDs** — Link test functions to BR/EC/ER IDs in logic contracts
+
+---
+
+**Last Updated**: 2026-02-28

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,12 +1,12 @@
 # isA Cloud Platform - Technical Design
 
-> Architecture and Design Documentation for Infrastructure gRPC Services
+> Architecture and Design Documentation for the isa_common Infrastructure SDK
 
 ---
 
 ## Overview
 
-This document describes the technical architecture of isA Cloud's infrastructure services layer, providing a unified gRPC interface to various backend systems.
+This document describes the technical architecture of isA Cloud's infrastructure layer. The platform provides **native async Python clients** that connect directly to backend services, plus Kubernetes deployment and service discovery infrastructure.
 
 ---
 
@@ -18,18 +18,18 @@ This document describes the technical architecture of isA Cloud's infrastructure
 │                    (Agent, MCP, Model, User Services)                       │
 └─────────────────────────────────────┬───────────────────────────────────────┘
                                       │
-                                      │ gRPC (protobuf)
+                                      │ import isa_common
                                       ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                           API Gateway (APISIX)                               │
-│                    - Routing, Rate Limiting, Auth                           │
+│                        isa_common Python SDK                                 │
+│              Native async clients (asyncpg, redis-py, nats-py, etc.)       │
 └─────────────────────────────────────┬───────────────────────────────────────┘
                                       │
                     ┌─────────────────┼─────────────────┐
                     ▼                 ▼                 ▼
 ┌───────────────────────┐ ┌───────────────────┐ ┌───────────────────┐
-│    Redis Service      │ │  Postgres Service │ │   NATS Service    │
-│    (Port 50055)       │ │   (Port 50061)    │ │   (Port 50056)    │
+│   AsyncRedisClient    │ │ AsyncPostgresClient│ │  AsyncNATSClient  │
+│    (Port 6379)        │ │   (Port 5432)     │ │   (Port 4222)     │
 └───────────┬───────────┘ └─────────┬─────────┘ └─────────┬─────────┘
             │                       │                     │
             ▼                       ▼                     ▼
@@ -39,93 +39,90 @@ This document describes the technical architecture of isA Cloud's infrastructure
 └───────────────────────┘ └───────────────────┘ └───────────────────┘
 ```
 
+Clients connect **directly** to backend services on their native ports. There is no intermediate gRPC or proxy layer.
+
 ---
 
-## Service Architecture
+## Client Architecture
 
-Each gRPC service follows Clean Architecture:
+All async clients extend `AsyncBaseClient` and follow a consistent pattern:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                      gRPC Handler Layer                          │
-│              (Request validation, Response mapping)              │
+│                      AsyncBaseClient                              │
+│         (Abstract base: connect, disconnect, health_check)       │
 └───────────────────────────────┬─────────────────────────────────┘
-                                │
+                                │ extends
                                 ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│                       Service Layer                              │
-│           (Business logic, Multi-tenancy, Audit)                │
-└───────────────────────────────┬─────────────────────────────────┘
-                                │
-                                ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     Repository Layer                             │
-│              (Data access abstraction)                          │
-└───────────────────────────────┬─────────────────────────────────┘
-                                │
-                                ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   Infrastructure Layer                           │
-│            (Redis client, PG driver, NATS client)               │
+│                    Concrete Client                                │
+│         (AsyncRedisClient, AsyncPostgresClient, etc.)            │
+│                                                                   │
+│   _connect()       → Establish native driver connection          │
+│   _disconnect()    → Close connection + pool cleanup             │
+│   health_check()   → Backend health + connection stats           │
+│   _prefix_key()    → Multi-tenant key isolation                  │
+│   Domain methods   → Service-specific operations                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+### Key Design Patterns
+
+1. **Lazy Connection**: Clients connect on first use (`_ensure_connected()`)
+2. **Async Context Manager**: `async with client:` for lifecycle management
+3. **Multi-Tenancy**: All keys/subjects auto-prefixed with `{org_id}{separator}{user_id}`
+4. **Error Handling**: Standardized `handle_error(error, operation)` logging
+5. **Configuration**: Environment variable defaults (`{PREFIX}_HOST`, `{PREFIX}_PORT`)
 
 ---
 
 ## Component Design
 
-### Redis Service
+### Redis Client
 
 ```
-cmd/redis-service/
-├── main.go                 # Entry point, DI setup
-└── server/
-    ├── server.go           # gRPC handler implementation
-    └── auth.go             # Authentication logic
+isA_common/isa_common/async_redis_client.py (790 lines)
 
-Internal Flow:
+Data Flow:
 ┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────┐
-│  Client  │────▶│  Auth    │────▶│ Isolate  │────▶│  Redis   │
-│ Request  │     │ Validate │     │   Key    │     │  Client  │
+│  Client  │────▶│ Prefix   │────▶│  redis-py │────▶│  Redis   │
+│  Call    │     │   Key    │     │  (async)  │     │  :6379   │
 └──────────┘     └──────────┘     └──────────┘     └──────────┘
-                                        │
-                                        ▼
-                                 ┌──────────┐
-                                 │  Audit   │
-                                 │   Log    │
-                                 └──────────┘
+
+Tenant separator: ":" → org_id:user_id:key
+Native driver: redis.asyncio
+Features: strings, hashes, lists, sets, sorted sets, pub/sub, locks, sessions
 ```
 
-### PostgreSQL Service
+### PostgreSQL Client
 
 ```
-cmd/postgres-service/
-├── main.go
-└── server/
-    ├── server.go           # Query execution
-    └── utils.go            # Result mapping
+isA_common/isa_common/async_postgres_client.py (657 lines)
 
 Query Flow:
 ┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────┐
-│  Query   │────▶│ Validate │────▶│ Execute  │────▶│  Return  │
-│ Request  │     │  & Auth  │     │   SQL    │     │   JSON   │
+│  Query   │────▶│ Validate │────▶│  asyncpg  │────▶│ Postgres │
+│ Request  │     │  Params  │     │  (pool)   │     │  :5432   │
 └──────────┘     └──────────┘     └──────────┘     └──────────┘
+
+Native driver: asyncpg
+Features: query, execute, transactions, connection pooling, JSON/JSONB codecs
 ```
 
-### NATS Service
+### NATS Client
 
 ```
-cmd/nats-service/
-├── main.go
-└── server/
-    ├── server.go           # Pub/Sub, JetStream, KV
-    └── auth.go             # Publisher/Subscriber auth
+isA_common/isa_common/async_nats_client.py (869 lines)
 
 JetStream Flow:
 ┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────┐
 │ Publish  │────▶│  Stream  │────▶│ Consumer │────▶│ Deliver  │
 │ Message  │     │  Store   │     │  Pull    │     │ to Sub   │
 └──────────┘     └──────────┘     └──────────┘     └──────────┘
+
+Tenant separator: "." → org_id.user_id.subject
+Native driver: nats-py
+Features: pub/sub, JetStream, KV store, object store, reconnection with observability
 ```
 
 ---
@@ -137,19 +134,14 @@ JetStream Flow:
 ```mermaid
 sequenceDiagram
     participant C as Client
-    participant R as Redis Service
-    participant A as Auth Service
+    participant R as AsyncRedisClient
     participant Redis as Redis Backend
-    participant L as Loki
 
-    C->>R: Get(user_id, org_id, key)
-    R->>A: ValidateUser(user_id)
-    A-->>R: OK
-    R->>R: IsolateKey(org_id, user_id, key)
-    R->>Redis: GET isolated_key
+    C->>R: get("session:token")
+    R->>R: _prefix_key("session:token") → "org:user:session:token"
+    R->>Redis: GET org:user:session:token
     Redis-->>R: value (or nil)
-    R->>L: LogAudit(Get, key, status)
-    R-->>C: GetResponse(value)
+    R-->>C: value
 ```
 
 ### Event Publish (NATS)
@@ -157,17 +149,14 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant P as Publisher
-    participant N as NATS Service
-    participant JS as JetStream
+    participant N as AsyncNATSClient
+    participant JS as JetStream (NATS)
     participant S as Subscriber
-    participant L as Loki
 
-    P->>N: Publish(subject, data)
-    N->>N: ValidatePublisher
-    N->>JS: Publish to Stream
+    P->>N: publish("billing.usage.recorded.gpt-4", data)
+    N->>JS: Publish to stream
     JS-->>N: Ack (sequence)
-    N->>L: LogAudit(Publish, subject)
-    N-->>P: PublishResponse(sequence)
+    N-->>P: {"success": true}
 
     Note over JS,S: Async delivery
     JS->>S: Deliver message
@@ -179,16 +168,13 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant C as Client
-    participant M as MinIO Service
+    participant M as AsyncMinIOClient
     participant MinIO as MinIO Backend
-    participant L as Loki
 
-    C->>M: GetPresignedURL(bucket, key, PUT)
-    M->>M: ValidatePermissions
-    M->>MinIO: GeneratePresignedURL
-    MinIO-->>M: Presigned URL
-    M->>L: LogAudit(PresignedURL, key)
-    M-->>C: URL (expires in 15m)
+    C->>M: generate_presigned_url(bucket, key)
+    M->>MinIO: Create presigned PUT URL
+    MinIO-->>M: Presigned URL (expires 1h)
+    M-->>C: URL
 
     Note over C,MinIO: Direct upload
     C->>MinIO: PUT object (via presigned URL)
@@ -201,15 +187,21 @@ sequenceDiagram
 
 ### Key Isolation Pattern
 
-```go
-// All keys are prefixed with org_id:user_id
-func (s *Server) isolateKey(userID, orgID, key string) string {
-    return fmt.Sprintf("%s:%s:%s", orgID, userID, key)
-}
+```python
+# All keys are prefixed with org_id + user_id via AsyncBaseClient._prefix_key()
+# Each client uses a service-appropriate separator
 
-// Example transformations:
-// Input:  key="session:token"
-// Output: key="org-001:user-123:session:token"
+# Redis (separator: ":")
+"session:token" → "org-001:user-123:session:token"
+
+# NATS (separator: ".")
+"orders.created" → "org-001.user-123.orders.created"
+
+# MQTT (separator: "/")
+"devices/sensor1" → "org-001/user-123/devices/sensor1"
+
+# MinIO (separator: "-")
+"uploads" → "user-user-123-uploads"
 ```
 
 ### Database Isolation (PostgreSQL)
@@ -219,21 +211,6 @@ func (s *Server) isolateKey(userID, orgID, key string) string {
 SELECT * FROM users
 WHERE organization_id = $1
 AND id = $2;
-
--- Schema per org (future)
-SET search_path TO org_001;
-```
-
-### Bucket Isolation (MinIO)
-
-```
-Bucket naming convention:
-{org_id}-{bucket_name}
-
-Example:
-org-001-uploads
-org-001-exports
-org-002-uploads
 ```
 
 ---
@@ -242,75 +219,46 @@ org-002-uploads
 
 ### Consul Registration
 
-```go
-// Each service registers with Consul on startup
-registration := &consul.AgentServiceRegistration{
-    ID:      fmt.Sprintf("%s-%s", serviceName, hostname),
-    Name:    serviceName,
-    Port:    grpcPort,
-    Tags:    []string{"grpc", "infrastructure"},
-    Check: &consul.AgentServiceCheck{
-        GRPC:     fmt.Sprintf("%s:%d", hostname, grpcPort),
-        Interval: "10s",
-        Timeout:  "5s",
-    },
-}
-```
+```python
+# isa_common provides ConsulRegistry for service registration
+from isa_common import ConsulRegistry, consul_lifespan
 
-### Service Mesh
+# FastAPI integration via lifespan
+app = FastAPI(lifespan=consul_lifespan(
+    app, service_name="my-service", service_port=8080
+))
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                           Consul                                 │
-│                    (Service Registry)                           │
-└───────────────────────────┬─────────────────────────────────────┘
-                            │
-            ┌───────────────┼───────────────┐
-            ▼               ▼               ▼
-    ┌───────────────┐ ┌───────────────┐ ┌───────────────┐
-    │ redis-grpc    │ │ postgres-grpc │ │ nats-grpc     │
-    │ 10.244.1.24   │ │ 10.244.2.27   │ │ 10.244.1.28   │
-    └───────────────┘ └───────────────┘ └───────────────┘
+# Or manual registration
+registry = ConsulRegistry(service_name="my-service", service_port=8080)
+await registry.register()
+
+# Service discovery with load balancing
+endpoint = await registry.get_service_endpoint(
+    "auth-service", strategy="health_weighted"
+)
 ```
 
 ---
 
 ## Error Handling
 
-### gRPC Status Codes
+### Standard Error Pattern
 
-| Scenario | gRPC Code | Description |
-|----------|-----------|-------------|
-| Invalid input | `InvalidArgument` | Missing/malformed fields |
-| Auth failure | `PermissionDenied` | Invalid user/token |
-| Not found | `NotFound` | Resource doesn't exist |
-| Already exists | `AlreadyExists` | Duplicate resource |
-| Backend error | `Internal` | Database/cache error |
-| Timeout | `DeadlineExceeded` | Operation timed out |
-| Unavailable | `Unavailable` | Backend unreachable |
-
-### Error Response Pattern
-
-```go
-// Consistent error responses
-func (s *Server) handleError(err error, operation string) error {
-    // Log error
-    s.logger.Error("operation failed",
-        "operation", operation,
-        "error", err,
-    )
-
-    // Map to gRPC status
-    switch {
-    case errors.Is(err, ErrNotFound):
-        return status.Error(codes.NotFound, "resource not found")
-    case errors.Is(err, ErrPermissionDenied):
-        return status.Error(codes.PermissionDenied, "access denied")
-    default:
-        return status.Error(codes.Internal, "internal error")
-    }
-}
+```python
+# All clients use AsyncBaseClient.handle_error()
+def handle_error(self, error: Exception, operation: str):
+    self._logger.error(f"{self.SERVICE_NAME} {operation} failed: {error}")
 ```
+
+### Common Exceptions
+
+| Scenario | Exception | Description |
+|----------|-----------|-------------|
+| Connection failed | `ConnectionError` | Backend unreachable |
+| Timeout | `TimeoutError` | Operation timed out |
+| Not found | `KeyError` / custom | Resource doesn't exist |
+| Auth failure | `PermissionError` | Invalid credentials |
+| Backend error | `RuntimeError` | Internal backend error |
 
 ---
 
@@ -319,71 +267,41 @@ func (s *Server) handleError(err error, operation string) error {
 ### Environment Variables
 
 ```bash
-# Common
-SERVICE_NAME=redis-grpc-service
-GRPC_PORT=50055
+# Each client reads from env with a service-specific prefix
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=secret
+POSTGRES_DB=mydb
+
+NATS_HOST=localhost
+NATS_PORT=4222
 
 # Consul
-ISA_CLOUD_CONSUL_ENABLED=true
-ISA_CLOUD_CONSUL_HOST=consul.isa-cloud-staging.svc.cluster.local
-ISA_CLOUD_CONSUL_PORT=8500
-
-# Loki (Audit)
-LOKI_URL=http://loki.isa-cloud-staging.svc.cluster.local:3100
-
-# Service-specific
-ISA_CLOUD_REDIS_HOST=redis.isa-cloud-staging.svc.cluster.local
-ISA_CLOUD_REDIS_PORT=6379
+CONSUL_HOST=localhost
+CONSUL_PORT=8500
 ```
 
----
+### Native Ports
 
-## Deployment
+```python
+from isa_common import NATIVE_PORTS
 
-### Kubernetes Resources
-
-```yaml
-# Each service deployed as:
-- Deployment (1-2 replicas for staging)
-- Service (ClusterIP, gRPC port)
-- ConfigMap (environment config)
-- Secret (credentials, if needed)
+# NATIVE_PORTS = {
+#     'postgres': 5432,
+#     'redis': 6379,
+#     'neo4j': 7687,
+#     'nats': 4222,
+#     'qdrant': 6333,
+#     'mqtt': 1883,
+#     'minio': 9000,
+#     'consul': 8500,
+#     'duckdb': 0,  # Embedded
+# }
 ```
-
-### Resource Allocation (Staging)
-
-| Service | CPU Request | Memory Request | Replicas |
-|---------|-------------|----------------|----------|
-| redis-grpc | 100m | 256Mi | 1 |
-| postgres-grpc | 100m | 256Mi | 1 |
-| nats-grpc | 100m | 256Mi | 1 |
-| minio-grpc | 100m | 256Mi | 1 |
-| qdrant-grpc | 100m | 256Mi | 1 |
-| loki-grpc | 100m | 256Mi | 1 |
-
----
-
-## Security
-
-### Authentication Flow
-
-```
-┌──────────┐     ┌──────────┐     ┌──────────┐
-│  Client  │────▶│ Gateway  │────▶│ Service  │
-│          │     │ (Auth)   │     │          │
-└──────────┘     └──────────┘     └──────────┘
-     │                │                │
-     │  JWT Token     │  Validated     │
-     │  in metadata   │  user context  │
-     └────────────────┴────────────────┘
-```
-
-### Data Protection
-
-- All keys/data isolated by organization
-- Audit logs for all operations
-- No cross-tenant data access
-- Secrets in Kubernetes Secrets
 
 ---
 
@@ -392,9 +310,8 @@ ISA_CLOUD_REDIS_PORT=6379
 - [Domain](../domain/README.md) - Business Context
 - [PRD](../prd/README.md) - Product Requirements
 - [CDD Guide](../cdd_guide.md) - Contract-Driven Development
-- [Go Dev Guide](../GO_MICROSERVICE_DEVELOPMENT_GUIDE.md) - Implementation Guide
 
 ---
 
-**Version**: 1.0.0
-**Last Updated**: 2025-12-11
+**Version**: 2.0.0
+**Last Updated**: 2026-02-28

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -1,12 +1,12 @@
 # isA Cloud Platform - Domain Context
 
-> Business Domain Documentation for Infrastructure gRPC Services
+> Business Domain Documentation for Infrastructure Services
 
 ---
 
 ## Overview
 
-isA Cloud provides a unified **gRPC service layer** that abstracts infrastructure components (databases, caches, message queues, storage) behind consistent, multi-tenant, audited APIs.
+isA Cloud provides a unified **Python SDK (isa_common)** that abstracts infrastructure components (databases, caches, message queues, storage) behind consistent, multi-tenant async client APIs. Clients connect directly to backends on their native ports.
 
 ---
 
@@ -97,8 +97,9 @@ All services implement **organization-level isolation**:
 
 ```
 ┌──────────────────┐     ┌──────────────────┐
-│  gRPC Request    │────▶│  Auth Interceptor │
-└──────────────────┘     └────────┬─────────┘
+│  Client Request  │────▶│  API Gateway     │
+└──────────────────┘     │  (APISIX)        │
+                         └────────┬─────────┘
                                   │
                     ┌─────────────┼─────────────┐
                     ▼             ▼             ▼
@@ -204,16 +205,19 @@ Every operation is logged to Loki:
             │  Service    │ │  Service    │ │  Service    │
             └──────┬──────┘ └──────┬──────┘ └──────┬──────┘
                    │               │               │
+                   │    import isa_common Python SDK │
+                   │               │               │
      ┌─────────────┴───────────────┴───────────────┴─────────────┐
-     │                    gRPC Service Layer                      │
+     │              isa_common (Native Async Clients)             │
+     │     Direct connections to backends on native ports         │
      ├─────────┬─────────┬─────────┬─────────┬─────────┬─────────┤
      │ Redis   │Postgres │  NATS   │  MinIO  │ Qdrant  │  Loki   │
-     │ Service │ Service │ Service │ Service │ Service │ Service │
+     │ Client  │ Client  │ Client  │ Client  │ Client  │(direct) │
      └────┬────┴────┬────┴────┬────┴────┬────┴────┬────┴────┬────┘
           │         │         │         │         │         │
      ┌────▼────┐┌───▼───┐┌────▼────┐┌───▼───┐┌────▼────┐┌───▼───┐
      │  Redis  ││Postgres││  NATS   ││ MinIO ││ Qdrant  ││ Loki  │
-     │(Backend)││(Backend)│(Backend)││(Backend)│(Backend)││(Backend)│
+     │  :6379  ││ :5432  ││  :4222  ││ :9000 ││  :6333  ││ :3100 │
      └─────────┘└────────┘└─────────┘└────────┘└─────────┘└────────┘
 ```
 
@@ -223,8 +227,8 @@ Every operation is logged to Loki:
 
 | Term | Definition |
 |------|------------|
-| **gRPC** | High-performance RPC framework using Protocol Buffers |
-| **Proto** | Protocol Buffer definition file (.proto) |
+| **isa_common** | Python library providing native async infrastructure clients |
+| **AsyncBaseClient** | Abstract base class all infrastructure clients extend |
 | **Multi-tenant** | Single deployment serving multiple isolated organizations |
 | **JetStream** | NATS persistent streaming feature |
 | **Presigned URL** | Time-limited URL for direct object storage access |
@@ -241,5 +245,5 @@ Every operation is logged to Loki:
 
 ---
 
-**Version**: 1.0.0
-**Last Updated**: 2025-12-11
+**Version**: 2.0.0
+**Last Updated**: 2026-02-28

--- a/docs/guidance/grpc-services.md
+++ b/docs/guidance/grpc-services.md
@@ -1,284 +1,199 @@
-# gRPC Services
+# Infrastructure Clients (isa_common)
 
-Unified gRPC interface to 9 backend infrastructure systems.
+> **Note**: This project originally used Go gRPC wrapper services (ports 50051-50069). Those were removed in January 2026 in favor of direct Python async clients connecting to native ports. This document describes the current Python implementation.
+
+Native async Python clients for 8 backend infrastructure systems.
 
 ## Overview
 
-Each gRPC service wraps a backend system with:
+Each client extends `AsyncBaseClient` and provides:
 
-- Clean Architecture (handler → service → repository)
-- Multi-tenancy support
-- Audit logging
+- Direct connection to backend service on its native port
+- Lazy connection management (connect on first use)
+- Multi-tenancy support (automatic key/subject prefixing)
 - Health checks
-- Automatic Consul registration
+- Async context manager support
 
-## Services
+## Clients
 
-| Service | Port | Backend | Purpose |
-|---------|------|---------|---------|
-| **postgres-grpc** | 50061 | PostgreSQL:5432 | SQL database operations |
-| **redis-grpc** | 50055 | Redis:6379 | Cache and sessions |
-| **neo4j-grpc** | 50063 | Neo4j:7687 | Graph database |
-| **nats-grpc** | 50056 | NATS:4222 | Messaging and streaming |
-| **mqtt-grpc** | 50053 | MQTT:1883 | IoT messaging |
-| **minio-grpc** | 50051 | MinIO:9000 | Object storage |
-| **qdrant-grpc** | 50062 | Qdrant:6333 | Vector search |
-| **duckdb-grpc** | 50052 | DuckDB | Analytics |
-| **loki-grpc** | 50054 | Loki:3100 | Log aggregation |
+| Client | Backend | Port | Driver | Key Features |
+|--------|---------|------|--------|-------------|
+| **AsyncPostgresClient** | PostgreSQL | 5432 | asyncpg | SQL queries, transactions, pooling |
+| **AsyncRedisClient** | Redis | 6379 | redis-py async | K-V, hashes, pub/sub, locks |
+| **AsyncNeo4jClient** | Neo4j | 7687 | neo4j | Cypher queries, graph ops |
+| **AsyncNATSClient** | NATS | 4222 | nats-py | Pub/sub, JetStream, KV store |
+| **AsyncMQTTClient** | Mosquitto | 1883 | aiomqtt | IoT messaging, QoS |
+| **AsyncMinIOClient** | MinIO | 9000 | aioboto3 | Object storage, presigned URLs |
+| **AsyncQdrantClient** | Qdrant | 6333 | qdrant-client | Vector search, filtering |
+| **AsyncDuckDBClient** | DuckDB | embedded | duckdb | OLAP analytics, Parquet/CSV |
 
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    gRPC Handler Layer                       │
-│         Request validation • Response mapping               │
-└─────────────────────────────────────────────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────┐
-│                    Service Layer                            │
-│         Business logic • Multi-tenancy • Audit              │
-└─────────────────────────────────────────────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────┐
-│                    Repository Layer                         │
-│         Data access abstraction • Query building            │
-└─────────────────────────────────────────────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────┐
-│                    Infrastructure Layer                     │
-│         Database clients • Connection pooling               │
-└─────────────────────────────────────────────────────────────┘
-```
-
-## PostgreSQL gRPC (50061)
-
-### Execute Query
-
-```protobuf
-rpc ExecuteQuery(QueryRequest) returns (QueryResponse);
-
-message QueryRequest {
-  string query = 1;
-  repeated Value params = 2;
-  string org_id = 3;
-}
-```
-
-### Python Client
+## PostgreSQL (5432)
 
 ```python
 from isa_common import AsyncPostgresClient
 
-client = AsyncPostgresClient(host="localhost", port=50061)
+async with AsyncPostgresClient(
+    host="localhost", port=5432, database="mydb"
+) as client:
+    # Execute query
+    rows = await client.query(
+        "SELECT * FROM users WHERE org_id = $1", "org_123"
+    )
 
-# Execute query
-result = await client.execute(
-    query="SELECT * FROM users WHERE org_id = $1",
-    params=["org_123"]
-)
+    # Insert
+    await client.insert("users", {"name": "Alice", "org_id": "org_123"})
+
+    # Transaction
+    await client.begin()
+    await client.execute("UPDATE accounts SET balance = balance - $1", 100)
+    await client.commit()
 ```
 
-## Redis gRPC (50055)
-
-### Operations
-
-```protobuf
-rpc Get(GetRequest) returns (GetResponse);
-rpc Set(SetRequest) returns (SetResponse);
-rpc Delete(DeleteRequest) returns (DeleteResponse);
-rpc Publish(PublishRequest) returns (PublishResponse);
-```
-
-### Python Client
+## Redis (6379)
 
 ```python
 from isa_common import AsyncRedisClient
 
-client = AsyncRedisClient(host="localhost", port=50055)
+async with AsyncRedisClient(host="localhost", port=6379) as client:
+    # Set with TTL
+    await client.set("session:user_123", session_data, ttl=3600)
 
-# Set with TTL
-await client.set("session:user_123", session_data, ttl=3600)
+    # Get value
+    session = await client.get("session:user_123")
 
-# Get value
-session = await client.get("session:user_123")
+    # Hash operations
+    await client.hset("user:profile", "name", "Alice")
+    name = await client.hget("user:profile", "name")
 
-# Publish event
-await client.publish("events:user", event_data)
+    # Pub/Sub
+    await client.publish("events:user", event_data)
+
+    # Distributed lock
+    token = await client.acquire_lock("critical-section", timeout=10)
+    await client.release_lock("critical-section", token)
 ```
 
 ### Key Isolation
 
-Keys are automatically prefixed with org_id:
+Keys are automatically prefixed with `org_id:user_id`:
 ```
-{org_id}:{key} → org_123:session:user_456
-```
-
-## Neo4j gRPC (50063)
-
-### Operations
-
-```protobuf
-rpc ExecuteCypher(CypherRequest) returns (CypherResponse);
-rpc CreateNode(CreateNodeRequest) returns (NodeResponse);
-rpc CreateRelationship(RelationshipRequest) returns (RelationshipResponse);
+"session:token" → "org-001:user-123:session:token"
 ```
 
-### Python Client
+## Neo4j (7687)
 
 ```python
 from isa_common import AsyncNeo4jClient
 
-client = AsyncNeo4jClient(host="localhost", port=50063)
+async with AsyncNeo4jClient(host="localhost", port=7687) as client:
+    # Execute Cypher
+    result = await client.query(
+        "MATCH (u:User)-[:FOLLOWS]->(f) WHERE u.id = $user_id RETURN f",
+        user_id="user_123"
+    )
 
-# Execute Cypher
-result = await client.execute_cypher(
-    query="MATCH (u:User)-[:FOLLOWS]->(f) WHERE u.id = $user_id RETURN f",
-    params={"user_id": "user_123"}
-)
+    # Create node
+    await client.create_node("User", name="Alice", id="user_123")
 
-# Create relationship
-await client.create_relationship(
-    from_id="user_123",
-    to_id="user_456",
-    relationship_type="FOLLOWS"
-)
+    # Create relationship
+    await client.create_relationship(
+        "user_123", "FOLLOWS", "user_456"
+    )
 ```
 
-## NATS gRPC (50056)
-
-### Operations
-
-```protobuf
-rpc Publish(PublishRequest) returns (PublishResponse);
-rpc Subscribe(SubscribeRequest) returns (stream Message);
-rpc CreateStream(StreamRequest) returns (StreamResponse);
-```
-
-### Python Client
+## NATS (4222)
 
 ```python
-from isa_common import AsyncNatsClient
+from isa_common import AsyncNATSClient
 
-client = AsyncNatsClient(host="localhost", port=50056)
+async with AsyncNATSClient(host="localhost", port=4222) as client:
+    # Publish message
+    await client.publish("user.created", {"user_id": "123"})
 
-# Publish message
-await client.publish(
-    subject="user.created",
-    data={"user_id": "user_123", "email": "user@example.com"}
-)
+    # JetStream - Create stream
+    await client.create_stream("USERS", subjects=["user.>"])
 
-# Subscribe to subject
-async for msg in client.subscribe("user.*"):
-    print(f"Received: {msg.data}")
+    # Pull messages from consumer
+    messages = await client.pull_messages("USERS", "my-consumer", batch_size=10)
 
-# JetStream - Create stream
-await client.create_stream(
-    name="USERS",
-    subjects=["user.>"]
-)
+    # KV store
+    await client.kv_put("config", "feature_flags", '{"dark_mode": true}')
+    value = await client.kv_get("config", "feature_flags")
 ```
 
-## MinIO gRPC (50051)
-
-### Operations
-
-```protobuf
-rpc PutObject(PutObjectRequest) returns (PutObjectResponse);
-rpc GetObject(GetObjectRequest) returns (stream ObjectChunk);
-rpc DeleteObject(DeleteObjectRequest) returns (DeleteObjectResponse);
-rpc ListObjects(ListObjectsRequest) returns (ListObjectsResponse);
-```
-
-### Python Client
+## MinIO (9000)
 
 ```python
-from isa_common import AsyncMinioClient
+from isa_common import AsyncMinIOClient
 
-client = AsyncMinioClient(host="localhost", port=50051)
+async with AsyncMinIOClient(host="localhost", port=9000) as client:
+    # Upload file
+    await client.upload_object("user-files", "photos/vacation.jpg", file_bytes)
 
-# Upload file
-await client.put_object(
-    bucket="user-files",
-    key="photos/vacation.jpg",
-    data=file_bytes,
-    content_type="image/jpeg"
-)
+    # Download file
+    data = await client.download_object("user-files", "photos/vacation.jpg")
 
-# Download file
-data = await client.get_object(
-    bucket="user-files",
-    key="photos/vacation.jpg"
-)
+    # Generate presigned URL
+    url = await client.generate_presigned_url(
+        "user-files", "photos/vacation.jpg", expiry_seconds=3600
+    )
 
-# Generate presigned URL
-url = await client.presigned_url(
-    bucket="user-files",
-    key="photos/vacation.jpg",
-    expires=3600
-)
+    # List objects
+    objects = await client.list_objects("user-files", prefix="photos/")
 ```
 
-## Qdrant gRPC (50062)
-
-### Operations
-
-```protobuf
-rpc Upsert(UpsertRequest) returns (UpsertResponse);
-rpc Search(SearchRequest) returns (SearchResponse);
-rpc Delete(DeleteRequest) returns (DeleteResponse);
-```
-
-### Python Client
+## Qdrant (6333)
 
 ```python
 from isa_common import AsyncQdrantClient
 
-client = AsyncQdrantClient(host="localhost", port=50062)
+async with AsyncQdrantClient(host="localhost", port=6333) as client:
+    # Create collection
+    await client.create_collection("memories", vector_size=768)
 
-# Upsert vectors
-await client.upsert(
-    collection="memories",
-    points=[
-        {"id": "mem_123", "vector": embedding, "payload": {"text": "..."}}
-    ]
-)
+    # Upsert vectors
+    await client.upsert_point(
+        "memories", point_id="mem_123",
+        vector=embedding, payload={"text": "..."}
+    )
 
-# Search similar
-results = await client.search(
-    collection="memories",
-    query_vector=query_embedding,
-    limit=10
-)
+    # Search similar
+    results = await client.search(
+        "memories", query_vector=query_embedding, limit=10
+    )
 ```
 
 ## Health Checks
 
-All services expose health endpoints:
+All clients expose async health check:
 
-```protobuf
-rpc Health(HealthRequest) returns (HealthResponse);
+```python
+health = await client.health_check()
+# Returns: {"connected": True, "host": "localhost", "port": 6379, ...}
 ```
+
+## Service Discovery
+
+```python
+from isa_common import ConsulRegistry
+
+registry = ConsulRegistry(service_name="my-service", service_port=8080)
+await registry.register()
+
+# Discover other services
+endpoint = await registry.get_service_endpoint("auth-service")
+```
+
+## Installation
 
 ```bash
-grpcurl -plaintext localhost:50061 grpc.health.v1.Health/Check
+pip install isa-common
+# or from source:
+cd isA_common && pip install -e ".[dev]"
 ```
 
-## Building Services
+## Related Docs
 
-```bash
-# Build all
-make build
-
-# Build specific service
-cd services/postgres-grpc
-go build -o ../../bin/postgres-service ./cmd/server
-
-# Run locally
-./bin/postgres-service --config configs/development.yaml
-```
-
-## Next Steps
-
-- [Gateway](./gateway) - APISIX routing
-- [Discovery](./discovery) - Consul registration
-- [SDK](./sdk) - Python client library
+- [Technical Design](../design/README.md) - Architecture overview
+- [Domain Context](../domain/README.md) - Business scenarios
+- [PRD](../prd/README.md) - Product requirements

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -1,12 +1,12 @@
 # isA Cloud Platform - Product Requirements Document
 
-> User Stories and Acceptance Criteria for Infrastructure gRPC Services
+> User Stories and Acceptance Criteria for Infrastructure Services
 
 ---
 
 ## Overview
 
-This document defines the product requirements for isA Cloud's infrastructure services layer, organized by service and epic.
+This document defines the product requirements for isA Cloud's infrastructure services layer, provided through the **isa_common** Python SDK. Each service is accessed via native async clients connecting directly to backend services on their native ports.
 
 ---
 
@@ -15,8 +15,8 @@ This document defines the product requirements for isA Cloud's infrastructure se
 ### E1-US1: Key-Value Operations
 
 **As a** backend developer
-**I want** to store and retrieve key-value pairs via gRPC
-**So that** I can cache data without managing Redis connections directly
+**I want** to store and retrieve key-value pairs via the async Redis client
+**So that** I can cache data with automatic multi-tenant isolation
 
 #### Acceptance Criteria
 
@@ -64,8 +64,8 @@ This document defines the product requirements for isA Cloud's infrastructure se
 ### E2-US1: Query Execution
 
 **As a** backend developer
-**I want** to execute SQL queries via gRPC
-**So that** I can access the database without connection management
+**I want** to execute SQL queries via the async PostgreSQL client
+**So that** I can access the database with automatic connection pooling
 
 #### Acceptance Criteria
 
@@ -271,7 +271,7 @@ This document defines the product requirements for isA Cloud's infrastructure se
 
 | ID | Criteria | Status |
 |----|----------|--------|
-| AC-2.1 | gRPC metrics exported (latency, errors) | Partial |
+| AC-2.1 | Client metrics exported (latency, errors) | Partial |
 | AC-2.2 | Distributed tracing with trace IDs | Planned |
 | AC-2.3 | Dashboard in Grafana | Done |
 
@@ -299,5 +299,5 @@ This document defines the product requirements for isA Cloud's infrastructure se
 
 ---
 
-**Version**: 1.0.0
-**Last Updated**: 2025-12-11
+**Version**: 2.0.0
+**Last Updated**: 2026-02-28


### PR DESCRIPTION
## Summary
- Rewrites 6 core documentation files that still described the deleted Go/gRPC wrapper layer
- All docs now accurately reflect the current isa_common Python SDK with native async clients

## Changes
- **README.md** — New architecture diagram, Python examples, native ports
- **docs/design/README.md** — AsyncBaseClient pattern, Python client flows
- **docs/current_status.md** — Actual client/test status (178 tests)
- **docs/guidance/grpc-services.md** — Rewritten as Infrastructure Clients
- **docs/domain/README.md** — Updated diagrams and glossary
- **docs/prd/README.md** — User stories updated from gRPC to async clients

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)