### PR TITLE
chore(infra): implement Terraform modules and environment configs

### DIFF
--- a/deployments/terraform/environments/dev/backend.tf
+++ b/deployments/terraform/environments/dev/backend.tf
@@ -1,0 +1,13 @@
+# ============================================
+# isA Cloud - Dev State Backend
+# ============================================
+
+terraform {
+  backend "s3" {
+    bucket         = "isa-cloud-terraform-state-dev"
+    key            = "dev/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "isa-cloud-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/deployments/terraform/environments/dev/main.tf
+++ b/deployments/terraform/environments/dev/main.tf
@@ -1,0 +1,216 @@
+# ============================================
+# isA Cloud - Dev Environment
+# ============================================
+# Cost-optimized configuration: single AZ, minimal resources,
+# no deletion protection, short log retention.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# ============================================
+# Provider Configuration
+# ============================================
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = var.project_name
+      ManagedBy   = "Terraform"
+      Repository  = "isA_Cloud"
+    }
+  }
+}
+
+# ============================================
+# Data Sources
+# ============================================
+data "aws_caller_identity" "current" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# ============================================
+# Local Variables
+# ============================================
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+
+  common_tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+
+  # Dev service configuration — minimal resources
+  services = {
+    # Infrastructure services (minimum viable)
+    consul    = { port = 8500, cpu = 256, memory = 512 }
+    redis     = { port = 6379, cpu = 256, memory = 512 }
+    minio     = { port = 9000, cpu = 512, memory = 1024 }
+    nats      = { port = 4222, cpu = 256, memory = 512 }
+    mosquitto = { port = 1883, cpu = 256, memory = 512 }
+
+    # Gateway layer
+    gateway = { port = 8000, cpu = 512, memory = 1024 }
+
+    # Application services (minimal)
+    agent = { port = 8080, cpu = 1024, memory = 2048 }
+    model = { port = 8082, cpu = 2048, memory = 4096 }
+    mcp   = { port = 8081, cpu = 1024, memory = 2048 }
+    user  = { port = 8201, cpu = 2048, memory = 4096 }
+  }
+}
+
+# ============================================
+# Module: Networking
+# ============================================
+module "networking" {
+  source = "../../modules/networking"
+
+  environment        = var.environment
+  project_name       = var.project_name
+  vpc_cidr           = var.vpc_cidr
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 2)
+
+  # Disable VPC endpoints to save cost in dev
+  enable_ecr_endpoint            = false
+  enable_s3_endpoint             = true
+  enable_secretsmanager_endpoint = false
+  enable_cloudwatch_endpoint     = false
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: ECS Cluster
+# ============================================
+module "ecs_cluster" {
+  source = "../../modules/ecs-cluster"
+
+  cluster_name              = "${var.project_name}-${var.environment}"
+  environment               = var.environment
+  enable_container_insights = false
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: Storage (EFS, ECR)
+# ============================================
+module "storage" {
+  source = "../../modules/storage"
+
+  environment  = var.environment
+  project_name = var.project_name
+
+  vpc_id                = module.networking.vpc_id
+  private_subnet_ids    = module.networking.private_subnet_ids
+  efs_security_group_id = module.networking.efs_security_group_id
+
+  efs_access_points = [
+    { name = "consul", path = "/consul" },
+    { name = "redis", path = "/redis" },
+    { name = "minio", path = "/minio" },
+    { name = "nats", path = "/nats" },
+  ]
+
+  # Fewer ECR repos in dev — only core services
+  ecr_repositories = [
+    "consul", "redis", "minio", "nats",
+    "gateway",
+    "agent", "model", "mcp", "user"
+  ]
+
+  ecr_lifecycle_policy_days = 3
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: Secrets Management
+# ============================================
+module "secrets" {
+  source = "../../modules/secrets"
+
+  environment  = var.environment
+  project_name = var.project_name
+
+  recovery_window_in_days = 0
+
+  secrets = {
+    database = {
+      description = "Database credentials (dev)"
+      secret_data = {
+        SUPABASE_URL              = var.supabase_url
+        SUPABASE_ANON_KEY         = var.supabase_anon_key
+        SUPABASE_SERVICE_ROLE_KEY = var.supabase_service_role_key
+        DATABASE_PASSWORD         = var.database_password
+      }
+    }
+    redis = {
+      description = "Redis credentials (dev)"
+      secret_data = {
+        REDIS_PASSWORD = var.redis_password
+      }
+    }
+    minio = {
+      description = "MinIO credentials (dev)"
+      secret_data = {
+        MINIO_ROOT_USER     = var.minio_root_user
+        MINIO_ROOT_PASSWORD = var.minio_root_password
+      }
+    }
+    gateway = {
+      description = "Gateway service secrets (dev)"
+      secret_data = {
+        JWT_SECRET = var.jwt_secret
+      }
+    }
+  }
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: Load Balancer
+# ============================================
+module "load_balancer" {
+  source = "../../modules/load-balancer"
+
+  environment  = var.environment
+  project_name = var.project_name
+
+  vpc_id                = module.networking.vpc_id
+  public_subnet_ids     = module.networking.public_subnet_ids
+  alb_security_group_id = module.networking.alb_security_group_id
+
+  enable_deletion_protection = false
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: Monitoring
+# ============================================
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  environment  = var.environment
+  project_name = var.project_name
+  cluster_name = module.ecs_cluster.cluster_name
+
+  enable_alarms      = false
+  log_retention_days = 7
+  enable_dashboard   = false
+
+  tags = local.common_tags
+}

--- a/deployments/terraform/environments/dev/outputs.tf
+++ b/deployments/terraform/environments/dev/outputs.tf
@@ -1,0 +1,38 @@
+# ============================================
+# isA Cloud - Dev Environment Outputs
+# ============================================
+
+output "account_id" {
+  description = "AWS Account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "region" {
+  description = "AWS Region"
+  value       = var.aws_region
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.networking.vpc_id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS Cluster name"
+  value       = module.ecs_cluster.cluster_name
+}
+
+output "ecr_repository_urls" {
+  description = "ECR repository URLs"
+  value       = module.storage.ecr_repository_urls
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS name"
+  value       = module.load_balancer.alb_dns_name
+}
+
+output "application_url" {
+  description = "Application URL (via ALB)"
+  value       = "http://${module.load_balancer.alb_dns_name}"
+}

--- a/deployments/terraform/environments/dev/variables.tf
+++ b/deployments/terraform/environments/dev/variables.tf
@@ -1,0 +1,145 @@
+# ============================================
+# isA Cloud - Dev Environment Variables
+# ============================================
+# Cost-optimized defaults for development.
+
+# ============================================
+# General Configuration
+# ============================================
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+  default     = "isa-cloud"
+}
+
+# ============================================
+# Networking Configuration
+# ============================================
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.2.0.0/16"
+}
+
+# ============================================
+# Database Secrets (Supabase)
+# ============================================
+variable "supabase_url" {
+  description = "Supabase project URL"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "supabase_anon_key" {
+  description = "Supabase anonymous key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "supabase_service_role_key" {
+  description = "Supabase service role key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "database_password" {
+  description = "Database password"
+  type        = string
+  sensitive   = true
+  default     = "dev_password_2024"
+}
+
+# ============================================
+# Infrastructure Secrets
+# ============================================
+variable "redis_password" {
+  description = "Redis password"
+  type        = string
+  default     = "dev_redis_2024"
+  sensitive   = true
+}
+
+variable "minio_root_user" {
+  description = "MinIO root user"
+  type        = string
+  default     = "minioadmin"
+  sensitive   = true
+}
+
+variable "minio_root_password" {
+  description = "MinIO root password"
+  type        = string
+  default     = "minioadmin"
+  sensitive   = true
+}
+
+# ============================================
+# Application Secrets
+# ============================================
+variable "jwt_secret" {
+  description = "JWT secret for gateway"
+  type        = string
+  default     = "dev-secret-key-not-for-production"
+  sensitive   = true
+}
+
+variable "mcp_api_key" {
+  description = "MCP API key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "composio_api_key" {
+  description = "Composio API key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "brave_token" {
+  description = "Brave search API token"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "neo4j_password" {
+  description = "Neo4j database password"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# ============================================
+# SSL/TLS Configuration
+# ============================================
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS (optional for dev)"
+  type        = string
+  default     = ""
+}
+
+# ============================================
+# Monitoring Configuration
+# ============================================
+variable "alarm_email_endpoints" {
+  description = "Email addresses for CloudWatch alarms"
+  type        = list(string)
+  default     = []
+}

--- a/deployments/terraform/environments/production/backend.tf
+++ b/deployments/terraform/environments/production/backend.tf
@@ -1,0 +1,13 @@
+# ============================================
+# isA Cloud - Production State Backend
+# ============================================
+
+terraform {
+  backend "s3" {
+    bucket         = "isa-cloud-terraform-state-production"
+    key            = "production/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "isa-cloud-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/deployments/terraform/environments/production/main.tf
+++ b/deployments/terraform/environments/production/main.tf
@@ -1,0 +1,240 @@
+# ============================================
+# isA Cloud - Production Environment
+# ============================================
+# Production configuration: multi-AZ, deletion protection,
+# HTTPS required, alarms enabled, higher resource limits.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# ============================================
+# Provider Configuration
+# ============================================
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = var.project_name
+      ManagedBy   = "Terraform"
+      Repository  = "isA_Cloud"
+    }
+  }
+}
+
+# ============================================
+# Data Sources
+# ============================================
+data "aws_caller_identity" "current" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# ============================================
+# Local Variables
+# ============================================
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+
+  common_tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+
+  # Production service configuration — higher resources than staging
+  services = {
+    # Infrastructure services
+    consul    = { port = 8500, cpu = 1024, memory = 2048 }
+    redis     = { port = 6379, cpu = 1024, memory = 2048 }
+    minio     = { port = 9000, cpu = 2048, memory = 4096 }
+    nats      = { port = 4222, cpu = 1024, memory = 2048 }
+    mosquitto = { port = 1883, cpu = 512, memory = 1024 }
+    loki      = { port = 3100, cpu = 1024, memory = 2048 }
+    grafana   = { port = 3000, cpu = 512, memory = 1024 }
+
+    # Gateway layer
+    gateway   = { port = 8000, cpu = 2048, memory = 4096 }
+    openresty = { port = 80, cpu = 1024, memory = 2048 }
+
+    # Application services
+    agent = { port = 8080, cpu = 4096, memory = 8192 }
+    model = { port = 8082, cpu = 8192, memory = 16384 }
+    mcp   = { port = 8081, cpu = 4096, memory = 8192 }
+    user  = { port = 8201, cpu = 8192, memory = 16384 }
+  }
+}
+
+# ============================================
+# Module: Networking
+# ============================================
+module "networking" {
+  source = "../../modules/networking"
+
+  environment        = var.environment
+  project_name       = var.project_name
+  vpc_cidr           = var.vpc_cidr
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  enable_ecr_endpoint            = true
+  enable_s3_endpoint             = true
+  enable_secretsmanager_endpoint = true
+  enable_cloudwatch_endpoint     = true
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: ECS Cluster
+# ============================================
+module "ecs_cluster" {
+  source = "../../modules/ecs-cluster"
+
+  cluster_name              = "${var.project_name}-${var.environment}"
+  environment               = var.environment
+  enable_container_insights = true
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: Storage (EFS, ECR)
+# ============================================
+module "storage" {
+  source = "../../modules/storage"
+
+  environment  = var.environment
+  project_name = var.project_name
+
+  vpc_id                = module.networking.vpc_id
+  private_subnet_ids    = module.networking.private_subnet_ids
+  efs_security_group_id = module.networking.efs_security_group_id
+
+  efs_access_points = [
+    { name = "consul", path = "/consul" },
+    { name = "redis", path = "/redis" },
+    { name = "minio", path = "/minio" },
+    { name = "nats", path = "/nats" },
+    { name = "mosquitto", path = "/mosquitto" },
+    { name = "loki", path = "/loki" },
+    { name = "grafana", path = "/grafana" },
+    { name = "duckdb", path = "/duckdb" },
+  ]
+
+  ecr_repositories = [
+    "consul", "redis", "minio", "nats", "mosquitto", "loki", "grafana",
+    "gateway", "openresty",
+    "agent", "model", "mcp", "user"
+  ]
+
+  ecr_image_tag_mutability  = "IMMUTABLE"
+  ecr_lifecycle_policy_days = 30
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: Secrets Management
+# ============================================
+module "secrets" {
+  source = "../../modules/secrets"
+
+  environment  = var.environment
+  project_name = var.project_name
+
+  recovery_window_in_days = 30
+
+  secrets = {
+    database = {
+      description = "Supabase database credentials"
+      secret_data = {
+        SUPABASE_URL              = var.supabase_url
+        SUPABASE_ANON_KEY         = var.supabase_anon_key
+        SUPABASE_SERVICE_ROLE_KEY = var.supabase_service_role_key
+        DATABASE_PASSWORD         = var.database_password
+      }
+    }
+    redis = {
+      description = "Redis credentials"
+      secret_data = {
+        REDIS_PASSWORD = var.redis_password
+      }
+    }
+    minio = {
+      description = "MinIO credentials"
+      secret_data = {
+        MINIO_ROOT_USER     = var.minio_root_user
+        MINIO_ROOT_PASSWORD = var.minio_root_password
+      }
+    }
+    gateway = {
+      description = "Gateway service secrets"
+      secret_data = {
+        JWT_SECRET = var.jwt_secret
+      }
+    }
+    mcp = {
+      description = "MCP service API keys"
+      secret_data = {
+        MCP_API_KEY      = var.mcp_api_key
+        COMPOSIO_API_KEY = var.composio_api_key
+        BRAVE_TOKEN      = var.brave_token
+        NEO4J_PASSWORD   = var.neo4j_password
+      }
+    }
+    stripe = {
+      description = "Stripe payment credentials"
+      secret_data = {
+        STRIPE_SECRET_KEY     = var.stripe_secret_key
+        STRIPE_WEBHOOK_SECRET = var.stripe_webhook_secret
+      }
+    }
+  }
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: Load Balancer
+# ============================================
+module "load_balancer" {
+  source = "../../modules/load-balancer"
+
+  environment  = var.environment
+  project_name = var.project_name
+
+  vpc_id                = module.networking.vpc_id
+  public_subnet_ids     = module.networking.public_subnet_ids
+  alb_security_group_id = module.networking.alb_security_group_id
+
+  certificate_arn            = var.certificate_arn
+  enable_deletion_protection = true
+
+  tags = local.common_tags
+}
+
+# ============================================
+# Module: Monitoring
+# ============================================
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  environment  = var.environment
+  project_name = var.project_name
+  cluster_name = module.ecs_cluster.cluster_name
+
+  enable_alarms         = true
+  alarm_email_endpoints = var.alarm_email_endpoints
+  log_retention_days    = 90
+  enable_dashboard      = true
+
+  tags = local.common_tags
+}

--- a/deployments/terraform/environments/production/outputs.tf
+++ b/deployments/terraform/environments/production/outputs.tf
@@ -1,0 +1,105 @@
+# ============================================
+# isA Cloud - Production Environment Outputs
+# ============================================
+
+output "account_id" {
+  description = "AWS Account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "region" {
+  description = "AWS Region"
+  value       = var.aws_region
+}
+
+# ============================================
+# Networking Outputs
+# ============================================
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.networking.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs"
+  value       = module.networking.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs"
+  value       = module.networking.private_subnet_ids
+}
+
+# ============================================
+# ECS Outputs
+# ============================================
+output "ecs_cluster_name" {
+  description = "ECS Cluster name"
+  value       = module.ecs_cluster.cluster_name
+}
+
+output "ecs_cluster_arn" {
+  description = "ECS Cluster ARN"
+  value       = module.ecs_cluster.cluster_arn
+}
+
+# ============================================
+# Storage Outputs
+# ============================================
+output "efs_file_system_id" {
+  description = "EFS File System ID"
+  value       = module.storage.efs_file_system_id
+}
+
+output "ecr_repository_urls" {
+  description = "ECR repository URLs"
+  value       = module.storage.ecr_repository_urls
+}
+
+# ============================================
+# Load Balancer Outputs
+# ============================================
+output "alb_dns_name" {
+  description = "ALB DNS name"
+  value       = module.load_balancer.alb_dns_name
+}
+
+output "alb_zone_id" {
+  description = "ALB Zone ID for Route53 alias records"
+  value       = module.load_balancer.alb_zone_id
+}
+
+output "alb_arn" {
+  description = "ALB ARN"
+  value       = module.load_balancer.alb_arn
+}
+
+# ============================================
+# Monitoring Outputs
+# ============================================
+output "log_group_name" {
+  description = "CloudWatch log group name"
+  value       = module.monitoring.log_group_name
+}
+
+output "sns_topic_arn" {
+  description = "SNS alarm topic ARN"
+  value       = module.monitoring.sns_topic_arn
+}
+
+# ============================================
+# Secrets Outputs
+# ============================================
+output "secrets_arns" {
+  description = "ARNs of secrets in Secrets Manager"
+  value       = module.secrets.secret_arns
+  sensitive   = true
+}
+
+# ============================================
+# Quick Access Commands
+# ============================================
+output "application_url" {
+  description = "Application URL (via ALB)"
+  value       = "https://${module.load_balancer.alb_dns_name}"
+}

--- a/deployments/terraform/environments/production/variables.tf
+++ b/deployments/terraform/environments/production/variables.tf
@@ -1,0 +1,148 @@
+# ============================================
+# isA Cloud - Production Environment Variables
+# ============================================
+
+# ============================================
+# General Configuration
+# ============================================
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+  default     = "isa-cloud"
+}
+
+# ============================================
+# Networking Configuration
+# ============================================
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.1.0.0/16"
+}
+
+# ============================================
+# Database Secrets (Supabase)
+# ============================================
+variable "supabase_url" {
+  description = "Supabase project URL"
+  type        = string
+  sensitive   = true
+}
+
+variable "supabase_anon_key" {
+  description = "Supabase anonymous key"
+  type        = string
+  sensitive   = true
+}
+
+variable "supabase_service_role_key" {
+  description = "Supabase service role key"
+  type        = string
+  sensitive   = true
+}
+
+variable "database_password" {
+  description = "Database password"
+  type        = string
+  sensitive   = true
+}
+
+# ============================================
+# Infrastructure Secrets
+# ============================================
+variable "redis_password" {
+  description = "Redis password"
+  type        = string
+  sensitive   = true
+}
+
+variable "minio_root_user" {
+  description = "MinIO root user"
+  type        = string
+  sensitive   = true
+}
+
+variable "minio_root_password" {
+  description = "MinIO root password"
+  type        = string
+  sensitive   = true
+}
+
+# ============================================
+# Application Secrets
+# ============================================
+variable "jwt_secret" {
+  description = "JWT secret for gateway"
+  type        = string
+  sensitive   = true
+}
+
+variable "mcp_api_key" {
+  description = "MCP API key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "composio_api_key" {
+  description = "Composio API key"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "brave_token" {
+  description = "Brave search API token"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "neo4j_password" {
+  description = "Neo4j database password"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "stripe_secret_key" {
+  description = "Stripe API secret key for payments"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "stripe_webhook_secret" {
+  description = "Stripe webhook secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# ============================================
+# SSL/TLS Configuration
+# ============================================
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS (required for production)"
+  type        = string
+}
+
+# ============================================
+# Monitoring Configuration
+# ============================================
+variable "alarm_email_endpoints" {
+  description = "Email addresses for CloudWatch alarms"
+  type        = list(string)
+}

--- a/deployments/terraform/modules/ecs-service/main.tf
+++ b/deployments/terraform/modules/ecs-service/main.tf
@@ -1,0 +1,261 @@
+# ============================================
+# ECS Service Module
+# ============================================
+# Reusable ECS Fargate service with task definition,
+# IAM roles, optional ALB target group, EFS volumes,
+# service discovery, and auto-scaling.
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ============================================
+# IAM - Task Execution Role
+# ============================================
+resource "aws_iam_role" "execution" {
+  name_prefix = "${var.project_name}-${var.environment}-${var.service_name}-exec-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-${var.service_name}-exec"
+    Environment = var.environment
+    Service     = var.service_name
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "execution_base" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "execution_secrets" {
+  count = var.secrets_read_policy_arn != "" ? 1 : 0
+
+  role       = aws_iam_role.execution.name
+  policy_arn = var.secrets_read_policy_arn
+}
+
+# ============================================
+# IAM - Task Role
+# ============================================
+resource "aws_iam_role" "task" {
+  name_prefix = "${var.project_name}-${var.environment}-${var.service_name}-task-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-${var.service_name}-task"
+    Environment = var.environment
+    Service     = var.service_name
+  })
+}
+
+# Allow ECS Exec for debugging
+resource "aws_iam_role_policy" "task_exec" {
+  name = "ecs-exec"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+# ============================================
+# Task Definition
+# ============================================
+resource "aws_ecs_task_definition" "main" {
+  family                   = "${var.project_name}-${var.environment}-${var.service_name}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([{
+    name      = var.service_name
+    image     = var.container_image
+    essential = true
+
+    portMappings = [{
+      containerPort = var.container_port
+      protocol      = "tcp"
+    }]
+
+    environment = var.environment_variables
+    secrets     = var.secrets
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = var.log_group_name
+        "awslogs-region"        = data.aws_region.current.name
+        "awslogs-stream-prefix" = var.service_name
+      }
+    }
+
+    mountPoints = var.efs_file_system_id != "" ? [{
+      sourceVolume  = "efs-storage"
+      containerPath = var.efs_mount_path
+      readOnly      = false
+    }] : []
+  }])
+
+  dynamic "volume" {
+    for_each = var.efs_file_system_id != "" ? [1] : []
+    content {
+      name = "efs-storage"
+      efs_volume_configuration {
+        file_system_id     = var.efs_file_system_id
+        transit_encryption = "ENABLED"
+
+        dynamic "authorization_config" {
+          for_each = var.efs_access_point_id != "" ? [1] : []
+          content {
+            access_point_id = var.efs_access_point_id
+            iam             = "ENABLED"
+          }
+        }
+      }
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-${var.service_name}"
+    Environment = var.environment
+    Service     = var.service_name
+  })
+}
+
+# ============================================
+# Service Discovery (optional)
+# ============================================
+resource "aws_service_discovery_service" "main" {
+  count = var.cloud_map_namespace_id != "" ? 1 : 0
+
+  name = var.service_name
+
+  dns_config {
+    namespace_id = var.cloud_map_namespace_id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+# ============================================
+# ECS Service
+# ============================================
+resource "aws_ecs_service" "main" {
+  name            = "${var.project_name}-${var.environment}-${var.service_name}"
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.main.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  enable_execute_command = true
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.security_group_id]
+    assign_public_ip = false
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.target_group_arn != "" ? [1] : []
+    content {
+      target_group_arn = var.target_group_arn
+      container_name   = var.service_name
+      container_port   = var.container_port
+    }
+  }
+
+  dynamic "service_registries" {
+    for_each = var.cloud_map_namespace_id != "" ? [1] : []
+    content {
+      registry_arn = aws_service_discovery_service.main[0].arn
+    }
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 100
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-${var.service_name}"
+    Environment = var.environment
+    Service     = var.service_name
+  })
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+}
+
+# ============================================
+# Auto Scaling (optional)
+# ============================================
+resource "aws_appautoscaling_target" "main" {
+  count = var.enable_autoscaling ? 1 : 0
+
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  count = var.enable_autoscaling ? 1 : 0
+
+  name               = "${var.project_name}-${var.environment}-${var.service_name}-cpu-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.main[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.main[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.main[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value       = var.cpu_target_value
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}

