### PR TITLE
chore(core,sdk): map contract IDs to tests and export local clients

### DIFF
--- a/isA_common/README.md
+++ b/isA_common/README.md
@@ -1,22 +1,38 @@
 # isA Common
 
-Shared Python infrastructure library for the isA platform.
+Shared async Python client library for the isA platform.
 
 ## Overview
 
-`isa-common` provides Python client libraries and utilities for interacting with various infrastructure services in the isA Cloud platform, including:
+`isa-common` provides async Python clients for interacting with isA Cloud infrastructure services. All clients use `async with` context managers and share a common base class (`AsyncBaseClient`).
 
-- **DuckDB Client** - Analytics database integration
-- **Loki Client** - Log aggregation and querying
-- **MinIO Client** - Object storage operations
-- **MQTT Client** - Message broker for IoT
-- **NATS Client** - Cloud-native messaging system
-- **Redis Client** - Caching and data structures
-- **Supabase Client** - Backend-as-a-Service integration
+### Infrastructure Clients (require running services)
+
+| Client | Service | Default Port | Protocol |
+|--------|---------|-------------|----------|
+| `AsyncRedisClient` | Redis | 6379 | gRPC proxy |
+| `AsyncPostgresClient` | PostgreSQL | 5432 | gRPC proxy |
+| `AsyncNeo4jClient` | Neo4j | 7687 | gRPC proxy |
+| `AsyncNATSClient` | NATS | 4222 | gRPC proxy |
+| `AsyncMQTTClient` | MQTT | 1883 | gRPC proxy |
+| `AsyncMinioClient` | MinIO | 9000 | gRPC proxy |
+| `AsyncQdrantClient` | Qdrant | 6333 | gRPC proxy |
+| `AsyncDuckDBClient` | DuckDB | embedded | native |
+
+### Local-Mode Clients (no external services needed)
+
+Drop-in alternatives for desktop/offline use. Same API surface, backed by local storage:
+
+| Local Client | Replaces | Backed By |
+|-------------|----------|-----------|
+| `AsyncSQLiteClient` | `AsyncPostgresClient` | SQLite file |
+| `AsyncLocalStorageClient` | `AsyncMinioClient` | Local filesystem |
+| `AsyncChromaClient` | `AsyncQdrantClient` | ChromaDB (embedded) |
+| `AsyncMemoryClient` | `AsyncRedisClient` | In-memory dict |
+
+**When to use local clients:** Use local-mode clients when running on desktop/ICP without cloud infrastructure, for development/testing without Docker, or when you need offline-capable storage.
 
 ## Installation
-
-Install from PyPI:
 
 ```bash
 pip install isa-common
@@ -24,96 +40,49 @@ pip install isa-common
 
 ## Quick Start
 
-### DuckDB Client Example
-
 ```python
-from isa_common.duckdb_client import DuckDBClient
+from isa_common import AsyncRedisClient
 
-client = DuckDBClient(host="localhost", port=50051)
-client.connect()
-
-# Execute query
-result = client.execute_query("SELECT * FROM my_table")
-print(result)
+async with AsyncRedisClient(host="localhost", port=6379, user_id="my-user") as client:
+    health = await client.health_check()
+    await client.set("key", "value")
+    value = await client.get("key")
 ```
 
-### NATS Client Example
+### Using Local-Mode Clients
 
 ```python
-from isa_common.nats_client import NATSClient
+from isa_common import AsyncSQLiteClient, AsyncLocalStorageClient
 
-client = NATSClient(host="localhost", port=50054)
-client.connect()
+# SQLite instead of PostgreSQL
+async with AsyncSQLiteClient(database="app.db", user_id="my-user") as db:
+    await db.query("SELECT * FROM users")
 
-# Publish message
-client.publish("my.subject", b"Hello World")
-
-# Subscribe to subject
-messages = client.subscribe("my.subject")
+# Local filesystem instead of MinIO
+async with AsyncLocalStorageClient(base_path="./storage", user_id="my-user") as storage:
+    await storage.put_object("my-bucket", "file.txt", b"contents")
 ```
-
-### MinIO Client Example
-
-```python
-from isa_common.minio_client import MinIOClient
-
-client = MinIOClient(host="localhost", port=50052)
-client.connect()
-
-# Upload file
-client.put_object("my-bucket", "file.txt", b"file contents")
-
-# Download file
-data = client.get_object("my-bucket", "file.txt")
-```
-
-## Features
-
-- **gRPC-based** communication with backend services
-- **Service Discovery** integration with Consul
-- **Automatic Reconnection** with configurable retry policies
-- **Type Safety** with Pydantic models
-- **Comprehensive Examples** included in the package
-
-## Requirements
-
-- Python 3.8+
-- grpcio >= 1.50.0
-- pydantic >= 2.0.0
-- tenacity >= 8.0.0
-
-## Documentation
-
-For detailed documentation and more examples, see:
-- [DuckDB Client Examples](examples/duck_client_examples.py)
-- [Loki Client Examples](examples/loki_client_examples.py)
-- [MinIO Client Examples](examples/minio_client_examples.py)
-- [MQTT Client Examples](examples/mqtt_client_examples.py)
-- [NATS Client Examples](examples/nats_client_examples.py)
-- [Redis Client Examples](examples/redis_client_examples.py)
-- [Supabase Client Examples](examples/supa_client_examples.py)
 
 ## Development
 
-Install development dependencies:
+Run tests (requires services or use local clients):
 
 ```bash
