### PR TITLE
feat(infra): enable APISIX active and passive health checks on model_service upstream

### DIFF
--- a/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
@@ -128,6 +128,8 @@ data:
                     \"discovery_type\": \"consul\",\
                     \"scheme\": \"http\",\
                     \"pass_host\": \"pass\",\
+                    \"retries\": 2,\
+                    \"retry_timeout\": 6,\
                     \"timeout\": {\
                         \"connect\": 6,\
                         \"send\": 6,\
@@ -137,6 +139,18 @@ data:
                         \"size\": 320,\
                         \"idle_timeout\": 60,\
                         \"requests\": 1000\
+                    },\
+                    \"checks\": {\
+                        \"active\": {\
+                            \"http_path\": \"/health\",\
+                            \"timeout\": 3,\
+                            \"healthy\": { \"interval\": 5, \"successes\": 3 },\
+                            \"unhealthy\": { \"interval\": 2, \"http_failures\": 2 }\
+                        },\
+                        \"passive\": {\
+                            \"healthy\": { \"http_statuses\": [200, 201, 204], \"successes\": 3 },\
+                            \"unhealthy\": { \"http_statuses\": [500, 502, 503, 504], \"http_failures\": 3, \"timeouts\": 3 }\
+                        }\
                     }\
                 }\
             }")
@@ -203,6 +217,18 @@ data:
                         \"connect\": 6,\
                         \"send\": 6,\
                         \"read\": 10\
+                    },\
+                    \"checks\": {\
+                        \"active\": {\
+                            \"http_path\": \"/health\",\
+                            \"timeout\": 3,\
+                            \"healthy\": { \"interval\": 5, \"successes\": 3 },\
+                            \"unhealthy\": { \"interval\": 2, \"http_failures\": 2 }\
+                        },\
+                        \"passive\": {\
+                            \"healthy\": { \"http_statuses\": [200, 201, 204], \"successes\": 3 },\
+                            \"unhealthy\": { \"http_statuses\": [500, 502, 503, 504], \"http_failures\": 3, \"timeouts\": 3 }\
+                        }\
                     }\
                 }\
             }")

--- a/tests/test_apisix_health_checks.sh
+++ b/tests/test_apisix_health_checks.sh
@@ -6,7 +6,7 @@
 # - Active health checks present in main route upstream
 # - Passive health checks present in main route upstream
 # - Health check parameters match requirements
-# - Both production and staging environments configured
+# - All environments configured (local, staging, production)
 
 set -e
 
@@ -30,8 +30,6 @@ assert_fail() {
     TESTS_FAILED=$((TESTS_FAILED + 1))
 }
 