--- a/deployments/terraform/modules/ecs-service/outputs.tf
+++ b/deployments/terraform/modules/ecs-service/outputs.tf
@@ -1,0 +1,38 @@
+# ============================================
+# ECS Service Module - Outputs
+# ============================================
+
+output "service_id" {
+  description = "ECS service ID"
+  value       = aws_ecs_service.main.id
+}
+
+output "service_name" {
+  description = "ECS service name"
+  value       = aws_ecs_service.main.name
+}
+
+output "task_definition_arn" {
+  description = "Task definition ARN"
+  value       = aws_ecs_task_definition.main.arn
+}
+
+output "task_definition_family" {
+  description = "Task definition family"
+  value       = aws_ecs_task_definition.main.family
+}
+
+output "execution_role_arn" {
+  description = "Task execution role ARN"
+  value       = aws_iam_role.execution.arn
+}
+
+output "task_role_arn" {
+  description = "Task role ARN"
+  value       = aws_iam_role.task.arn
+}
+
+output "service_discovery_arn" {
+  description = "Service discovery ARN (empty if not enabled)"
+  value       = length(aws_service_discovery_service.main) > 0 ? aws_service_discovery_service.main[0].arn : ""
+}

--- a/deployments/terraform/modules/ecs-service/variables.tf
+++ b/deployments/terraform/modules/ecs-service/variables.tf
@@ -1,0 +1,179 @@
+# ============================================
+# ECS Service Module - Variables
+# ============================================
+
+variable "environment" {
+  description = "Environment name (staging, production, dev)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "service_name" {
+  description = "Name of the ECS service"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "ECS cluster ID"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+}
+
+# ============================================
+# Container Configuration
+# ============================================
+variable "container_image" {
+  description = "Docker image URI for the container"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Port the container listens on"
+  type        = number
+}
+
+variable "cpu" {
+  description = "CPU units for the task (1 vCPU = 1024)"
+  type        = number
+  default     = 256
+}
+
+variable "memory" {
+  description = "Memory in MiB for the task"
+  type        = number
+  default     = 512
+}
+
+variable "desired_count" {
+  description = "Desired number of running tasks"
+  type        = number
+  default     = 1
+}
+
+variable "environment_variables" {
+  description = "Environment variables for the container"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "secrets" {
+  description = "Secrets from Secrets Manager or SSM Parameter Store"
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  default = []
+}
+
+# ============================================
+# Networking
+# ============================================
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the service"
+  type        = list(string)
+}
+
+variable "security_group_id" {
+  description = "Security group ID for the ECS tasks"
+  type        = string
+}
+
+# ============================================
+# Load Balancer (optional)
+# ============================================
+variable "target_group_arn" {
+  description = "ALB target group ARN (empty to skip LB registration)"
+  type        = string
+  default     = ""
+}
+
+# ============================================
+# Storage (optional)
+# ============================================
+variable "efs_file_system_id" {
+  description = "EFS file system ID for persistent storage (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "efs_access_point_id" {
+  description = "EFS access point ID (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "efs_mount_path" {
+  description = "Container path to mount EFS volume"
+  type        = string
+  default     = "/data"
+}
+
+# ============================================
+# Service Discovery (optional)
+# ============================================
+variable "cloud_map_namespace_id" {
+  description = "Cloud Map namespace ID for service discovery (optional)"
+  type        = string
+  default     = ""
+}
+
+# ============================================
+# IAM
+# ============================================
+variable "secrets_read_policy_arn" {
+  description = "IAM policy ARN for reading secrets (optional)"
+  type        = string
+  default     = ""
+}
+
+# ============================================
+# Logging
+# ============================================
+variable "log_group_name" {
+  description = "CloudWatch log group name"
+  type        = string
+}
+
+# ============================================
+# Auto Scaling (optional)
+# ============================================
+variable "enable_autoscaling" {
+  description = "Enable ECS service auto-scaling"
+  type        = bool
+  default     = false
+}
+
+variable "min_capacity" {
+  description = "Minimum number of tasks"
+  type        = number
+  default     = 1
+}
+
+variable "max_capacity" {
+  description = "Maximum number of tasks"
+  type        = number
+  default     = 4
+}
+
+variable "cpu_target_value" {
+  description = "Target CPU utilization for auto-scaling (percent)"
+  type        = number
+  default     = 70
+}
+
+variable "tags" {
+  description = "Additional tags for resources"
+  type        = map(string)
+  default     = {}
+}