-pip install isa-common[dev]
+# Run individual service tests
+python tests/redis/test_async_redis.py
+python tests/duck/test_async_duckdb.py
+
+# Run all tests via Makefile
+make test
 ```
 
-Run tests:
+## Contract Coverage
 
-```bash
-pytest
-```
+See [tests/contract_coverage.md](tests/contract_coverage.md) for the mapping between CDD contract IDs (BR/EC/ER) and test functions.
 
 ## License
 
 Copyright © 2024 isA Platform
-
-## Support
-
-For issues and questions, please visit: https://github.com/isa-platform/isA_Cloud
 
 
 

--- a/isA_common/isa_common/__init__.py
+++ b/isA_common/isa_common/__init__.py
@@ -44,6 +44,14 @@ from .async_duckdb_client import AsyncDuckDBClient
 from .async_mqtt_client import AsyncMQTTClient
 from .async_qdrant_client import AsyncQdrantClient
 
+# =============================================================================
+# Local-Mode Alternative Clients (ICP/Desktop — no infrastructure required)
+# =============================================================================
+from .async_sqlite_client import AsyncSQLiteClient
+from .async_local_storage_client import AsyncLocalStorageClient
+from .async_chroma_client import AsyncChromaClient
+from .async_memory_client import AsyncMemoryClient
+
 # Service Discovery
 from .consul_client import ConsulRegistry, consul_lifespan
 
@@ -66,6 +74,11 @@ __all__ = [
     'AsyncDuckDBClient',
     'AsyncMQTTClient',
     'AsyncQdrantClient',
+    # Local-mode alternative clients
+    'AsyncSQLiteClient',
+    'AsyncLocalStorageClient',
+    'AsyncChromaClient',
+    'AsyncMemoryClient',
     # Service discovery
     'ConsulRegistry',
     'consul_lifespan',

--- a/isA_common/tests/duck/test_async_duckdb.py
+++ b/isA_common/tests/duck/test_async_duckdb.py
@@ -26,6 +26,29 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 from isa_common import AsyncDuckDBClient
 
+# ============================================
+# Contract Mapping — see tests/contracts/duckdb/logic_contract.md
+# ============================================
+CONTRACT_MAP = {
+    'test_health_check':          [],
+    'test_simple_query':          ['BR-002'],
+    'test_query_with_params':     ['BR-002'],
+    'test_create_table':          [],
+    'test_list_tables':           [],
+    'test_get_table_schema':      [],
+    'test_execute_insert':        [],
+    'test_execute_batch_insert':  [],
+    'test_query_data':            ['BR-002'],
+    'test_aggregate_functions':   ['BR-002'],
+    'test_update':                [],
+    'test_delete':                [],
+    'test_sequential_queries':    [],
+    'test_csv_export':            ['BR-004'],
+    'test_drop_table':            [],
+}
+
+UNCOVERED_CONTRACTS = ['BR-001', 'BR-003', 'BR-005', 'BR-006', 'BR-007', 'BR-008', 'EC-001', 'EC-002', 'EC-003', 'EC-004', 'EC-005', 'EC-006', 'EC-007', 'EC-008', 'EC-009', 'ER-001']
+
 # Configuration
 DATABASE = os.environ.get('DATABASE', ':memory:')  # In-memory by default
 USER_ID = os.environ.get('USER_ID', 'test_user')
@@ -47,7 +70,10 @@ def test_result(success: bool, test_name: str):
 
 
 async def test_health_check(client: AsyncDuckDBClient) -> bool:
-    """Test 1: Health Check (verify connection)"""
+    """Test 1: Health Check (verify connection)
+
+    Validates: (additional coverage)
+    """
     try:
         health = await client.health_check()
         success = health is not None and health.get('healthy', False)
@@ -59,7 +85,10 @@ async def test_health_check(client: AsyncDuckDBClient) -> bool:
 
 
 async def test_simple_query(client: AsyncDuckDBClient):
-    """Test 2: Simple Query"""
+    """Test 2: Simple Query
+
+    Validates: BR-002 (OLAP Query Execution)
+    """
     try:
         result = await client.query("SELECT 1 as num, 'hello' as msg")
         if result is None or len(result) == 0:
@@ -76,7 +105,10 @@ async def test_simple_query(client: AsyncDuckDBClient):
 
 
 async def test_query_with_params(client: AsyncDuckDBClient):
-    """Test 3: Query with Parameters"""
+    """Test 3: Query with Parameters
+
+    Validates: BR-002 (OLAP Query Execution)
+    """
     try:
         result = await client.query(
             "SELECT ? as num, ? as msg",
@@ -96,7 +128,10 @@ async def test_query_with_params(client: AsyncDuckDBClient):
 
 
 async def test_create_table(client: AsyncDuckDBClient):
-    """Test 4: Create Table"""
+    """Test 4: Create Table
+
+    Validates: (additional coverage)
+    """
     try:
         schema = {
             'id': 'INTEGER',
@@ -112,7 +147,10 @@ async def test_create_table(client: AsyncDuckDBClient):
 
 
 async def test_list_tables(client: AsyncDuckDBClient):
-    """Test 5: List Tables"""
+    """Test 5: List Tables
+
+    Validates: (additional coverage)
+    """
     try:
         tables = await client.list_tables()
         if tables is None:
@@ -126,7 +164,10 @@ async def test_list_tables(client: AsyncDuckDBClient):
 
 
 async def test_get_table_schema(client: AsyncDuckDBClient):
-    """Test 6: Get Table Schema"""
+    """Test 6: Get Table Schema
+
+    Validates: (additional coverage)
+    """
     try:
         schema = await client.get_table_schema('', 'test_table')
         if schema is None:
@@ -143,7 +184,10 @@ async def test_get_table_schema(client: AsyncDuckDBClient):
 
 
 async def test_execute_insert(client: AsyncDuckDBClient):
-    """Test 7: Execute INSERT"""
+    """Test 7: Execute INSERT
+
+    Validates: (additional coverage)
+    """
     try:
         rows = await client.execute(
             "INSERT INTO test_table (id, name, value) VALUES (1, 'test1', 3.14)"
@@ -154,7 +198,10 @@ async def test_execute_insert(client: AsyncDuckDBClient):
 
 
 async def test_execute_batch_insert(client: AsyncDuckDBClient):
-    """Test 8: Execute Batch INSERT"""
+    """Test 8: Execute Batch INSERT
+
+    Validates: (additional coverage)
+    """
     try:
         # execute_batch expects list of {'sql': str, 'params': list} dictionaries
         operations = [
@@ -170,7 +217,10 @@ async def test_execute_batch_insert(client: AsyncDuckDBClient):
 
 
 async def test_query_data(client: AsyncDuckDBClient):
-    """Test 9: Query Data from Table"""
+    """Test 9: Query Data from Table
+
+    Validates: BR-002 (OLAP Query Execution)
+    """
     try:
         result = await client.query("SELECT * FROM test_table ORDER BY id")
         if result is None or len(result) == 0:
@@ -187,7 +237,10 @@ async def test_query_data(client: AsyncDuckDBClient):
 
 
 async def test_aggregate_functions(client: AsyncDuckDBClient):
-    """Test 10: Aggregate Functions"""
+    """Test 10: Aggregate Functions
+
+    Validates: BR-002 (OLAP Query Execution)
+    """
     try:
         result = await client.query("""
             SELECT
@@ -213,7 +266,10 @@ async def test_aggregate_functions(client: AsyncDuckDBClient):
 
 
 async def test_update(client: AsyncDuckDBClient):
-    """Test 11: Execute UPDATE"""
+    """Test 11: Execute UPDATE
+
+    Validates: (additional coverage)
+    """
     try:
         await client.execute("UPDATE test_table SET value = 5.0 WHERE id = 1")
 
@@ -228,7 +284,10 @@ async def test_update(client: AsyncDuckDBClient):
 
 
 async def test_delete(client: AsyncDuckDBClient):
-    """Test 12: Execute DELETE"""
+    """Test 12: Execute DELETE
+
+    Validates: (additional coverage)
+    """
     try:
         await client.execute("DELETE FROM test_table WHERE id = 4")
 
@@ -243,7 +302,10 @@ async def test_delete(client: AsyncDuckDBClient):
 
 
 async def test_sequential_queries(client: AsyncDuckDBClient):
-    """Test 13: Sequential Queries (DuckDB is single-connection, no true concurrency)"""
+    """Test 13: Sequential Queries (DuckDB is single-connection, no true concurrency)
+
+    Validates: (additional coverage)
+    """
     try:
         queries = [
             "SELECT COUNT(*) as cnt FROM test_table",
@@ -267,7 +329,10 @@ async def test_sequential_queries(client: AsyncDuckDBClient):
 
 
 async def test_csv_export(client: AsyncDuckDBClient):
-    """Test 14: CSV Export"""
+    """Test 14: CSV Export
+
+    Validates: BR-004 (Data Export)
+    """
     try:
         with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
             csv_path = f.name
@@ -285,7 +350,10 @@ async def test_csv_export(client: AsyncDuckDBClient):
 
 
 async def test_drop_table(client: AsyncDuckDBClient):
-    """Test 15: Drop Table"""
+    """Test 15: Drop Table
+
+    Validates: (additional coverage)
+    """
     try:
         await client.drop_table('', 'test_table')
 

--- a/isA_common/tests/minio/test_async_minio.py
+++ b/isA_common/tests/minio/test_async_minio.py
@@ -36,6 +36,33 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from isa_common import AsyncMinIOClient
 
+# ============================================
+# Contract Mapping — see tests/contracts/minio/logic_contract.md
+# ============================================
+CONTRACT_MAP = {
+    'test_health_check':                [],
+    'test_create_bucket':               ['EC-002'],
+    'test_bucket_exists':               [],
+    'test_list_buckets':                [],
+    'test_get_bucket_info':             [],
+    'test_upload_object':               ['BR-004'],
+    'test_get_object':                  [],
+    'test_get_object_metadata':         ['BR-004'],
+    'test_list_objects':                ['BR-005'],
+    'test_copy_object':                 [],
+    'test_object_tags':                 [],
+    'test_presigned_url':               ['BR-003'],
+    'test_presigned_put_url':           ['BR-003'],
+    'test_bucket_tags':                 [],
+    'test_concurrent_upload':           [],
+    'test_upload_many_concurrent':      [],
+    'test_download_many_concurrent':    [],
+    'test_delete_object':               [],
+    'test_delete_objects':              [],
+}
+
+UNCOVERED_CONTRACTS = ['BR-001', 'BR-002', 'BR-006', 'BR-007', 'EC-001', 'EC-003', 'EC-004', 'EC-005', 'EC-006', 'EC-007', 'EC-008', 'ER-001']
+
 # Configuration - Native S3 client (aioboto3)
 HOST = os.environ.get('MINIO_HOST', 'localhost')
 PORT = int(os.environ.get('MINIO_PORT', '9000'))  # S3 API port (not gRPC)
@@ -63,7 +90,10 @@ def test_result(success: bool, test_name: str):
 
 
 async def test_health_check(client: AsyncMinIOClient) -> bool:
-    """Test 1: Service Health Check"""
+    """Test 1: Service Health Check
+
+    Validates: (additional coverage)
+    """
     try:
         health = await client.health_check()
         success = health is not None and health.get('healthy', False)
@@ -75,7 +105,10 @@ async def test_health_check(client: AsyncMinIOClient) -> bool:
 
 
 async def test_create_bucket(client: AsyncMinIOClient):
-    """Test 2: Create Bucket"""
+    """Test 2: Create Bucket
+
+    Validates: EC-002 (Bucket Already Exists)
+    """
     try:
         result = await client.create_bucket(TEST_BUCKET)
         if result is None:
@@ -93,7 +126,10 @@ async def test_create_bucket(client: AsyncMinIOClient):
 
 
 async def test_bucket_exists(client: AsyncMinIOClient):
-    """Test 3: Bucket Exists Check"""
+    """Test 3: Bucket Exists Check
+
+    Validates: (additional coverage)
+    """
     try:
         exists = await client.bucket_exists(TEST_BUCKET)
         if not exists:
@@ -106,7 +142,10 @@ async def test_bucket_exists(client: AsyncMinIOClient):
 
 
 async def test_list_buckets(client: AsyncMinIOClient):
-    """Test 4: List Buckets"""
+    """Test 4: List Buckets
+
+    Validates: (additional coverage)
+    """
     try:
         buckets = await client.list_buckets()
         if buckets is None:
@@ -119,7 +158,10 @@ async def test_list_buckets(client: AsyncMinIOClient):
 
 
 async def test_get_bucket_info(client: AsyncMinIOClient):
-    """Test 5: Get Bucket Info"""
+    """Test 5: Get Bucket Info
+
+    Validates: (additional coverage)
+    """
     try:
         info = await client.get_bucket_info(TEST_BUCKET)
         if info is None:
@@ -132,7 +174,10 @@ async def test_get_bucket_info(client: AsyncMinIOClient):
 
 
 async def test_upload_object(client: AsyncMinIOClient):
-    """Test 6: Upload Object"""
+    """Test 6: Upload Object
+
+    Validates: BR-004 (Object Metadata)
+    """
     try:
         data = b'Hello from async MinIO client! This is test content.'
         result = await client.upload_object(
@@ -156,7 +201,10 @@ async def test_upload_object(client: AsyncMinIOClient):
 
 
 async def test_get_object(client: AsyncMinIOClient):
-    """Test 7: Get Object"""
+    """Test 7: Get Object
+
+    Validates: (additional coverage)
+    """
     try:
         data = await client.get_object(TEST_BUCKET, 'test/hello.txt')
         if data is None:
@@ -173,7 +221,10 @@ async def test_get_object(client: AsyncMinIOClient):
 
 
 async def test_get_object_metadata(client: AsyncMinIOClient):
-    """Test 8: Get Object Metadata"""
+    """Test 8: Get Object Metadata
+
+    Validates: BR-004 (Object Metadata)
+    """
     try:
         metadata = await client.get_object_metadata(TEST_BUCKET, 'test/hello.txt')
         if metadata is None:
@@ -190,7 +241,10 @@ async def test_get_object_metadata(client: AsyncMinIOClient):
 
 
 async def test_list_objects(client: AsyncMinIOClient):
-    """Test 9: List Objects"""
+    """Test 9: List Objects
+
+    Validates: BR-005 (Object Listing with Pagination)
+    """
     try:
         objects = await client.list_objects(TEST_BUCKET, prefix='test/')
         if objects is None:
@@ -207,7 +261,10 @@ async def test_list_objects(client: AsyncMinIOClient):
 
 
 async def test_copy_object(client: AsyncMinIOClient):
-    """Test 10: Copy Object"""
+    """Test 10: Copy Object
+
+    Validates: (additional coverage)
+    """
     try:
         success = await client.copy_object(
             dest_bucket=TEST_BUCKET,
@@ -231,7 +288,10 @@ async def test_copy_object(client: AsyncMinIOClient):
 
 
 async def test_object_tags(client: AsyncMinIOClient):
-    """Test 11: Object Tags"""
+    """Test 11: Object Tags
+
+    Validates: (additional coverage)
+    """
     try:
         # Set tags
         success = await client.set_object_tags(
@@ -255,7 +315,10 @@ async def test_object_tags(client: AsyncMinIOClient):
 
 
 async def test_presigned_url(client: AsyncMinIOClient):
-    """Test 12: Generate Presigned URL"""
+    """Test 12: Generate Presigned URL
+
+    Validates: BR-003 (Presigned URL Generation)
+    """
     try:
         url = await client.get_presigned_url(
             TEST_BUCKET,
@@ -276,7 +339,10 @@ async def test_presigned_url(client: AsyncMinIOClient):
 
 
 async def test_presigned_put_url(client: AsyncMinIOClient):
-    """Test 13: Generate Presigned PUT URL"""
+    """Test 13: Generate Presigned PUT URL
+
+    Validates: BR-003 (Presigned URL Generation)
+    """
     try:
         url = await client.get_presigned_put_url(
             TEST_BUCKET,
@@ -294,7 +360,10 @@ async def test_presigned_put_url(client: AsyncMinIOClient):
 
 
 async def test_bucket_tags(client: AsyncMinIOClient):
-    """Test 14: Bucket Tags"""
+    """Test 14: Bucket Tags
+
+    Validates: (additional coverage)
+    """
     try:
         # Set bucket tags
         success = await client.set_bucket_tags(
@@ -317,7 +386,10 @@ async def test_bucket_tags(client: AsyncMinIOClient):
 
 
 async def test_concurrent_upload(client: AsyncMinIOClient):
-    """Test 15: Concurrent Upload"""
+    """Test 15: Concurrent Upload
+
+    Validates: (additional coverage)
+    """
     try:
         start = time.time()
 
@@ -345,7 +417,10 @@ async def test_concurrent_upload(client: AsyncMinIOClient):
 
 
 async def test_upload_many_concurrent(client: AsyncMinIOClient):
-    """Test 16: upload_many_concurrent Helper"""
+    """Test 16: upload_many_concurrent Helper
+
+    Validates: (additional coverage)
+    """
     try:
         uploads = [
             {'bucket': TEST_BUCKET, 'key': f'test/batch_{i}.txt', 'data': f'Batch {i}'.encode()}
@@ -367,7 +442,10 @@ async def test_upload_many_concurrent(client: AsyncMinIOClient):
 
 
 async def test_download_many_concurrent(client: AsyncMinIOClient):
-    """Test 17: download_many_concurrent Helper"""
+    """Test 17: download_many_concurrent Helper
+
+    Validates: (additional coverage)
+    """
     try:
         downloads = [
             {'bucket': TEST_BUCKET, 'key': f'test/batch_{i}.txt'}
@@ -389,7 +467,10 @@ async def test_download_many_concurrent(client: AsyncMinIOClient):
 
 
 async def test_delete_object(client: AsyncMinIOClient):
-    """Test 18: Delete Object"""
+    """Test 18: Delete Object
+
+    Validates: (additional coverage)
+    """
     try:
         success = await client.delete_object(TEST_BUCKET, 'test/hello_copy.txt')
         if not success:
@@ -402,7 +483,10 @@ async def test_delete_object(client: AsyncMinIOClient):
 
 
 async def test_delete_objects(client: AsyncMinIOClient):
-    """Test 19: Delete Multiple Objects"""
+    """Test 19: Delete Multiple Objects
+
+    Validates: (additional coverage)
+    """
     try:
         keys = [f'test/concurrent_{i}.txt' for i in range(5)]
         keys.extend([f'test/batch_{i}.txt' for i in range(3)])

--- a/isA_common/tests/mqtt/test_async_mqtt.py
+++ b/isA_common/tests/mqtt/test_async_mqtt.py
@@ -24,6 +24,33 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 from isa_common import AsyncMQTTClient
 
+# ============================================
+# Contract Mapping — see tests/contracts/mqtt/logic_contract.md
+# ============================================
+CONTRACT_MAP = {
+    'test_health_check':           [],
+    'test_connect':                [],
+    'test_connection_status':      [],
+    'test_publish':                ['BR-003', 'BR-006'],
+    'test_publish_batch':          ['BR-003'],
+    'test_publish_json':           ['BR-006'],
+    'test_validate_topic':         [],
+    'test_register_device':        [],
+    'test_list_devices':           [],
+    'test_get_device_info':        [],
+    'test_update_device_status':   [],
+    'test_list_topics':            [],
+    'test_set_retained_message':   ['BR-004'],
+    'test_get_retained_message':   ['BR-004'],
+    'test_delete_retained_message':['BR-004'],
+    'test_get_statistics':         [],
+    'test_bulk_publish':           [],
+    'test_unregister_device':      [],
+    'test_disconnect':             [],
+}
+
+UNCOVERED_CONTRACTS = ['BR-001', 'BR-002', 'BR-005', 'BR-007', 'EC-001', 'EC-002', 'EC-003', 'EC-004', 'EC-005', 'EC-006', 'EC-007', 'ER-001']
+
 # Configuration
 HOST = os.environ.get('HOST', 'localhost')
 PORT = int(os.environ.get('PORT', '1883'))
@@ -47,7 +74,10 @@ def test_result(success: bool, test_name: str):
 
 
 async def test_health_check(client: AsyncMQTTClient) -> bool:
-    """Test 1: Service Health Check"""
+    """Test 1: Service Health Check
+
+    Validates: (additional coverage)
+    """
     try:
         health = await client.health_check()
         success = health is not None and health.get('healthy', False)
@@ -59,7 +89,10 @@ async def test_health_check(client: AsyncMQTTClient) -> bool:
 
 
 async def test_connect(client: AsyncMQTTClient, client_id: str) -> str:
-    """Test 2: Connect to MQTT"""
+    """Test 2: Connect to MQTT
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.mqtt_connect(client_id)
         if result and result.get('success'):
@@ -73,7 +106,10 @@ async def test_connect(client: AsyncMQTTClient, client_id: str) -> str:
 
 
 async def test_connection_status(client: AsyncMQTTClient, session_id: str):
-    """Test 3: Get Connection Status"""
+    """Test 3: Get Connection Status
+
+    Validates: (additional coverage)
+    """
     try:
         status = await client.get_connection_status(session_id)
         success = status is not None
@@ -83,7 +119,10 @@ async def test_connection_status(client: AsyncMQTTClient, session_id: str):
 
 
 async def test_publish(client: AsyncMQTTClient, session_id: str):
-    """Test 4: Publish Message"""
+    """Test 4: Publish Message
+
+    Validates: BR-003 (Quality of Service), BR-006 (Message Payload)
+    """
     try:
         result = await client.publish(session_id, 'test/async/topic', b'Hello from async client', qos=1)
         success = result is not None and result.get('success')
@@ -93,7 +132,10 @@ async def test_publish(client: AsyncMQTTClient, session_id: str):
 
 
 async def test_publish_batch(client: AsyncMQTTClient, session_id: str):
-    """Test 5: Publish Batch"""
+    """Test 5: Publish Batch
+
+    Validates: BR-003 (Quality of Service)
+    """
     try:
         messages = [
             {'topic': 'test/async/batch/1', 'payload': b'Message 1', 'qos': 1},
@@ -108,7 +150,10 @@ async def test_publish_batch(client: AsyncMQTTClient, session_id: str):
 
 
 async def test_publish_json(client: AsyncMQTTClient, session_id: str):
-    """Test 6: Publish JSON"""
+    """Test 6: Publish JSON
+
+    Validates: BR-006 (Message Payload)
+    """
     try:
         data = {
             'temperature': 25.5,
@@ -123,7 +168,10 @@ async def test_publish_json(client: AsyncMQTTClient, session_id: str):
 
 
 async def test_validate_topic(client: AsyncMQTTClient):
-    """Test 7: Validate Topic"""
+    """Test 7: Validate Topic
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.validate_topic('sensors/temperature')
         success = result is not None and result.get('valid', False)
@@ -133,7 +181,10 @@ async def test_validate_topic(client: AsyncMQTTClient):
 
 
 async def test_register_device(client: AsyncMQTTClient, device_id: str):
-    """Test 8: Register Device"""
+    """Test 8: Register Device
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.register_device(
             device_id=device_id,
@@ -148,7 +199,10 @@ async def test_register_device(client: AsyncMQTTClient, device_id: str):
 
 
 async def test_list_devices(client: AsyncMQTTClient):
-    """Test 9: List Devices"""
+    """Test 9: List Devices
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.list_devices()
         success = result is not None and 'devices' in result
@@ -158,7 +212,10 @@ async def test_list_devices(client: AsyncMQTTClient):
 
 
 async def test_get_device_info(client: AsyncMQTTClient, device_id: str):
-    """Test 10: Get Device Info"""
+    """Test 10: Get Device Info
+
+    Validates: (additional coverage)
+    """
     try:
         info = await client.get_device_info(device_id)
         success = info is not None and info.get('device_id') == device_id
@@ -168,7 +225,10 @@ async def test_get_device_info(client: AsyncMQTTClient, device_id: str):
 
 
 async def test_update_device_status(client: AsyncMQTTClient, device_id: str):
-    """Test 11: Update Device Status"""
+    """Test 11: Update Device Status
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.update_device_status(device_id, status=1, metadata={'updated': 'true'})
         success = result is not None and result.get('success')
@@ -178,7 +238,10 @@ async def test_update_device_status(client: AsyncMQTTClient, device_id: str):
 
 
 async def test_list_topics(client: AsyncMQTTClient):
-    """Test 12: List Topics"""
+    """Test 12: List Topics
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.list_topics()
         success = result is not None and 'topics' in result
@@ -188,7 +251,10 @@ async def test_list_topics(client: AsyncMQTTClient):
 
 
 async def test_set_retained_message(client: AsyncMQTTClient):
-    """Test 13: Set Retained Message"""
+    """Test 13: Set Retained Message
+
+    Validates: BR-004 (Retained Messages)
+    """
     try:
         success = await client.set_retained_message('test/async/retained', b'Retained data', qos=1)
         test_result(success, "Set retained message")
@@ -197,7 +263,10 @@ async def test_set_retained_message(client: AsyncMQTTClient):
 
 
 async def test_get_retained_message(client: AsyncMQTTClient):
-    """Test 14: Get Retained Message"""
+    """Test 14: Get Retained Message
+
+    Validates: BR-004 (Retained Messages)
+    """
     try:
         result = await client.get_retained_message('test/async/retained')
         success = result is not None
@@ -207,7 +276,10 @@ async def test_get_retained_message(client: AsyncMQTTClient):
 
 
 async def test_delete_retained_message(client: AsyncMQTTClient):
-    """Test 15: Delete Retained Message"""
+    """Test 15: Delete Retained Message
+
+    Validates: BR-004 (Retained Messages)
+    """
     try:
         success = await client.delete_retained_message('test/async/retained')
         test_result(success, "Delete retained message")
@@ -216,7 +288,10 @@ async def test_delete_retained_message(client: AsyncMQTTClient):
 
 
 async def test_get_statistics(client: AsyncMQTTClient):
-    """Test 16: Get Statistics"""
+    """Test 16: Get Statistics
+
+    Validates: (additional coverage)
+    """
     try:
         stats = await client.get_statistics()
         success = stats is not None
@@ -226,7 +301,10 @@ async def test_get_statistics(client: AsyncMQTTClient):
 
 
 async def test_bulk_publish(client: AsyncMQTTClient, session_id: str):
-    """Test 17: Bulk Publish (using single connection batch)"""
+    """Test 17: Bulk Publish (using single connection batch)
+
+    Validates: (additional coverage)
+    """
     try:
         # Note: MQTT with aiomqtt creates new connection per publish call,
         # so we use publish_batch which shares a single connection
@@ -246,7 +324,10 @@ async def test_bulk_publish(client: AsyncMQTTClient, session_id: str):
 
 
 async def test_unregister_device(client: AsyncMQTTClient, device_id: str):
-    """Test 18: Unregister Device"""
+    """Test 18: Unregister Device
+
+    Validates: (additional coverage)
+    """
     try:
         success = await client.unregister_device(device_id)
         test_result(success, f"Unregister device '{device_id}'")
@@ -255,7 +336,10 @@ async def test_unregister_device(client: AsyncMQTTClient, device_id: str):
 
 
 async def test_disconnect(client: AsyncMQTTClient, session_id: str):
-    """Test 19: Disconnect"""
+    """Test 19: Disconnect
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.disconnect(session_id)
         success = result is not None and result.get('success')

--- a/isA_common/tests/nats/test_async_nats.py
+++ b/isA_common/tests/nats/test_async_nats.py
@@ -28,6 +28,29 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from isa_common import AsyncNATSClient
 
+# ============================================
+# Contract Mapping — see tests/contracts/nats/logic_contract.md
+# ============================================
+CONTRACT_MAP = {
+    'test_health_check':              [],
+    'test_publish':                   ['BR-001'],
+    'test_publish_with_headers':      ['BR-001'],
+    'test_publish_batch':             [],
+    'test_request_reply':             ['BR-006'],
+    'test_create_stream':             ['BR-003'],
+    'test_list_streams':              [],
+    'test_publish_to_stream':         ['BR-003'],
+    'test_create_consumer':           ['BR-004'],
+    'test_pull_messages':             ['BR-004'],
+    'test_kv_operations':             ['BR-005'],
+    'test_object_store_operations':   [],
+    'test_concurrent_publish':        [],
+    'test_publish_many_concurrent':   [],
+    'test_statistics':                [],
+}
+
+UNCOVERED_CONTRACTS = ['BR-002', 'EC-001', 'EC-002', 'EC-003', 'EC-004', 'EC-005', 'EC-006', 'EC-007', 'EC-008', 'ER-001']
+
 # Configuration
 HOST = os.environ.get('HOST', 'localhost')
 PORT = int(os.environ.get('PORT', '4222'))
@@ -52,7 +75,10 @@ def test_result(success: bool, test_name: str):
 
 
 async def test_health_check(client: AsyncNATSClient) -> bool:
-    """Test 1: Service Health Check (functional test via publish)"""
+    """Test 1: Service Health Check (functional test via publish)
+
+    Validates: (additional coverage)
+    """
     try:
         # The standard health_check() uses Ping which has a bug in the Go service
         # (FlushWithContext returns error even when connection is working).
@@ -73,7 +99,10 @@ async def test_health_check(client: AsyncNATSClient) -> bool:
 
 
 async def test_publish(client: AsyncNATSClient):
-    """Test 2: Publish Message"""
+    """Test 2: Publish Message
+
+    Validates: BR-001 (Subject-Based Publish/Subscribe)
+    """
     try:
         result = await client.publish(
             'async.test.subject',
@@ -89,7 +118,10 @@ async def test_publish(client: AsyncNATSClient):
 
 
 async def test_publish_with_headers(client: AsyncNATSClient):
-    """Test 3: Publish Message with Headers"""
+    """Test 3: Publish Message with Headers
+
+    Validates: BR-001 (Subject-Based Publish/Subscribe)
+    """
     try:
         result = await client.publish(
             'async.test.headers',
@@ -106,7 +138,10 @@ async def test_publish_with_headers(client: AsyncNATSClient):
 
 
 async def test_publish_batch(client: AsyncNATSClient):
-    """Test 4: Batch Publish"""
+    """Test 4: Batch Publish
+
+    Validates: (additional coverage)
+    """
     try:
         messages = [
             {'subject': 'async.test.batch.1', 'data': b'message 1'},
@@ -129,7 +164,10 @@ async def test_publish_batch(client: AsyncNATSClient):
 
 
 async def test_request_reply(client: AsyncNATSClient):
-    """Test 5: Request-Reply Pattern"""
+    """Test 5: Request-Reply Pattern
+
+    Validates: BR-006 (Request-Reply Pattern)
+    """
     try:
         # Note: This requires a responder - may timeout without one
         result = await client.request(
@@ -151,7 +189,10 @@ async def test_request_reply(client: AsyncNATSClient):
 
 
 async def test_create_stream(client: AsyncNATSClient):
-    """Test 6: Create JetStream Stream"""
+    """Test 6: Create JetStream Stream
+
+    Validates: BR-003 (JetStream Persistence)
+    """
     try:
         result = await client.create_stream(
             'ASYNC_TEST_STREAM',
@@ -173,7 +214,10 @@ async def test_create_stream(client: AsyncNATSClient):
 
 
 async def test_list_streams(client: AsyncNATSClient):
-    """Test 7: List Streams"""
+    """Test 7: List Streams
+
+    Validates: (additional coverage)
+    """
     try:
         streams = await client.list_streams()
         if streams is None:
@@ -186,7 +230,10 @@ async def test_list_streams(client: AsyncNATSClient):
 
 
 async def test_publish_to_stream(client: AsyncNATSClient):
-    """Test 8: Publish to JetStream Stream"""
+    """Test 8: Publish to JetStream Stream
+
+    Validates: BR-003 (JetStream Persistence)
+    """
     try:
         result = await client.publish_to_stream(
             'ASYNC_TEST_STREAM',
@@ -207,7 +254,10 @@ async def test_publish_to_stream(client: AsyncNATSClient):
 
 
 async def test_create_consumer(client: AsyncNATSClient):
-    """Test 9: Create JetStream Consumer"""
+    """Test 9: Create JetStream Consumer
+
+    Validates: BR-004 (Consumer Acknowledgment)
+    """
     try:
         result = await client.create_consumer(
             'ASYNC_TEST_STREAM',
@@ -229,7 +279,10 @@ async def test_create_consumer(client: AsyncNATSClient):
 
 
 async def test_pull_messages(client: AsyncNATSClient):
-    """Test 10: Pull Messages from Consumer"""
+    """Test 10: Pull Messages from Consumer
+
+    Validates: BR-004 (Consumer Acknowledgment)
+    """
     try:
         messages = await client.pull_messages(
             'ASYNC_TEST_STREAM',
@@ -246,7 +299,10 @@ async def test_pull_messages(client: AsyncNATSClient):
 
 
 async def test_kv_operations(client: AsyncNATSClient):
-    """Test 11: KV Store Operations"""
+    """Test 11: KV Store Operations
+
+    Validates: BR-005 (Key-Value Store)
+    """
     try:
         # Put
         result = await client.kv_put('async-test-bucket', 'test-key', b'test-value')
@@ -279,7 +335,10 @@ async def test_kv_operations(client: AsyncNATSClient):
 
 
 async def test_object_store_operations(client: AsyncNATSClient):
-    """Test 12: Object Store Operations"""
+    """Test 12: Object Store Operations
+
+    Validates: (additional coverage)
+    """
     try:
         # Put object
         result = await client.object_put(
@@ -312,7 +371,10 @@ async def test_object_store_operations(client: AsyncNATSClient):
 
 
 async def test_concurrent_publish(client: AsyncNATSClient):
-    """Test 13: Concurrent Publish Operations"""
+    """Test 13: Concurrent Publish Operations
+
+    Validates: (additional coverage)
+    """
     try:
         start = time.time()
 
@@ -335,7 +397,10 @@ async def test_concurrent_publish(client: AsyncNATSClient):
 
 
 async def test_publish_many_concurrent(client: AsyncNATSClient):
-    """Test 14: publish_many_concurrent Helper"""
+    """Test 14: publish_many_concurrent Helper
+
+    Validates: (additional coverage)
+    """
     try:
         messages = [
             {'subject': f'async.test.helper.{i}', 'data': f'msg {i}'.encode()}
@@ -356,7 +421,10 @@ async def test_publish_many_concurrent(client: AsyncNATSClient):
 
 
 async def test_statistics(client: AsyncNATSClient):
-    """Test 15: Get Statistics"""
+    """Test 15: Get Statistics
+
+    Validates: (additional coverage)
+    """
     try:
         stats = await client.get_statistics()
         if stats is None:

--- a/isA_common/tests/neo4j/test_async_neo4j.py
+++ b/isA_common/tests/neo4j/test_async_neo4j.py
@@ -27,6 +27,32 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from isa_common import AsyncNeo4jClient
 
+# ============================================
+# Contract Mapping — see tests/contracts/neo4j/logic_contract.md
+# ============================================
+CONTRACT_MAP = {
+    'test_health_check':                [],
+    'test_run_cypher':                  ['BR-004'],
+    'test_cypher_with_params':          ['BR-004'],
+    'test_create_node':                 ['BR-002'],
+    'test_get_node':                    ['BR-002'],
+    'test_update_node':                 ['BR-002'],
+    'test_create_second_node':          ['BR-002'],
+    'test_create_relationship':         ['BR-003'],
+    'test_get_relationship':            ['BR-003'],
+    'test_find_nodes':                  ['BR-002'],
+    'test_get_path':                    ['BR-005'],
+    'test_shortest_path':               ['BR-005'],
+    'test_concurrent_queries':          [],
+    'test_run_cypher_many_concurrent':  [],
+    'test_create_nodes_concurrent':     [],
+    'test_get_stats':                   [],
+    'test_delete_relationship':         ['BR-003'],
+    'test_delete_node':                 ['BR-002'],
+}
+
+UNCOVERED_CONTRACTS = ['BR-001', 'BR-006', 'BR-007', 'EC-001', 'EC-002', 'EC-003', 'EC-004', 'EC-005', 'EC-006', 'EC-007', 'EC-008', 'ER-001']
+
 # Configuration
 HOST = os.environ.get('HOST', 'localhost')
 PORT = int(os.environ.get('PORT', '50063'))
@@ -55,7 +81,10 @@ def test_result(success: bool, test_name: str):
 
 
 async def test_health_check(client: AsyncNeo4jClient) -> bool:
-    """Test 1: Service Health Check"""
+    """Test 1: Service Health Check
+
+    Validates: (additional coverage)
+    """
     try:
         health = await client.health_check()
         success = health is not None and health.get('healthy', False)
@@ -67,7 +96,10 @@ async def test_health_check(client: AsyncNeo4jClient) -> bool:
 
 
 async def test_run_cypher(client: AsyncNeo4jClient):
-    """Test 2: Run Cypher Query"""
+    """Test 2: Run Cypher Query
+
+    Validates: BR-004 (Cypher Query Execution)
+    """
     try:
         result = await client.run_cypher("RETURN 1 as num, 'hello' as msg")
         if result is None or len(result) == 0:
@@ -84,7 +116,10 @@ async def test_run_cypher(client: AsyncNeo4jClient):
 
 
 async def test_cypher_with_params(client: AsyncNeo4jClient):
-    """Test 3: Cypher Query with Parameters"""
+    """Test 3: Cypher Query with Parameters
+
+    Validates: BR-004 (Cypher Query Execution)
+    """
     try:
         result = await client.run_cypher(
             "RETURN $num as num, $msg as msg",
@@ -104,7 +139,10 @@ async def test_cypher_with_params(client: AsyncNeo4jClient):
 
 
 async def test_create_node(client: AsyncNeo4jClient):
-    """Test 4: Create Node"""
+    """Test 4: Create Node
+
+    Validates: BR-002 (Node Operations)
+    """
     global created_nodes
     try:
         node_id = await client.create_node(
@@ -122,7 +160,10 @@ async def test_create_node(client: AsyncNeo4jClient):
 
 
 async def test_get_node(client: AsyncNeo4jClient):
-    """Test 5: Get Node"""
+    """Test 5: Get Node
+
+    Validates: BR-002 (Node Operations)
+    """
     global created_nodes
     try:
         if not created_nodes:
@@ -148,7 +189,10 @@ async def test_get_node(client: AsyncNeo4jClient):
 
 
 async def test_update_node(client: AsyncNeo4jClient):
-    """Test 6: Update Node"""
+    """Test 6: Update Node
+
+    Validates: BR-002 (Node Operations)
+    """
     global created_nodes
     try:
         if not created_nodes:
@@ -175,7 +219,10 @@ async def test_update_node(client: AsyncNeo4jClient):
 
 
 async def test_create_second_node(client: AsyncNeo4jClient):
-    """Test 7: Create Second Node for Relationship Tests"""
+    """Test 7: Create Second Node for Relationship Tests
+
+    Validates: BR-002 (Node Operations)
+    """
     global created_nodes
     try:
         node_id = await client.create_node(
@@ -193,7 +240,10 @@ async def test_create_second_node(client: AsyncNeo4jClient):
 
 
 async def test_create_relationship(client: AsyncNeo4jClient):
-    """Test 8: Create Relationship"""
+    """Test 8: Create Relationship
+
+    Validates: BR-003 (Relationship Operations)
+    """
     global created_nodes, created_relationships
     try:
         if len(created_nodes) < 2:
@@ -217,7 +267,10 @@ async def test_create_relationship(client: AsyncNeo4jClient):
 
 
 async def test_get_relationship(client: AsyncNeo4jClient):
-    """Test 9: Get Relationship"""
+    """Test 9: Get Relationship
+
+    Validates: BR-003 (Relationship Operations)
+    """
     global created_relationships
     try:
         if not created_relationships:
@@ -239,7 +292,10 @@ async def test_get_relationship(client: AsyncNeo4jClient):
 
 
 async def test_find_nodes(client: AsyncNeo4jClient):
-    """Test 10: Find Nodes"""
+    """Test 10: Find Nodes
+
+    Validates: BR-002 (Node Operations)
+    """
     try:
         nodes = await client.find_nodes(
             labels=['AsyncTestPerson'],
@@ -259,7 +315,10 @@ async def test_find_nodes(client: AsyncNeo4jClient):
 
 
 async def test_get_path(client: AsyncNeo4jClient):
-    """Test 11: Get Path"""
+    """Test 11: Get Path
+
+    Validates: BR-005 (Graph Traversal)
+    """
     global created_nodes
     try:
         if len(created_nodes) < 2:
@@ -285,7 +344,10 @@ async def test_get_path(client: AsyncNeo4jClient):
 
 
 async def test_shortest_path(client: AsyncNeo4jClient):
-    """Test 12: Shortest Path"""
+    """Test 12: Shortest Path
+
+    Validates: BR-005 (Graph Traversal)
+    """
     global created_nodes
     try:
         if len(created_nodes) < 2:
@@ -307,7 +369,10 @@ async def test_shortest_path(client: AsyncNeo4jClient):
 
 
 async def test_concurrent_queries(client: AsyncNeo4jClient):
-    """Test 13: Concurrent Query Execution"""
+    """Test 13: Concurrent Query Execution
+
+    Validates: (additional coverage)
+    """
     try:
         start = time.time()
 
@@ -331,7 +396,10 @@ async def test_concurrent_queries(client: AsyncNeo4jClient):
 
 
 async def test_run_cypher_many_concurrent(client: AsyncNeo4jClient):
-    """Test 14: run_cypher_many_concurrent Helper"""
+    """Test 14: run_cypher_many_concurrent Helper
+
+    Validates: (additional coverage)
+    """
     try:
         queries = [
             {'cypher': "RETURN 1 as num"},
@@ -353,7 +421,10 @@ async def test_run_cypher_many_concurrent(client: AsyncNeo4jClient):
 
 
 async def test_create_nodes_concurrent(client: AsyncNeo4jClient):
-    """Test 15: create_nodes_concurrent Helper"""
+    """Test 15: create_nodes_concurrent Helper
+
+    Validates: (additional coverage)
+    """
     global created_nodes
     try:
         nodes = [
@@ -378,7 +449,10 @@ async def test_create_nodes_concurrent(client: AsyncNeo4jClient):
 
 
 async def test_get_stats(client: AsyncNeo4jClient):
-    """Test 16: Get Statistics"""
+    """Test 16: Get Statistics
+
+    Validates: (additional coverage)
+    """
     try:
         stats = await client.get_stats()
         if stats is None:
@@ -391,7 +465,10 @@ async def test_get_stats(client: AsyncNeo4jClient):
 
 
 async def test_delete_relationship(client: AsyncNeo4jClient):
-    """Test 17: Delete Relationship"""
+    """Test 17: Delete Relationship
+
+    Validates: BR-003 (Relationship Operations)
+    """
     global created_relationships
     try:
         if not created_relationships:
@@ -410,7 +487,10 @@ async def test_delete_relationship(client: AsyncNeo4jClient):
 
 
 async def test_delete_node(client: AsyncNeo4jClient):
-    """Test 18: Delete Node"""
+    """Test 18: Delete Node
+
+    Validates: BR-002 (Node Operations)
+    """
     global created_nodes
     try:
         if not created_nodes:

--- a/isA_common/tests/postgres/test_async_postgres.py
+++ b/isA_common/tests/postgres/test_async_postgres.py
@@ -27,6 +27,29 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from isa_common import AsyncPostgresClient
 
+# ============================================
+# Contract Mapping — see tests/contracts/postgres/logic_contract.md
+# ============================================
+CONTRACT_MAP = {
+    'test_health_check':          [],
+    'test_simple_query':          ['BR-003'],
+    'test_query_with_params':     ['BR-001'],
+    'test_query_row':             ['BR-003'],
+    'test_list_tables':           [],
+    'test_table_exists':          ['EC-005'],
+    'test_execute_ddl':           [],
+    'test_execute_insert':        ['BR-004'],
+    'test_execute_update':        ['BR-004'],
+    'test_select_from_table':     ['BR-003', 'EC-005'],
+    'test_execute_delete':        ['BR-004'],
+    'test_execute_batch':         [],
+    'test_concurrent_queries':    [],
+    'test_query_many_concurrent': [],
+    'test_get_stats':             [],
+}
+
+UNCOVERED_CONTRACTS = ['BR-002', 'BR-005', 'BR-006', 'EC-001', 'EC-002', 'EC-003', 'EC-004', 'EC-006', 'EC-007', 'ER-001']
+
 # Configuration
 HOST = os.environ.get('HOST', 'localhost')
 PORT = int(os.environ.get('PORT', '5432'))
@@ -54,7 +77,10 @@ def test_result(success: bool, test_name: str):
 
 
 async def test_health_check(client: AsyncPostgresClient) -> bool:
-    """Test 1: Service Health Check"""
+    """Test 1: Service Health Check
+
+    Validates: (additional coverage)
+    """
     try:
         health = await client.health_check()
         success = health is not None and health.get('healthy', False)
@@ -66,7 +92,10 @@ async def test_health_check(client: AsyncPostgresClient) -> bool:
 
 
 async def test_simple_query(client: AsyncPostgresClient):
-    """Test 2: Simple Query"""
+    """Test 2: Simple Query
+
+    Validates: BR-003 (Query Result Formatting)
+    """
     try:
         result = await client.query("SELECT 1 as num, 'hello' as msg")
         if result is None or len(result) == 0:
@@ -83,7 +112,10 @@ async def test_simple_query(client: AsyncPostgresClient):
 
 
 async def test_query_with_params(client: AsyncPostgresClient):
-    """Test 3: Query with Parameters"""
+    """Test 3: Query with Parameters
+
+    Validates: BR-001 (Query Execution with Parameter Binding)
+    """
     try:
         result = await client.query(
             "SELECT $1::int as num, $2::text as msg",
@@ -103,7 +135,10 @@ async def test_query_with_params(client: AsyncPostgresClient):
 
 
 async def test_query_row(client: AsyncPostgresClient):
-    """Test 4: Query Single Row"""
+    """Test 4: Query Single Row
+
+    Validates: BR-003 (Query Result Formatting)
+    """
     try:
         result = await client.query_row("SELECT 1 as id, 'test' as name")
         if result is None:
@@ -120,7 +155,10 @@ async def test_query_row(client: AsyncPostgresClient):
 
 
 async def test_list_tables(client: AsyncPostgresClient):
-    """Test 5: List Tables"""
+    """Test 5: List Tables
+
+    Validates: (additional coverage)
+    """
     try:
         tables = await client.list_tables()
         # Tables list could be empty, that's ok
@@ -134,7 +172,10 @@ async def test_list_tables(client: AsyncPostgresClient):
 
 
 async def test_table_exists(client: AsyncPostgresClient):
-    """Test 6: Table Exists Check"""
+    """Test 6: Table Exists Check
+
+    Validates: EC-005 (Table Does Not Exist)
+    """
     try:
         # Check a common system table
         exists = await client.table_exists('pg_catalog.pg_tables', schema='pg_catalog')
@@ -150,7 +191,10 @@ async def test_table_exists(client: AsyncPostgresClient):
 
 
 async def test_execute_ddl(client: AsyncPostgresClient):
-    """Test 7: Execute DDL (Create/Drop Table)"""
+    """Test 7: Execute DDL (Create/Drop Table)
+
+    Validates: (additional coverage)
+    """
     try:
         # Create test table
         await client.execute("""
@@ -174,7 +218,10 @@ async def test_execute_ddl(client: AsyncPostgresClient):
 
 
 async def test_execute_insert(client: AsyncPostgresClient):
-    """Test 8: Execute INSERT"""
+    """Test 8: Execute INSERT
+
+    Validates: BR-004 (Affected Rows for Mutations)
+    """
     try:
         # Insert data
         rows = await client.execute(
@@ -188,7 +235,10 @@ async def test_execute_insert(client: AsyncPostgresClient):
 
 
 async def test_execute_update(client: AsyncPostgresClient):
-    """Test 9: Execute UPDATE"""
+    """Test 9: Execute UPDATE
+
+    Validates: BR-004 (Affected Rows for Mutations)
+    """
     try:
         rows = await client.execute(
             "UPDATE async_test_table SET value = $1 WHERE name = $2",
@@ -201,7 +251,10 @@ async def test_execute_update(client: AsyncPostgresClient):
 
 
 async def test_select_from_table(client: AsyncPostgresClient):
-    """Test 10: Query Inserted Data"""
+    """Test 10: Query Inserted Data
+
+    Validates: BR-003 (Query Result Formatting), EC-005 (Table Does Not Exist)
+    """
     try:
         result = await client.query(
             "SELECT * FROM async_test_table WHERE name = $1",
@@ -222,7 +275,10 @@ async def test_select_from_table(client: AsyncPostgresClient):
 
 
 async def test_execute_delete(client: AsyncPostgresClient):
-    """Test 11: Execute DELETE"""
+    """Test 11: Execute DELETE
+
+    Validates: BR-004 (Affected Rows for Mutations)
+    """
     try:
         rows = await client.execute(
             "DELETE FROM async_test_table WHERE name = $1",
@@ -235,7 +291,10 @@ async def test_execute_delete(client: AsyncPostgresClient):
 
 
 async def test_execute_batch(client: AsyncPostgresClient):
-    """Test 12: Execute Batch Operations"""
+    """Test 12: Execute Batch Operations
+
+    Validates: (additional coverage)
+    """
     try:
         operations = [
             {'sql': "INSERT INTO async_test_table (name, value) VALUES ($1, $2)", 'params': ['batch1', 10]},
@@ -254,7 +313,10 @@ async def test_execute_batch(client: AsyncPostgresClient):
 
 
 async def test_concurrent_queries(client: AsyncPostgresClient):
-    """Test 13: Concurrent Query Execution"""
+    """Test 13: Concurrent Query Execution
+
+    Validates: (additional coverage)
+    """
     try:
         start = time.time()
 
@@ -285,7 +347,10 @@ async def test_concurrent_queries(client: AsyncPostgresClient):
 
 
 async def test_query_many_concurrent(client: AsyncPostgresClient):
-    """Test 14: query_many_concurrent Helper"""
+    """Test 14: query_many_concurrent Helper
+
+    Validates: (additional coverage)
+    """
     try:
         queries = [
             {'sql': "SELECT 1 as num"},
@@ -307,7 +372,10 @@ async def test_query_many_concurrent(client: AsyncPostgresClient):
 
 
 async def test_get_stats(client: AsyncPostgresClient):
-    """Test 15: Get Statistics"""
+    """Test 15: Get Statistics
+
+    Validates: (additional coverage)
+    """
     try:
         stats = await client.get_stats()
         if stats is None:

--- a/isA_common/tests/qdrant/test_async_qdrant.py
+++ b/isA_common/tests/qdrant/test_async_qdrant.py
@@ -26,6 +26,32 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 from isa_common import AsyncQdrantClient
 
+# ============================================
+# Contract Mapping — see tests/contracts/qdrant/logic_contract.md
+# ============================================
+CONTRACT_MAP = {
+    'test_health_check':              [],
+    'test_create_collection':         ['BR-002'],
+    'test_list_collections':          [],
+    'test_get_collection_info':       [],
+    'test_upsert_points':            ['BR-003', 'BR-006', 'EC-008'],
+    'test_count_points':              [],
+    'test_search':                    ['BR-004'],
+    'test_search_with_filter':        ['BR-005'],
+    'test_search_with_score_threshold':[],
+    'test_scroll':                    [],
+    'test_recommend':                 [],
+    'test_update_payload':            ['BR-007'],
+    'test_delete_payload_fields':     [],
+    'test_create_field_index':        [],
+    'test_delete_points':             ['BR-006'],
+    'test_concurrent_searches':       [],
+    'test_concurrent_upserts':        [],
+    'test_delete_collection':         [],
+}
+
+UNCOVERED_CONTRACTS = ['BR-001', 'BR-008', 'EC-001', 'EC-002', 'EC-003', 'EC-004', 'EC-005', 'EC-006', 'EC-007', 'ER-001']
+
 # Configuration
 HOST = os.environ.get('HOST', 'localhost')
 PORT = int(os.environ.get('PORT', '6333'))
@@ -58,7 +84,10 @@ def test_result(success: bool, test_name: str):
 
 
 async def test_health_check(client: AsyncQdrantClient) -> bool:
-    """Test 1: Service Health Check"""
+    """Test 1: Service Health Check
+
+    Validates: (additional coverage)
+    """
     try:
         health = await client.health_check()
         success = health is not None and health.get('healthy', False)
@@ -70,7 +99,10 @@ async def test_health_check(client: AsyncQdrantClient) -> bool:
 
 
 async def test_create_collection(client: AsyncQdrantClient, collection_name: str):
-    """Test 2: Create Collection"""
+    """Test 2: Create Collection
+
+    Validates: BR-002 (Collection Configuration)
+    """
     try:
         result = await client.create_collection(
             collection_name=collection_name,
@@ -83,7 +115,10 @@ async def test_create_collection(client: AsyncQdrantClient, collection_name: str
 
 
 async def test_list_collections(client: AsyncQdrantClient):
-    """Test 3: List Collections"""
+    """Test 3: List Collections
+
+    Validates: (additional coverage)
+    """
     try:
         collections = await client.list_collections()
         success = isinstance(collections, list)
@@ -93,7 +128,10 @@ async def test_list_collections(client: AsyncQdrantClient):
 
 
 async def test_get_collection_info(client: AsyncQdrantClient, collection_name: str):
-    """Test 4: Get Collection Info"""
+    """Test 4: Get Collection Info
+
+    Validates: (additional coverage)
+    """
     try:
         info = await client.get_collection_info(collection_name)
         success = info is not None
@@ -103,7 +141,11 @@ async def test_get_collection_info(client: AsyncQdrantClient, collection_name: s
 
 
 async def test_upsert_points(client: AsyncQdrantClient, collection_name: str):
-    """Test 5: Upsert Points"""
+    """Test 5: Upsert Points
+
+    Validates: BR-003 (Vector Upsert with Payload), BR-006 (Batch Operations),
+               EC-008 (Vector ID Conflict in Batch)
+    """
     try:
         # Note: IDs start from 1 because the Go server has a bug where ID 0
         # is treated as empty string (if id.GetNum() > 0 check fails for 0)
@@ -129,7 +171,10 @@ async def test_upsert_points(client: AsyncQdrantClient, collection_name: str):
 
 
 async def test_count_points(client: AsyncQdrantClient, collection_name: str):
-    """Test 6: Count Points"""
+    """Test 6: Count Points
+
+    Validates: (additional coverage)
+    """
     try:
         count = await client.count_points(collection_name)
         success = count is not None and count >= 0
@@ -139,7 +184,10 @@ async def test_count_points(client: AsyncQdrantClient, collection_name: str):
 
 
 async def test_search(client: AsyncQdrantClient, collection_name: str):
-    """Test 7: Vector Search"""
+    """Test 7: Vector Search
+
+    Validates: BR-004 (Similarity Search)
+    """
     try:
         query_vector = generate_vector()
         results = await client.search(
@@ -155,7 +203,10 @@ async def test_search(client: AsyncQdrantClient, collection_name: str):
 
 
 async def test_search_with_filter(client: AsyncQdrantClient, collection_name: str):
-    """Test 8: Search with Filter"""
+    """Test 8: Search with Filter
+
+    Validates: BR-005 (Payload Filtering)
+    """
     try:
         query_vector = generate_vector()
         filter_conditions = {
@@ -176,7 +227,10 @@ async def test_search_with_filter(client: AsyncQdrantClient, collection_name: st
 
 
 async def test_search_with_score_threshold(client: AsyncQdrantClient, collection_name: str):
-    """Test 9: Search with Score Threshold"""
+    """Test 9: Search with Score Threshold
+
+    Validates: (additional coverage)
+    """
     try:
         query_vector = generate_vector()
         results = await client.search(
@@ -192,7 +246,10 @@ async def test_search_with_score_threshold(client: AsyncQdrantClient, collection
 
 
 async def test_scroll(client: AsyncQdrantClient, collection_name: str):
-    """Test 10: Scroll Points"""
+    """Test 10: Scroll Points
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.scroll(
             collection_name=collection_name,
@@ -206,7 +263,10 @@ async def test_scroll(client: AsyncQdrantClient, collection_name: str):
 
 
 async def test_recommend(client: AsyncQdrantClient, collection_name: str):
-    """Test 11: Recommendation Search"""
+    """Test 11: Recommendation Search
+
+    Validates: (additional coverage)
+    """
     try:
         results = await client.recommend(
             collection_name=collection_name,
@@ -221,7 +281,10 @@ async def test_recommend(client: AsyncQdrantClient, collection_name: str):
 
 
 async def test_update_payload(client: AsyncQdrantClient, collection_name: str):
-    """Test 12: Update Payload"""
+    """Test 12: Update Payload
+
+    Validates: BR-007 (Point Retrieval by ID)
+    """
     try:
         result = await client.update_payload(
             collection_name=collection_name,
@@ -235,7 +298,10 @@ async def test_update_payload(client: AsyncQdrantClient, collection_name: str):
 
 
 async def test_delete_payload_fields(client: AsyncQdrantClient, collection_name: str):
-    """Test 13: Delete Payload Fields"""
+    """Test 13: Delete Payload Fields
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.delete_payload_fields(
             collection_name=collection_name,
@@ -249,7 +315,10 @@ async def test_delete_payload_fields(client: AsyncQdrantClient, collection_name:
 
 
 async def test_create_field_index(client: AsyncQdrantClient, collection_name: str):
-    """Test 14: Create Field Index"""
+    """Test 14: Create Field Index
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.create_field_index(
             collection_name=collection_name,
@@ -263,7 +332,10 @@ async def test_create_field_index(client: AsyncQdrantClient, collection_name: st
 
 
 async def test_delete_points(client: AsyncQdrantClient, collection_name: str):
-    """Test 15: Delete Points"""
+    """Test 15: Delete Points
+
+    Validates: BR-006 (Batch Operations)
+    """
     try:
         result = await client.delete_points(collection_name, ids=[18, 19])
         success = result is not None
@@ -273,7 +345,10 @@ async def test_delete_points(client: AsyncQdrantClient, collection_name: str):
 
 
 async def test_concurrent_searches(client: AsyncQdrantClient, collection_name: str):
-    """Test 16: Concurrent Searches"""
+    """Test 16: Concurrent Searches
+
+    Validates: (additional coverage)
+    """
     try:
         vectors = [generate_vector() for _ in range(10)]
 
@@ -293,7 +368,10 @@ async def test_concurrent_searches(client: AsyncQdrantClient, collection_name: s
 
 
 async def test_concurrent_upserts(client: AsyncQdrantClient, collection_name: str):
-    """Test 17: Concurrent Upserts"""
+    """Test 17: Concurrent Upserts
+
+    Validates: (additional coverage)
+    """
     try:
         batches = [
             [{'id': 100 + i * 5 + j, 'vector': generate_vector(), 'payload': {'batch': i}}
@@ -313,7 +391,10 @@ async def test_concurrent_upserts(client: AsyncQdrantClient, collection_name: st
 
 
 async def test_delete_collection(client: AsyncQdrantClient, collection_name: str):
-    """Test 18: Delete Collection"""
+    """Test 18: Delete Collection
+
+    Validates: (additional coverage)
+    """
     try:
         result = await client.delete_collection(collection_name)
         test_result(result is True, f"Delete collection '{collection_name}'")

--- a/isA_common/tests/redis/test_async_redis.py
+++ b/isA_common/tests/redis/test_async_redis.py
@@ -32,6 +32,32 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from isa_common import AsyncRedisClient, BatchedRedisGet, BatchedRedisSet
 
+# ============================================
+# Contract Mapping — see tests/contracts/redis/logic_contract.md
+# ============================================
+CONTRACT_MAP = {
+    'test_health_check':          [],
+    'test_string_operations':     ['BR-001', 'BR-003', 'EC-003', 'EC-004'],
+    'test_ttl_expiration':        ['BR-002'],
+    'test_batch_operations':      [],
+    'test_counter_operations':    [],
+    'test_hash_operations':       ['BR-005'],
+    'test_list_operations':       [],
+    'test_set_operations':        [],
+    'test_sorted_set_operations': [],
+    'test_lock_operations':       [],
+    'test_pubsub_publish':        [],
+    'test_session_management':    [],
+    'test_concurrent_operations': ['EC-007'],
+    'test_get_many_concurrent':   ['EC-007'],
+    'test_auto_batching_get':     [],
+    'test_auto_batching_set':     [],
+    'test_execute_batch':         [],
+    'test_statistics':            [],
+}
+
+UNCOVERED_CONTRACTS = ['BR-004', 'EC-001', 'EC-002', 'EC-005', 'EC-006', 'ER-001', 'ER-002']
+
 # Configuration
 HOST = os.environ.get('HOST', 'localhost')
 PORT = int(os.environ.get('PORT', '6379'))
@@ -56,7 +82,10 @@ def test_result(success: bool, test_name: str):
 
 
 async def test_health_check(client: AsyncRedisClient) -> bool:
-    """Test 1: Service Health Check"""
+    """Test 1: Service Health Check
+
+    Validates: (additional coverage)
+    """
     try:
         health = await client.health_check()
         success = health is not None and health.get('healthy', False)
@@ -68,7 +97,11 @@ async def test_health_check(client: AsyncRedisClient) -> bool:
 
 
 async def test_string_operations(client: AsyncRedisClient):
-    """Test 2: String SET/GET/DELETE Operations"""
+    """Test 2: String SET/GET/DELETE Operations
+
+    Validates: BR-001 (Multi-Tenant Key Isolation), BR-003 (User Authentication),
+               EC-003 (Empty Value), EC-004 (Non-Existent Key)
+    """
     try:
         # SET
         success = await client.set('async:test:key1', 'value1')
@@ -106,7 +139,10 @@ async def test_string_operations(client: AsyncRedisClient):
 
 
 async def test_ttl_expiration(client: AsyncRedisClient):
-    """Test 3: TTL and Expiration"""
+    """Test 3: TTL and Expiration
+
+    Validates: BR-002 (TTL Expiration)
+    """
     try:
         # Set with TTL
         await client.set_with_ttl('async:test:expire', 'temp_value', 2)
@@ -132,7 +168,10 @@ async def test_ttl_expiration(client: AsyncRedisClient):
 
 
 async def test_batch_operations(client: AsyncRedisClient):
-    """Test 4: Batch MSET/MGET Operations (using ExecuteBatch)"""
+    """Test 4: Batch MSET/MGET Operations (using ExecuteBatch)
+
+    Validates: (additional coverage)
+    """
     try:
         # MSET - now uses single ExecuteBatch RPC
         data = {
@@ -157,7 +196,10 @@ async def test_batch_operations(client: AsyncRedisClient):
 
 
 async def test_counter_operations(client: AsyncRedisClient):
-    """Test 5: INCR/DECR Counter Operations"""
+    """Test 5: INCR/DECR Counter Operations
+
+    Validates: (additional coverage)
+    """
     try:
         # Clean up first
         await client.delete('async:test:counter')
@@ -186,7 +228,10 @@ async def test_counter_operations(client: AsyncRedisClient):
 
 
 async def test_hash_operations(client: AsyncRedisClient):
-    """Test 6: Hash Operations"""
+    """Test 6: Hash Operations
+
+    Validates: BR-005 (Hash Field Operations)
+    """
     try:
         # HSET
         success = await client.hset('async:test:hash', 'field1', 'value1')
@@ -226,7 +271,10 @@ async def test_hash_operations(client: AsyncRedisClient):
 
 
 async def test_list_operations(client: AsyncRedisClient):
-    """Test 7: List Operations"""
+    """Test 7: List Operations
+
+    Validates: (additional coverage)
+    """
     try:
         # Clean up
         await client.delete('async:test:list')
@@ -273,7 +321,10 @@ async def test_list_operations(client: AsyncRedisClient):
 
 
 async def test_set_operations(client: AsyncRedisClient):
-    """Test 8: Set Operations"""
+    """Test 8: Set Operations
+
+    Validates: (additional coverage)
+    """
     try:
         # Clean up
         await client.delete('async:test:set1')
@@ -311,7 +362,10 @@ async def test_set_operations(client: AsyncRedisClient):
 
 
 async def test_sorted_set_operations(client: AsyncRedisClient):
-    """Test 9: Sorted Set Operations"""
+    """Test 9: Sorted Set Operations
+
+    Validates: (additional coverage)
+    """
     try:
         # Clean up
         await client.delete('async:test:zset')
@@ -352,7 +406,10 @@ async def test_sorted_set_operations(client: AsyncRedisClient):
 
 
 async def test_lock_operations(client: AsyncRedisClient):
-    """Test 10: Distributed Lock Operations"""
+    """Test 10: Distributed Lock Operations
+
+    Validates: (additional coverage)
+    """
     try:
         # Acquire lock
         lock_id = await client.acquire_lock('async:test:lock', ttl_seconds=10)
@@ -385,7 +442,10 @@ async def test_lock_operations(client: AsyncRedisClient):
 
 
 async def test_pubsub_publish(client: AsyncRedisClient):
-    """Test 11: Pub/Sub Publish"""
+    """Test 11: Pub/Sub Publish
+
+    Validates: (additional coverage)
+    """
     try:
         # Publish (subscribers count may be 0)
         count = await client.publish('async:test:channel', 'Hello World')
@@ -399,7 +459,10 @@ async def test_pubsub_publish(client: AsyncRedisClient):
 
 
 async def test_session_management(client: AsyncRedisClient):
-    """Test 12: Session Management"""
+    """Test 12: Session Management
+
+    Validates: (additional coverage)
+    """
     try:
         # Create session
         session_id = await client.create_session({'user': 'john', 'role': 'admin'}, ttl_seconds=3600)
@@ -418,7 +481,10 @@ async def test_session_management(client: AsyncRedisClient):
 
 
 async def test_concurrent_operations(client: AsyncRedisClient):
-    """Test 13: Concurrent Operations with asyncio.gather"""
+    """Test 13: Concurrent Operations with asyncio.gather
+
+    Validates: EC-007 (Concurrent Updates)
+    """
     try:
         # Setup keys
         await client.mset({
@@ -452,7 +518,10 @@ async def test_concurrent_operations(client: AsyncRedisClient):
 
 
 async def test_get_many_concurrent(client: AsyncRedisClient):
-    """Test 14: get_many_concurrent helper"""
+    """Test 14: get_many_concurrent helper
+
+    Validates: EC-007 (Concurrent Updates)
+    """
     try:
         # Setup keys
         await client.mset({
@@ -482,7 +551,10 @@ async def test_get_many_concurrent(client: AsyncRedisClient):
 
 
 async def test_auto_batching_get(client: AsyncRedisClient):
-    """Test 15: Auto-batching with BatchedRedisGet"""
+    """Test 15: Auto-batching with BatchedRedisGet
+
+    Validates: (additional coverage)
+    """
     try:
         # Setup keys
         await client.mset({
@@ -517,7 +589,10 @@ async def test_auto_batching_get(client: AsyncRedisClient):
 
 
 async def test_auto_batching_set(client: AsyncRedisClient):
-    """Test 16: Auto-batching with BatchedRedisSet"""
+    """Test 16: Auto-batching with BatchedRedisSet
+
+    Validates: (additional coverage)
+    """
     try:
         # Create batched setter
         batched_set = BatchedRedisSet(client, max_size=100, max_wait_ms=10)
@@ -543,7 +618,10 @@ async def test_auto_batching_set(client: AsyncRedisClient):
 
 
 async def test_execute_batch(client: AsyncRedisClient):
-    """Test 17: Execute Batch Commands"""
+    """Test 17: Execute Batch Commands
+
+    Validates: (additional coverage)
+    """
     try:
         commands = [
             {'operation': 'SET', 'key': 'async:test:batch_exec1', 'value': 'val1'},
@@ -567,7 +645,10 @@ async def test_execute_batch(client: AsyncRedisClient):
 
 
 async def test_statistics(client: AsyncRedisClient):
-    """Test 18: Get Statistics"""
+    """Test 18: Get Statistics
+
+    Validates: (additional coverage)
+    """
     try:
         stats = await client.get_statistics()
         if not stats or 'total_keys' not in stats:

--- a/tests/contract_coverage.md
+++ b/tests/contract_coverage.md
@@ -1,0 +1,202 @@
+# Contract Coverage Report
+
+> Auto-generated mapping of logic contract IDs to test functions.
+> See `tests/contracts/{service}/logic_contract.md` for full contract definitions.
+> See `isA_common/tests/{service}/test_async_{service}.py` for test implementations.
+
+## Summary
+
+| Service    | BR Covered | BR Total | EC Covered | EC Total | ER Covered | ER Total | Coverage |
+|------------|-----------|----------|-----------|----------|-----------|----------|----------|
+| Redis      | 4/5       | 80%      | 2/7       | 29%      | 0/2       | 0%       | **43%**  |
+| PostgreSQL | 3/6       | 50%      | 1/7       | 14%      | 0/1       | 0%       | **29%**  |
+| Neo4j      | 4/7       | 57%      | 0/8       | 0%       | 0/1       | 0%       | **25%**  |
+| NATS       | 5/6       | 83%      | 0/8       | 0%       | 0/1       | 0%       | **33%**  |
+| MQTT       | 3/7       | 43%      | 0/7       | 0%       | 0/1       | 0%       | **20%**  |
+| MinIO      | 3/7       | 43%      | 1/8       | 13%      | 0/1       | 0%       | **25%**  |
+| Qdrant     | 5/8       | 63%      | 1/8       | 13%      | 0/1       | 0%       | **35%**  |
+| DuckDB     | 2/8       | 25%      | 0/9       | 0%       | 0/1       | 0%       | **11%**  |
+| **Total**  | **29/54** | **54%**  | **5/62**  | **8%**   | **0/9**   | **0%**   | **27%**  |
+
+## Detailed Mapping
+
+### Redis
+
+| Contract ID | Description | Test Function(s) | Status |
+|------------|-------------|------------------|--------|
+| BR-001 | Multi-Tenant Key Isolation | `test_string_operations` | Covered |
+| BR-002 | TTL Expiration | `test_ttl_expiration` | Covered |
+| BR-003 | User Authentication | `test_string_operations` | Covered |
+| BR-004 | Audit Logging | — | Missing |
+| BR-005 | Hash Field Operations | `test_hash_operations` | Covered |
+| EC-001 | Empty Key | — | Missing |
+| EC-002 | Key Too Long | — | Missing |
+| EC-003 | Empty Value | `test_string_operations` | Covered |
+| EC-004 | Non-Existent Key | `test_string_operations` | Covered |
+| EC-005 | Negative TTL | — | Missing |
+| EC-006 | Redis Connection Failure | — | Missing |
+| EC-007 | Concurrent Updates | `test_concurrent_operations`, `test_get_many_concurrent` | Covered |
+| ER-001 | Error Response Format | — | Missing |
+| ER-002 | Error Logging | — | Missing |
+
+### PostgreSQL
+
+| Contract ID | Description | Test Function(s) | Status |
+|------------|-------------|------------------|--------|
+| BR-001 | Query Execution with Parameter Binding | `test_query_with_params` | Covered |
+| BR-002 | Multi-Tenant Data Isolation | — | Missing |
+| BR-003 | Query Result Formatting | `test_simple_query`, `test_query_row`, `test_select_from_table` | Covered |
+| BR-004 | Affected Rows for Mutations | `test_execute_insert`, `test_execute_update`, `test_execute_delete` | Covered |
+| BR-005 | Transaction Support | — | Missing |
+| BR-006 | Audit Logging | — | Missing |
+| EC-001 | Empty Query | — | Missing |
+| EC-002 | Syntax Error in Query | — | Missing |
+| EC-003 | Query Timeout | — | Missing |
+| EC-004 | Connection Pool Exhausted | — | Missing |
+| EC-005 | Table Does Not Exist | `test_table_exists`, `test_select_from_table` | Covered |
+| EC-006 | Permission Denied on Table | — | Missing |
+| EC-007 | Large Result Set | — | Missing |
+| ER-001 | Error Response Mapping | — | Missing |
+
+### Neo4j
+
+| Contract ID | Description | Test Function(s) | Status |
+|------------|-------------|------------------|--------|
+| BR-001 | Multi-Tenant Graph Isolation | — | Missing |
+| BR-002 | Node Operations | `test_create_node`, `test_get_node`, `test_update_node`, `test_create_second_node`, `test_find_nodes`, `test_delete_node` | Covered |
+| BR-003 | Relationship Operations | `test_create_relationship`, `test_get_relationship`, `test_delete_relationship` | Covered |
+| BR-004 | Cypher Query Execution | `test_run_cypher`, `test_cypher_with_params` | Covered |
+| BR-005 | Graph Traversal | `test_get_path`, `test_shortest_path` | Covered |
+| BR-006 | Index and Constraint Support | — | Missing |
+| BR-007 | Audit Logging | — | Missing |
+| EC-001 | Empty Query | — | Missing |
+| EC-002 | Syntax Error in Cypher | — | Missing |
+| EC-003 | Node Not Found | — | Missing |
+| EC-004 | Relationship Node Not Found | — | Missing |
+| EC-005 | Unique Constraint Violation | — | Missing |
+| EC-006 | Query Timeout | — | Missing |
+| EC-007 | Neo4j Unavailable | — | Missing |
+| EC-008 | Invalid Label Name | — | Missing |
+| ER-001 | Error Response Mapping | — | Missing |
+
+### NATS
+
+| Contract ID | Description | Test Function(s) | Status |
+|------------|-------------|------------------|--------|
+| BR-001 | Subject-Based Publish/Subscribe | `test_publish`, `test_publish_with_headers` | Covered |
+| BR-002 | Multi-Tenant Subject Isolation | — | Missing |
+| BR-003 | JetStream Persistence | `test_create_stream`, `test_publish_to_stream` | Covered |
+| BR-004 | Consumer Acknowledgment | `test_create_consumer`, `test_pull_messages` | Covered |
+| BR-005 | Key-Value Store | `test_kv_operations` | Covered |
+| BR-006 | Request-Reply Pattern | `test_request_reply` | Covered |
+| EC-001 | Empty Subject | — | Missing |
+| EC-002 | Invalid Subject Characters | — | Missing |
+| EC-003 | Message Too Large | — | Missing |
+| EC-004 | Stream Does Not Exist | — | Missing |
+| EC-005 | Consumer Does Not Exist | — | Missing |
+| EC-006 | KV Bucket Does Not Exist | — | Missing |
+| EC-007 | Duplicate Durable Consumer | — | Missing |
+| EC-008 | NATS Unavailable | — | Missing |
+| ER-001 | Error Response Mapping | — | Missing |
+
+### MQTT
+
+| Contract ID | Description | Test Function(s) | Status |
+|------------|-------------|------------------|--------|
+| BR-001 | Multi-Tenant Topic Isolation | — | Missing |
+| BR-002 | Topic Wildcards | — | Missing |
+| BR-003 | Quality of Service (QoS) | `test_publish`, `test_publish_batch` | Covered |
+| BR-004 | Retained Messages | `test_set_retained_message`, `test_get_retained_message`, `test_delete_retained_message` | Covered |
+| BR-005 | Last Will and Testament (LWT) | — | Missing |
+| BR-006 | Message Payload | `test_publish`, `test_publish_json` | Covered |
+| BR-007 | Audit Logging | — | Missing |
+| EC-001 | Empty Topic | — | Missing |
+| EC-002 | Invalid Topic Characters | — | Missing |
+| EC-003 | Topic Too Long | — | Missing |
+| EC-004 | Invalid QoS Level | — | Missing |
+| EC-005 | Wildcard in Publish Topic | — | Missing |
+| EC-006 | Broker Unavailable | — | Missing |
+| EC-007 | Connection Timeout | — | Missing |
+| ER-001 | Error Response Mapping | — | Missing |
+
+### MinIO
+
+| Contract ID | Description | Test Function(s) | Status |
+|------------|-------------|------------------|--------|
+| BR-001 | Multi-Tenant Bucket Isolation | — | Missing |
+| BR-002 | Object Key Namespacing | — | Missing |
+| BR-003 | Presigned URL Generation | `test_presigned_url`, `test_presigned_put_url` | Covered |
+| BR-004 | Object Metadata | `test_upload_object`, `test_get_object_metadata` | Covered |
+| BR-005 | Object Listing with Pagination | `test_list_objects` | Covered |
+| BR-006 | Object Versioning | — | Missing |
+| BR-007 | Audit Logging | — | Missing |
+| EC-001 | Invalid Bucket Name | — | Missing |
+| EC-002 | Bucket Already Exists | `test_create_bucket` | Covered |
+| EC-003 | Bucket Not Empty | — | Missing |
+| EC-004 | Object Not Found | — | Missing |
+| EC-005 | Empty Object Key | — | Missing |
+| EC-006 | Object Too Large | — | Missing |
+| EC-007 | MinIO Unavailable | — | Missing |
+| EC-008 | Presigned URL Expired | — | Missing |
+| ER-001 | Error Response Mapping | — | Missing |
+
+### Qdrant
+
+| Contract ID | Description | Test Function(s) | Status |
+|------------|-------------|------------------|--------|
+| BR-001 | Multi-Tenant Collection Isolation | — | Missing |
+| BR-002 | Collection Configuration | `test_create_collection` | Covered |
+| BR-003 | Vector Upsert with Payload | `test_upsert_points` | Covered |
+| BR-004 | Similarity Search | `test_search` | Covered |
+| BR-005 | Payload Filtering | `test_search_with_filter` | Covered |
+| BR-006 | Batch Operations | `test_upsert_points`, `test_delete_points` | Covered |
+| BR-007 | Point Retrieval by ID | `test_update_payload` | Covered |
+| BR-008 | Audit Logging | — | Missing |
+| EC-001 | Invalid Vector Dimension | — | Missing |
+| EC-002 | Collection Does Not Exist | — | Missing |
+| EC-003 | Collection Already Exists | — | Missing |
+| EC-004 | Empty Query Vector | — | Missing |
+| EC-005 | Invalid Filter Syntax | — | Missing |
+| EC-006 | Top-K Too Large | — | Missing |
+| EC-007 | Qdrant Unavailable | — | Missing |
+| EC-008 | Vector ID Conflict in Batch | `test_upsert_points` | Covered |
+| ER-001 | Error Response Mapping | — | Missing |
+
+### DuckDB
+
+| Contract ID | Description | Test Function(s) | Status |
+|------------|-------------|------------------|--------|
+| BR-001 | Multi-Tenant Data Isolation | — | Missing |
+| BR-002 | OLAP Query Execution | `test_simple_query`, `test_query_with_params`, `test_query_data`, `test_aggregate_functions` | Covered |
+| BR-003 | Data Import from External Sources | — | Missing |
+| BR-004 | Data Export | `test_csv_export` | Covered |
+| BR-005 | Query Result Pagination | — | Missing |
+| BR-006 | Query Caching | — | Missing |
+| BR-007 | Temporary Tables | — | Missing |
+| BR-008 | Audit Logging | — | Missing |
+| EC-001 | Empty Query | — | Missing |
+| EC-002 | Syntax Error | — | Missing |
+| EC-003 | Table Not Found | — | Missing |
+| EC-004 | Query Timeout | — | Missing |
+| EC-005 | Memory Limit Exceeded | — | Missing |
+| EC-006 | Invalid File Format | — | Missing |
+| EC-007 | File Not Found | — | Missing |
+| EC-008 | DuckDB Unavailable | — | Missing |
+| EC-009 | Division by Zero | — | Missing |
+| ER-001 | Error Response Mapping | — | Missing |
+
+## Missing Scenarios for Future Work
+
+### High-Value Gaps (recommended next)
+
+1. **Multi-tenant isolation tests** (BR-001 across all services) — Critical for security
+2. **Error response format tests** (ER-001 across all services) — Validates API contract consistency
+3. **Connection failure handling** (EC-006/EC-007/EC-008) — Resilience testing
+4. **Audit logging verification** (BR-004/BR-007/BR-008) — Compliance
+
+### Edge Cases (lower priority)
+
+- Empty/invalid input handling (EC-001, EC-002 across services)
+- Resource limit testing (EC-003, EC-005, EC-006)
+- Timeout behavior (EC-003, EC-004, EC-006)
+- Concurrent write conflicts beyond Redis EC-007


### PR DESCRIPTION
## Summary
- Map all CDD contract IDs (BR/EC/ER) to test functions across 8 service test files with `CONTRACT_MAP` dicts, `UNCOVERED_CONTRACTS` lists, and `Validates:` docstring annotations (137 test functions annotated)
- Create `tests/contract_coverage.md` with full coverage report — 27% overall (29/54 BR, 5/62 EC, 0/9 ER covered)
- Export 4 local-mode clients (`AsyncSQLiteClient`, `AsyncLocalStorageClient`, `AsyncChromaClient`, `AsyncMemoryClient`) from `isa_common` package `__init__.py`
- Rewrite `isA_common/README.md` to document infrastructure vs local-mode client usage

## Test plan
- [ ] Verify `from isa_common import AsyncSQLiteClient, AsyncLocalStorageClient, AsyncChromaClient, AsyncMemoryClient` works
- [ ] Verify existing `from isa_common import AsyncRedisClient` etc. still works
- [ ] Spot-check CONTRACT_MAP entries match actual docstring annotations
- [ ] Review contract_coverage.md for accuracy against logic_contract.md files

Fixes #35
Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)