### PR TITLE
fix(chart): add podAnnotations support to isa-service Helm chart

### DIFF
--- a/deployments/charts/isa-service/values.yaml
+++ b/deployments/charts/isa-service/values.yaml
@@ -97,6 +97,11 @@ service:
 consul:
   enabled: true
 
+# Custom pod annotations (e.g. Prometheus scrape config, Datadog, Vault)
+podAnnotations: {}
+# prometheus.io/scrape: "true"
+# prometheus.io/port: "8080"
+
 # Topology spread constraints (spread pods across nodes/zones)
 topologySpreadConstraints: []
 # - maxSkew: 1


### PR DESCRIPTION
## Summary

- Add `podAnnotations: {}` default to `values.yaml` so the deployment template renders correctly when consumers don't explicitly set podAnnotations
- The deployment template already supports merging custom podAnnotations with Consul annotations (added in a prior commit) but the values.yaml default was missing, which could cause Helm template failures

Fixes xenoISA/isA_Cloud#61

## Files Changed

| File | Change |
|------|--------|
| `deployments/charts/isa-service/values.yaml` | Add `podAnnotations: {}` default with example comments |

## Test plan

- [ ] `helm template` with no podAnnotations set (should render without error)
- [ ] `helm template` with custom podAnnotations (should merge with Consul annotations)
- [ ] CI security scan passes (qdrant-client CVE was fixed in prior main commits)

Generated with [Claude Code](https://claude.com/claude-code)