### PR TITLE
fix(infra): add port 8081 to network policies for MCP

### DIFF
--- a/deployments/kubernetes/local/manifests/network-policies.yaml
+++ b/deployments/kubernetes/local/manifests/network-policies.yaml
@@ -315,6 +315,8 @@ spec:
         - protocol: TCP
           port: 8080
         - protocol: TCP
+          port: 8081
+        - protocol: TCP
           port: 9090
         # gRPC ports range 50051-50063
         - protocol: TCP
@@ -471,6 +473,8 @@ spec:
           port: 443
         - protocol: TCP
           port: 8080
+        - protocol: TCP
+          port: 8081
         - protocol: TCP
           port: 9090
         - protocol: TCP

--- a/deployments/kubernetes/production/manifests/network-policies.yaml
+++ b/deployments/kubernetes/production/manifests/network-policies.yaml
@@ -315,6 +315,8 @@ spec:
         - protocol: TCP
           port: 8080
         - protocol: TCP
+          port: 8081
+        - protocol: TCP
           port: 9090
         # gRPC ports range 50051-50063
         - protocol: TCP
@@ -471,6 +473,8 @@ spec:
           port: 443
         - protocol: TCP
           port: 8080
+        - protocol: TCP
+          port: 8081
         - protocol: TCP
           port: 9090
         - protocol: TCP

--- a/deployments/kubernetes/staging/manifests/network-policies.yaml
+++ b/deployments/kubernetes/staging/manifests/network-policies.yaml
@@ -315,6 +315,8 @@ spec:
         - protocol: TCP
           port: 8080
         - protocol: TCP
+          port: 8081
+        - protocol: TCP
           port: 9090
         # gRPC ports range 50051-50063
         - protocol: TCP
@@ -471,6 +473,8 @@ spec:
           port: 443
         - protocol: TCP
           port: 8080
+        - protocol: TCP
+          port: 8081
         - protocol: TCP
           port: 9090
         - protocol: TCP

--- a/tests/test_network_policy_port_8081.sh
+++ b/tests/test_network_policy_port_8081.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# L1 Unit Test: Validate port 8081 in network policies
+# Tests that network-policies.yaml includes port 8081 for MCP service
+# in both ingress (allow-apisix-to-backends) and egress (allow-apisix-egress)
+#
+# Validates all 3 environments: production, staging, local
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_DIR="$(dirname "$SCRIPT_DIR")"
+
+assert_pass() {
+    echo -e "${GREEN}PASS:${NC} $1"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+assert_fail() {
+    echo -e "${RED}FAIL:${NC} $1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+check_port_8081() {
+    local env=$1
+    local file="${BASE_DIR}/deployments/kubernetes/${env}/manifests/network-policies.yaml"
+
+    if [ ! -f "$file" ]; then
+        assert_fail "${env}: network-policies.yaml not found"
+        return
+    fi
+
+    # Check port 8081 exists at all
+    if grep -q 'port: 8081' "$file"; then
+        assert_pass "${env}: port 8081 present in network policies"
+    else
+        assert_fail "${env}: port 8081 missing from network policies"
+    fi
+
+    # Check it appears at least twice (ingress + egress)
+    local count
+    count=$(grep -c 'port: 8081' "$file" || true)
+
+    if [ "$count" -ge 2 ]; then
+        assert_pass "${env}: port 8081 in both ingress and egress policies (found ${count})"
+    else
+        assert_fail "${env}: port 8081 only in ${count} policy (expected >= 2 for ingress + egress)"
+    fi
+}
+
+echo "======================================================================"
+echo "Network Policy Port 8081 Tests"
+echo "======================================================================"
+
+echo ""
+echo "--- Production ---"
+check_port_8081 "production"
+
+echo ""
+echo "--- Staging ---"
+check_port_8081 "staging"
+
+echo ""
+echo "--- Local ---"
+check_port_8081 "local"
+
+echo ""
+echo "======================================================================"
+TOTAL=$((TESTS_PASSED + TESTS_FAILED))
+echo -e "Total: $TOTAL | ${GREEN}Passed: $TESTS_PASSED${NC} | ${RED}Failed: $TESTS_FAILED${NC}"
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Add port 8081 (MCP service) to `allow-apisix-to-backends` ingress and `allow-apisix-egress` egress network policies
- Applied to all three environments: production, staging, local
- Without this fix, APISIX→MCP traffic is blocked when NetworkPolicies are enforced

Fixes xenoISA/isA_MCP#133
Related to xenoISA/isA_MCP#130 (Epic: APISIX HA)

## Files Changed

| File | Change |
|------|--------|
| `deployments/kubernetes/production/manifests/network-policies.yaml` | Add port 8081 to ingress + egress |
| `deployments/kubernetes/staging/manifests/network-policies.yaml` | Same |
| `deployments/kubernetes/local/manifests/network-policies.yaml` | Same |
| `tests/test_network_policy_port_8081.sh` | New L1 config validation test (6 assertions) |

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 6 | Pass |
| L5 Smoke | N/A | Requires live cluster with NetworkPolicies enforced |

## Test plan

- [x] `bash tests/test_network_policy_port_8081.sh` passes (6/6)
- [ ] Apply to staging, verify `kubectl exec -n isa-cloud deploy/apisix -- curl -s http://mcp-service:8081/health` succeeds
- [ ] Verify no other services are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)