--- a/deployments/terraform/modules/load-balancer/main.tf
+++ b/deployments/terraform/modules/load-balancer/main.tf
@@ -1,0 +1,116 @@
+# ============================================
+# Load Balancer Module
+# ============================================
+# Application Load Balancer with HTTP/HTTPS listeners,
+# default target group, and optional SSL termination.
+
+# ============================================
+# Application Load Balancer
+# ============================================
+resource "aws_lb" "main" {
+  name               = "${var.project_name}-${var.environment}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.alb_security_group_id]
+  subnets            = var.public_subnet_ids
+
+  idle_timeout                     = var.idle_timeout
+  enable_deletion_protection       = var.enable_deletion_protection
+  enable_cross_zone_load_balancing = true
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-alb"
+    Environment = var.environment
+  })
+}
+
+# ============================================
+# Default Target Group
+# ============================================
+resource "aws_lb_target_group" "default" {
+  name        = "${var.project_name}-${var.environment}-default-tg"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    path                = var.health_check_path
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    interval            = var.health_check_interval
+    timeout             = var.health_check_timeout
+    healthy_threshold   = var.healthy_threshold
+    unhealthy_threshold = var.unhealthy_threshold
+    matcher             = "200-299"
+  }
+
+  deregistration_delay = 30
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-default-tg"
+    Environment = var.environment
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ============================================
+# HTTP Listener
+# ============================================
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  # If HTTPS is configured, redirect HTTP to HTTPS
+  # Otherwise, forward to default target group
+  dynamic "default_action" {
+    for_each = var.certificate_arn != "" ? [1] : []
+    content {
+      type = "redirect"
+      redirect {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+  }
+
+  dynamic "default_action" {
+    for_each = var.certificate_arn == "" ? [1] : []
+    content {
+      type             = "forward"
+      target_group_arn = aws_lb_target_group.default.arn
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-http-listener"
+  })
+}
+
+# ============================================
+# HTTPS Listener (optional - only if certificate provided)
+# ============================================
+resource "aws_lb_listener" "https" {
+  count = var.certificate_arn != "" ? 1 : 0
+
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.default.arn
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-https-listener"
+  })
+}

