### PR TITLE
fix(events): restore nats_client compatibility and await async NATS APIs

### DIFF
--- a/isA_common/isa_common/events/base_event_publisher.py
+++ b/isA_common/isa_common/events/base_event_publisher.py
@@ -8,6 +8,7 @@ Generic event publisher that can be extended for business-specific needs.
 
 import json
 import logging
+import asyncio
 from typing import Optional, Dict, Any, TYPE_CHECKING
 from abc import ABC, abstractmethod
 
@@ -103,14 +104,18 @@ class BaseEventPublisher(ABC):
     def close(self):
         """Close NATS connection"""
         if hasattr(self.nats_client, 'close'):
-            self.nats_client.close()
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self.nats_client.close())
+            except RuntimeError:
+                asyncio.run(self.nats_client.close())
 
     async def aclose(self):
         """Async close NATS connection"""
         if hasattr(self.nats_client, 'aclose'):
             await self.nats_client.aclose()
         elif hasattr(self.nats_client, 'close'):
-            self.nats_client.close()
+            await self.nats_client.close()
 
     def _serialize_event(self, event: BaseEvent) -> bytes:
         """
@@ -157,7 +162,7 @@ class BaseEventPublisher(ABC):
             headers['event_type'] = event.event_type
 
             # Publish to NATS
-            result = self.nats_client.publish(
+            result = await self.nats_client.publish(
                 subject=subject,
                 data=data,
                 headers=headers
@@ -200,7 +205,7 @@ class BaseEventPublisher(ABC):
             True if published successfully
         """
         try:
-            result = self.nats_client.publish(
+            result = await self.nats_client.publish(
                 subject=subject,
                 data=data,
                 headers=headers

--- a/isA_common/isa_common/events/base_event_subscriber.py
+++ b/isA_common/isa_common/events/base_event_subscriber.py
@@ -252,7 +252,7 @@ class BaseEventSubscriber:
 
             logger.info(f"[{self.service_name}] Creating stream {stream_name} with subjects: {stream_subjects}")
 
-            stream_result = self.nats_client.create_stream(
+            stream_result = await self.nats_client.create_stream(
                 name=stream_name,
                 subjects=stream_subjects
             )
@@ -267,7 +267,7 @@ class BaseEventSubscriber:
 
         # Create JetStream consumer
         try:
-            result = self.nats_client.create_consumer(
+            result = await self.nats_client.create_consumer(
                 stream_name=stream_name,
                 consumer_name=consumer_name,
                 filter_subject=subject
@@ -367,7 +367,7 @@ class BaseEventSubscriber:
         while True:
             try:
                 # Pull batch of messages (non-blocking)
-                messages = self.nats_client.pull_messages(
+                messages = await self.nats_client.pull_messages(
                     stream_name=stream_name,
                     consumer_name=consumer_name,
                     batch_size=10
@@ -383,7 +383,7 @@ class BaseEventSubscriber:
 
                         # Acknowledge if processed successfully
                         if success:
-                            self.nats_client.ack_message(
+                            await self.nats_client.ack_message(
                                 stream_name=stream_name,
                                 consumer_name=consumer_name,
                                 sequence=msg['sequence']
@@ -609,7 +609,7 @@ class BaseEventSubscriber:
             dlq_bytes = json.dumps(dlq_data).encode('utf-8')
 
             # Publish to DLQ
-            self.nats_client.publish(dlq_subject, dlq_bytes)
+            await self.nats_client.publish(dlq_subject, dlq_bytes)
 
             logger.warning(
                 f"[{self.service_name}] Moved event to DLQ: {dlq_subject}"

--- a/isA_common/isa_common/events/billing_event_publisher.py
+++ b/isA_common/isa_common/events/billing_event_publisher.py
@@ -8,6 +8,7 @@ Provides helper functions to publish billing events to NATS message bus.
 
 import json
 import logging
+import asyncio
 from typing import Optional, Dict, Any, TYPE_CHECKING
 from decimal import Decimal
 from datetime import datetime
@@ -96,14 +97,18 @@ class BillingEventPublisher:
     def close(self):
         """Close NATS connection"""
         if hasattr(self.nats_client, 'close'):
-            self.nats_client.close()
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self.nats_client.close())
+            except RuntimeError:
+                asyncio.run(self.nats_client.close())
 
     async def aclose(self):
         """Async close NATS connection"""
         if hasattr(self.nats_client, 'aclose'):
             await self.nats_client.aclose()
         elif hasattr(self.nats_client, 'close'):
-            self.nats_client.close()
+            await self.nats_client.close()
 
     def _serialize_event(self, event) -> bytes:
         """
@@ -178,7 +183,7 @@ class BillingEventPublisher:
             subject = get_nats_subject(event)
             data = self._serialize_event(event)
 
-            result = self.nats_client.publish(
+            result = await self.nats_client.publish(
                 subject=subject,
                 data=data,
                 headers={"event_type": "usage.recorded"}
@@ -249,7 +254,7 @@ class BillingEventPublisher:
             subject = get_nats_subject(event)
             data = self._serialize_event(event)
 
-            result = self.nats_client.publish(
+            result = await self.nats_client.publish(
                 subject=subject,
                 data=data,
                 headers={"event_type": "billing.calculated"}
@@ -311,7 +316,7 @@ class BillingEventPublisher:
             subject = get_nats_subject(event)
             data = self._serialize_event(event)
 
-            result = self.nats_client.publish(
+            result = await self.nats_client.publish(
                 subject=subject,
                 data=data,
                 headers={"event_type": "wallet.tokens.deducted"}
@@ -364,7 +369,7 @@ class BillingEventPublisher:
             subject = get_nats_subject(event)
             data = self._serialize_event(event)
 
-            result = self.nats_client.publish(
+            result = await self.nats_client.publish(
                 subject=subject,
                 data=data,
                 headers={"event_type": "wallet.tokens.insufficient"}
@@ -417,7 +422,7 @@ class BillingEventPublisher:
             subject = get_nats_subject(event)
             data = self._serialize_event(event)
 
-            result = self.nats_client.publish(
+            result = await self.nats_client.publish(
                 subject=subject,
                 data=data,
                 headers={"event_type": "billing.failed"}
@@ -442,7 +447,7 @@ async def publish_usage_event(
     usage_amount: Decimal,
     unit_type: str,
     nats_host: str = 'localhost',
-    nats_port: int = 50056,
+    nats_port: int = 4222,
     **kwargs
 ) -> bool:
     """

--- a/isA_common/isa_common/nats_client.py
+++ b/isA_common/isa_common/nats_client.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""
+Backward-compatible NATS client import.
+
+Historically, callers imported ``isa_common.nats_client.NATSClient``.
+The native implementation now lives in ``async_nats_client.AsyncNATSClient``.
+This shim preserves the old import path.
+"""
+
+from .async_nats_client import AsyncNATSClient
+
+
+class NATSClient(AsyncNATSClient):
+    """Compatibility alias for the async native NATS client."""
+
+    async def aclose(self) -> None:
+        """Compatibility alias for async close."""
+        await self.close()


### PR DESCRIPTION
## Summary
Restore `isa_common.events` compatibility and fix async NATS calls in event publisher/subscriber modules.

## What changed
- Add compatibility shim: `isa_common/nats_client.py` exposing `NATSClient` alias over `AsyncNATSClient`.
- Update event modules to correctly `await` async NATS methods:
  - `publish`, `create_stream`, `create_consumer`, `pull_messages`, `ack_message`.
- Make event publisher close paths async-safe.
- Align billing helper default NATS port from `50056` to native `4222`.

## Why
`isa_common.events` import/use in MCP degraded because `..nats_client` no longer existed, and existing event code called async NATS methods as sync functions.

## Validation
- `python -m py_compile` on changed event modules + shim
- MCP-side import check now succeeds:
  - `from isa_common.events import publish_usage_event`

## Related issues
- Related: xenoISA/isA_MCP#101
