### PR TITLE
fix(infra): add missing retry policy to local health route upstream

### DIFF
--- a/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
@@ -213,6 +213,8 @@ data:
                     \"discovery_type\": \"consul\",\
                     \"scheme\": \"http\",\
                     \"pass_host\": \"pass\",\
+                    \"retries\": 2,\
+                    \"retry_timeout\": 6,\
                     \"timeout\": {\
                         \"connect\": 6,\
                         \"send\": 6,\


### PR DESCRIPTION
## Summary

- Adds `retries: 2` and `retry_timeout: 6` to the local environment's health route upstream config
- Fixes inconsistency where production and staging had retry policies on health routes but local did not
- All 6 upstream configs (3 envs × 2 route types) now have identical retry configuration

Fixes xenoISA/isA_MCP#132
**Parent Epic**: xenoISA/isA_MCP#130

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 0 | N/A (config-only change) |
| L2 Component | 0 | N/A |
| L3 Integration | 0 | N/A |
| L4 API | 0 | N/A |
| L5 Smoke | Manual | Verify via `curl` after next CronJob sync |

## Test plan

- [ ] Deploy to local KIND cluster
- [ ] Trigger CronJob: `kubectl create job --from=cronjob/consul-apisix-sync manual-sync -n isa-cloud-local`
- [ ] Verify health route has retries: `curl -s http://localhost:9180/apisix/admin/routes -H "X-API-KEY: ..." | jq '.list[] | select(.value.name | endswith("_health_route")) | .value.upstream.retries'`
- [ ] Confirm retries = 2 and retry_timeout = 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)