--- a/deployments/terraform/modules/load-balancer/outputs.tf
+++ b/deployments/terraform/modules/load-balancer/outputs.tf
@@ -1,0 +1,38 @@
+# ============================================
+# Load Balancer Module - Outputs
+# ============================================
+
+output "alb_id" {
+  description = "ALB ID"
+  value       = aws_lb.main.id
+}
+
+output "alb_arn" {
+  description = "ALB ARN"
+  value       = aws_lb.main.arn
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS name"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_zone_id" {
+  description = "ALB hosted zone ID for Route53 alias records"
+  value       = aws_lb.main.zone_id
+}
+
+output "default_target_group_arn" {
+  description = "Default target group ARN"
+  value       = aws_lb_target_group.default.arn
+}
+
+output "http_listener_arn" {
+  description = "HTTP listener ARN"
+  value       = aws_lb_listener.http.arn
+}
+
+output "https_listener_arn" {
+  description = "HTTPS listener ARN (empty if no certificate)"
+  value       = length(aws_lb_listener.https) > 0 ? aws_lb_listener.https[0].arn : ""
+}

--- a/deployments/terraform/modules/load-balancer/variables.tf
+++ b/deployments/terraform/modules/load-balancer/variables.tf
@@ -1,0 +1,82 @@
+# ============================================
+# Load Balancer Module - Variables
+# ============================================
+
+variable "environment" {
+  description = "Environment name (staging, production, dev)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the ALB"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs for the ALB"
+  type        = list(string)
+}
+
+variable "alb_security_group_id" {
+  description = "Security group ID for the ALB"
+  type        = string
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS listener (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "idle_timeout" {
+  description = "ALB idle timeout in seconds"
+  type        = number
+  default     = 60
+}
+
+variable "enable_deletion_protection" {
+  description = "Enable ALB deletion protection"
+  type        = bool
+  default     = false
+}
+
+variable "health_check_path" {
+  description = "Default target group health check path"
+  type        = string
+  default     = "/health"
+}
+
+variable "health_check_interval" {
+  description = "Health check interval in seconds"
+  type        = number
+  default     = 30
+}
+
+variable "health_check_timeout" {
+  description = "Health check timeout in seconds"
+  type        = number
+  default     = 5
+}
+
+variable "healthy_threshold" {
+  description = "Number of consecutive successes before healthy"
+  type        = number
+  default     = 3
+}
+
+variable "unhealthy_threshold" {
+  description = "Number of consecutive failures before unhealthy"
+  type        = number
+  default     = 3
+}
+
+variable "tags" {
+  description = "Additional tags for resources"
+  type        = map(string)
+  default     = {}
+}

--- a/deployments/terraform/modules/monitoring/main.tf
+++ b/deployments/terraform/modules/monitoring/main.tf
@@ -1,0 +1,156 @@
+# ============================================
+# Monitoring Module
+# ============================================
+# CloudWatch log groups, alarms, SNS notifications,
+# and optional dashboard for ECS cluster monitoring.
+
+data "aws_region" "current" {}
+
+# ============================================
+# CloudWatch Log Group
+# ============================================
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/${var.project_name}-${var.environment}"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-ecs-logs"
+    Environment = var.environment
+  })
+}
+
+# ============================================
+# SNS Topic for Alarm Notifications
+# ============================================
+resource "aws_sns_topic" "alarms" {
+  count = var.enable_alarms ? 1 : 0
+
+  name = "${var.project_name}-${var.environment}-alarms"
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-alarms"
+    Environment = var.environment
+  })
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  count = var.enable_alarms ? length(var.alarm_email_endpoints) : 0
+
+  topic_arn = aws_sns_topic.alarms[0].arn
+  protocol  = "email"
+  endpoint  = var.alarm_email_endpoints[count.index]
+}
+
+# ============================================
+# CloudWatch Alarms - ECS Cluster
+# ============================================
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  count = var.enable_alarms ? 1 : 0
+
+  alarm_name          = "${var.project_name}-${var.environment}-cpu-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = var.alarm_evaluation_periods
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = var.alarm_period
+  statistic           = "Average"
+  threshold           = var.cpu_alarm_threshold
+  alarm_description   = "ECS cluster CPU utilization above ${var.cpu_alarm_threshold}%"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ClusterName = var.cluster_name
+  }
+
+  alarm_actions = [aws_sns_topic.alarms[0].arn]
+  ok_actions    = [aws_sns_topic.alarms[0].arn]
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-cpu-high"
+    Environment = var.environment
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_high" {
+  count = var.enable_alarms ? 1 : 0
+
+  alarm_name          = "${var.project_name}-${var.environment}-memory-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = var.alarm_evaluation_periods
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = var.alarm_period
+  statistic           = "Average"
+  threshold           = var.memory_alarm_threshold
+  alarm_description   = "ECS cluster memory utilization above ${var.memory_alarm_threshold}%"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ClusterName = var.cluster_name
+  }
+
+  alarm_actions = [aws_sns_topic.alarms[0].arn]
+  ok_actions    = [aws_sns_topic.alarms[0].arn]
+
+  tags = merge(var.tags, {
+    Name        = "${var.project_name}-${var.environment}-memory-high"
+    Environment = var.environment
+  })
+}
+
+# ============================================
+# CloudWatch Dashboard (optional)
+# ============================================
+resource "aws_cloudwatch_dashboard" "main" {
+  count = var.enable_dashboard ? 1 : 0
+
+  dashboard_name = "${var.project_name}-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title   = "ECS CPU Utilization"
+          metrics = [["AWS/ECS", "CPUUtilization", "ClusterName", var.cluster_name]]
+          period  = 300
+          stat    = "Average"
+          region  = data.aws_region.current.name
+          view    = "timeSeries"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title   = "ECS Memory Utilization"
+          metrics = [["AWS/ECS", "MemoryUtilization", "ClusterName", var.cluster_name]]
+          period  = 300
+          stat    = "Average"
+          region  = data.aws_region.current.name
+          view    = "timeSeries"
+        }
+      },
+      {
+        type   = "log"
+        x      = 0
+        y      = 6
+        width  = 24
+        height = 6
+        properties = {
+          title  = "ECS Application Logs"
+          query  = "SOURCE '${aws_cloudwatch_log_group.ecs.name}' | fields @timestamp, @message | sort @timestamp desc | limit 50"
+          region = data.aws_region.current.name
+          view   = "table"
+        }
+      }
+    ]
+  })
+}

