### PR TITLE
feat(infra): add Grafana MCP service dashboard with RED metrics

### DIFF
--- a/configs/local/grafana/dashboards/isa-mcp-service.json
+++ b/configs/local/grafana/dashboards/isa-mcp-service.json
@@ -58,7 +58,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "sum(rate(mcp_requests_total{status_code=~\"5..\", environment=~\"$environment\", instance=~\"$instance\"}[5m])) / sum(rate(mcp_requests_total{environment=~\"$environment\", instance=~\"$instance\"}[5m]))",
+          "expr": "sum(rate(mcp_requests_total{status_code=~\"5..\", environment=~\"$environment\", instance=~\"$instance\"}[5m])) / (sum(rate(mcp_requests_total{environment=~\"$environment\", instance=~\"$instance\"}[5m])) > 0)",
           "legendFormat": "Error Rate",
           "refId": "A"
         }
@@ -251,7 +251,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "sum(mcp_cache_hits_total{environment=~\"$environment\", instance=~\"$instance\"}) / (sum(mcp_cache_hits_total{environment=~\"$environment\", instance=~\"$instance\"}) + sum(mcp_cache_misses_total{environment=~\"$environment\", instance=~\"$instance\"}))",
+          "expr": "sum(rate(mcp_cache_hits_total{environment=~\"$environment\", instance=~\"$instance\"}[5m])) / (sum(rate(mcp_cache_hits_total{environment=~\"$environment\", instance=~\"$instance\"}[5m])) + sum(rate(mcp_cache_misses_total{environment=~\"$environment\", instance=~\"$instance\"}[5m])))",
           "legendFormat": "Hit Ratio",
           "refId": "A"
         }

--- a/deployments/kubernetes/local/manifests/grafana-dashboards.yaml
+++ b/deployments/kubernetes/local/manifests/grafana-dashboards.yaml
@@ -123,7 +123,7 @@ data:
           "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
           "id": 2,
           "fieldConfig": {"defaults": {"unit": "percentunit", "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.01}, {"color": "red", "value": 0.05}]}}, "overrides": []},
-          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "sum(rate(mcp_requests_total{status_code=~\"5..\", environment=~\"$environment\", instance=~\"$instance\"}[5m])) / sum(rate(mcp_requests_total{environment=~\"$environment\", instance=~\"$instance\"}[5m]))", "legendFormat": "Error Rate", "refId": "A"}]
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "sum(rate(mcp_requests_total{status_code=~\"5..\", environment=~\"$environment\", instance=~\"$instance\"}[5m])) / (sum(rate(mcp_requests_total{environment=~\"$environment\", instance=~\"$instance\"}[5m])) > 0)", "legendFormat": "Error Rate", "refId": "A"}]
         },
         {
           "title": "Request Latency (P50 / P95 / P99)",
@@ -191,7 +191,7 @@ data:
           "gridPos": {"h": 8, "w": 8, "x": 8, "y": 24},
           "id": 8,
           "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1, "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 2}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "yellow", "value": 0.5}, {"color": "green", "value": 0.8}]}}, "overrides": []},
-          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "sum(mcp_cache_hits_total{environment=~\"$environment\", instance=~\"$instance\"}) / (sum(mcp_cache_hits_total{environment=~\"$environment\", instance=~\"$instance\"}) + sum(mcp_cache_misses_total{environment=~\"$environment\", instance=~\"$instance\"}))", "legendFormat": "Hit Ratio", "refId": "A"}]
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "editorMode": "code", "expr": "sum(rate(mcp_cache_hits_total{environment=~\"$environment\", instance=~\"$instance\"}[5m])) / (sum(rate(mcp_cache_hits_total{environment=~\"$environment\", instance=~\"$instance\"}[5m])) + sum(rate(mcp_cache_misses_total{environment=~\"$environment\", instance=~\"$instance\"}[5m])))", "legendFormat": "Hit Ratio", "refId": "A"}]
         },
         {
           "title": "Active Background Shells",


### PR DESCRIPTION
## Summary
Creates a new Grafana dashboard (`isa-mcp-service`) with 10 panels covering RED metrics (Rate, Errors, Duration) for the isA MCP service, with drill-down links to Tempo traces.

## Changes
- New `configs/local/grafana/dashboards/isa-mcp-service.json` — standalone dashboard for docker-compose provisioning
- Extended `deployments/kubernetes/local/manifests/grafana-dashboards.yaml` ConfigMap with `isa-mcp-service.json` for Kind auto-provisioning

### Dashboard Panels (10)
| # | Panel | Type | Datasource |
|---|-------|------|------------|
| 1 | Request Rate by Endpoint | timeseries | Prometheus |
| 2 | Error Rate (%) | timeseries | Prometheus |
| 3 | Request Latency P50/P95/P99 | timeseries | Prometheus |
| 4 | Tool Execution Duration by Tool | timeseries | Prometheus |
| 5 | Top 10 Slowest Tools | table | Prometheus |
| 6 | Circuit Breaker State by Service | state-timeline | Prometheus |
| 7 | Rate Limit Hits | timeseries (bar) | Prometheus |
| 8 | Cache Hit/Miss Ratio | timeseries | Prometheus |
| 9 | Active Background Shells | gauge | Prometheus |
| 10 | Active Connections | gauge | Prometheus |

### Features
- Template variables: `environment`, `instance` (multi-select, all by default)
- Trace links on latency panel → Tempo explore view
- Color thresholds on error rate and cache hit ratio
- Value mappings on circuit breaker state (CLOSED/OPEN/HALF-OPEN)

## Testing
- YAML and JSON validated programmatically (yaml.safe_load + json.loads)
- ConfigMap structure verified: both dashboards parse with correct panel counts and UIDs

## Related Issues
Fixes #49
**Parent Epic**: xenoISA/isA_MCP#74