-# Extract the upstream JSON block from the sync script's create_or_update_route function
-# We look for the -d payload and extract the upstream object
 check_upstream_has_health_checks() {
     local env=$1
     local file="${BASE_DIR}/deployments/kubernetes/${env}/manifests/consul-apisix-sync.yaml"
@@ -41,65 +39,57 @@ check_upstream_has_health_checks() {
         return
     fi
 
-    # The sync script embeds JSON with escaped quotes (\"key\"), so match accordingly
-    # Check that the main route upstream contains "checks" config
     if grep -q '\\"checks\\"' "$file"; then
-        assert_pass "${env}: upstream contains 'checks' configuration"
+        assert_pass "${env}: upstream contains checks configuration"
     else
-        assert_fail "${env}: upstream missing 'checks' configuration"
+        assert_fail "${env}: upstream missing checks configuration"
         return
     fi
 
-    # Check active health check path
     if grep -q '\\"http_path\\"' "$file" && grep -q '/health' "$file"; then
         assert_pass "${env}: active health check polls /health"
     else
         assert_fail "${env}: active health check missing /health path"
     fi
 
-    # Check active healthy interval (should be 5s)
     if grep -q '\\"interval\\": 5' "$file" || grep -q '\\"interval\\":5' "$file"; then
         assert_pass "${env}: active healthy interval is 5s"
     else
         assert_fail "${env}: active healthy interval not set to 5s"
     fi
 
-    # Check active healthy successes is configured (value may differ per env)
-    if grep -q '\\"successes\\"' "$file"; then
-        assert_pass "${env}: healthy successes threshold is configured"
+    # AC: healthy after 3 successes
+    if grep -q '\\"successes\\": 3' "$file" || grep -q '\\"successes\\":3' "$file"; then
+        assert_pass "${env}: healthy successes threshold is 3"
     else
-        assert_fail "${env}: healthy successes threshold not configured"
+        assert_fail "${env}: healthy successes threshold not set to 3"
     fi
 
-    # Check active unhealthy http_failures is configured (value may differ per env)
-    if grep -q '\\"http_failures\\"' "$file"; then
-        assert_pass "${env}: unhealthy http_failures threshold is configured"
+    # AC: unhealthy after 2 failures
+    if grep -q '\\"http_failures\\": 2' "$file" || grep -q '\\"http_failures\\":2' "$file"; then
+        assert_pass "${env}: unhealthy http_failures threshold is 2"
     else
-        assert_fail "${env}: unhealthy http_failures threshold not configured"
+        assert_fail "${env}: unhealthy http_failures threshold not set to 2"
     fi
 
-    # Check active health check timeout (should be 3s)
     if grep -q '\\"timeout\\": 3' "$file" || grep -q '\\"timeout\\":3' "$file"; then
         assert_pass "${env}: active health check timeout is 3s"
     else
         assert_fail "${env}: active health check timeout not set to 3s"
     fi
 
-    # Check passive health checks exist
     if grep -q '\\"passive\\"' "$file"; then
         assert_pass "${env}: passive health checks configured"
     else
         assert_fail "${env}: passive health checks missing"
     fi
 
-    # Check passive unhealthy http_statuses includes 500, 502, 503, 504
     if grep -q '500' "$file" && grep -q '502' "$file" && grep -q '503' "$file" && grep -q '504' "$file"; then
         assert_pass "${env}: passive checks monitor 500/502/503/504 statuses"
     else
         assert_fail "${env}: passive checks missing 500/502/503/504 status monitoring"
     fi
 
-    # Check passive unhealthy timeouts (should be 3)
     if grep -q '\\"timeouts\\": 3' "$file" || grep -q '\\"timeouts\\":3' "$file"; then
         assert_pass "${env}: passive unhealthy timeouts threshold is 3"
     else
@@ -107,7 +97,6 @@ check_upstream_has_health_checks() {
     fi
 }
 
-# Check that health route upstream also has checks
 check_health_route_has_checks() {
     local env=$1
     local file="${BASE_DIR}/deployments/kubernetes/${env}/manifests/consul-apisix-sync.yaml"
@@ -116,7 +105,6 @@ check_health_route_has_checks() {
         return
     fi
 
-    # Count occurrences of "checks" — should appear in both route functions
     local checks_count
     checks_count=$(grep -c '\\"checks\\"' "$file" || true)
 


### PR DESCRIPTION
## Summary

- Add active + passive APISIX health checks to **local** environment consul-apisix-sync (staging/production already configured on main)
- Add retries (2) and retry_timeout (6) to local upstream config
- Tighten test assertions to validate exact AC values across all environments
- Add local environment to health check test coverage

### Health Check Configuration (all environments)

| Parameter | Value |
|-----------|-------|
| Active: `http_path` | `/health` |
| Active: `healthy.interval` | 5s |
| Active: `healthy.successes` | 3 |
| Active: `unhealthy.interval` | 2s |
| Active: `unhealthy.http_failures` | 2 |
| Active: `timeout` | 3s |
| Passive: `unhealthy.http_statuses` | 500, 502, 503, 504 |
| Passive: `unhealthy.http_failures` | 3 |
| Passive: `unhealthy.timeouts` | 3 |

### Detection Improvement

| Metric | Before | After |
|--------|--------|-------|
| Unhealthy detection (local) | None (no health checks) | <10s |
| Unhealthy detection (staging/prod) | <10s | <10s (unchanged) |

Fixes xenoISA/isA_Model#146
Related to xenoISA/isA_Cloud#144 (Gateway HA epic)

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 30 (config validation) | Pass |

## Test Plan

- [x] `bash tests/test_apisix_health_checks.sh` — 30/30 pass (local, staging, production)
- [ ] Deploy to local KIND cluster and verify APISIX active probes hit `/health`
- [ ] Kill a pod and confirm detection in <10s via APISIX error log

🤖 Generated with [Claude Code](https://claude.com/claude-code)