--- a/deployments/terraform/modules/monitoring/outputs.tf
+++ b/deployments/terraform/modules/monitoring/outputs.tf
@@ -1,0 +1,33 @@
+# ============================================
+# Monitoring Module - Outputs
+# ============================================
+
+output "log_group_name" {
+  description = "CloudWatch log group name"
+  value       = aws_cloudwatch_log_group.ecs.name
+}
+
+output "log_group_arn" {
+  description = "CloudWatch log group ARN"
+  value       = aws_cloudwatch_log_group.ecs.arn
+}
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for alarm notifications"
+  value       = length(aws_sns_topic.alarms) > 0 ? aws_sns_topic.alarms[0].arn : ""
+}
+
+output "dashboard_name" {
+  description = "CloudWatch dashboard name"
+  value       = length(aws_cloudwatch_dashboard.main) > 0 ? aws_cloudwatch_dashboard.main[0].dashboard_name : ""
+}
+
+output "cpu_alarm_arn" {
+  description = "CPU high alarm ARN"
+  value       = length(aws_cloudwatch_metric_alarm.cpu_high) > 0 ? aws_cloudwatch_metric_alarm.cpu_high[0].arn : ""
+}
+
+output "memory_alarm_arn" {
+  description = "Memory high alarm ARN"
+  value       = length(aws_cloudwatch_metric_alarm.memory_high) > 0 ? aws_cloudwatch_metric_alarm.memory_high[0].arn : ""
+}

--- a/deployments/terraform/modules/monitoring/variables.tf
+++ b/deployments/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,72 @@
+# ============================================
+# Monitoring Module - Variables
+# ============================================
+
+variable "environment" {
+  description = "Environment name (staging, production, dev)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "ECS cluster name for CloudWatch metrics"
+  type        = string
+}
+
+variable "enable_alarms" {
+  description = "Enable CloudWatch alarms"
+  type        = bool
+  default     = true
+}
+
+variable "alarm_email_endpoints" {
+  description = "Email addresses for alarm notifications"
+  type        = list(string)
+  default     = []
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log group retention in days"
+  type        = number
+  default     = 30
+}
+
+variable "cpu_alarm_threshold" {
+  description = "CPU utilization alarm threshold (percent)"
+  type        = number
+  default     = 80
+}
+
+variable "memory_alarm_threshold" {
+  description = "Memory utilization alarm threshold (percent)"
+  type        = number
+  default     = 80
+}
+
+variable "alarm_evaluation_periods" {
+  description = "Number of periods to evaluate before alarming"
+  type        = number
+  default     = 3
+}
+
+variable "alarm_period" {
+  description = "Alarm evaluation period in seconds"
+  type        = number
+  default     = 300
+}
+
+variable "enable_dashboard" {
+  description = "Create CloudWatch dashboard"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Additional tags for resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- Implement 3 previously-stub Terraform modules: **ecs-service**, **load-balancer**, **monitoring**
- Create **production** and **dev** environment configs following staging patterns
- All modules validate via `terraform validate` and follow existing naming/tagging conventions

## Modules

| Module | Resources | Lines |
|--------|-----------|-------|
| ecs-service | Task def, ECS service, IAM roles, service discovery, autoscaling | 261 |
| load-balancer | ALB, HTTP/HTTPS listeners, default target group | 116 |
| monitoring | CloudWatch log group, CPU/memory alarms, SNS topic, dashboard | 156 |

## Environments

| Environment | AZs | Key differences |
|-------------|-----|-----------------|
| production | 3 | Higher resources, HTTPS required, deletion protection, 90-day logs, Stripe secrets |
| dev | 2 | Minimal resources, no alarms, no VPC endpoints, 7-day logs, 3-day ECR cleanup |

## Test plan
- [x] `terraform init` succeeds for all 3 modules
- [x] `terraform validate` passes for all 3 modules
- [x] `terraform fmt -check` passes (auto-formatted)
- [x] Module interfaces match staging main.tf references

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)