### PR TITLE
feat(infra): add api-breaker circuit breaker to model_service route

### DIFF
--- a/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
@@ -111,6 +111,24 @@ data:
             print_info "  Added JWT auth requirement"
         fi
 
+        # Add circuit breaker for model_service to prevent cascading failures
+        if [[ "$service_name" == "model_service" ]]; then
+            plugins=$(echo "$plugins" | jq '. + {
+                "api-breaker": {
+                    "break_response_code": 502,
+                    "max_breaker_sec": 15,
+                    "unhealthy": {
+                        "http_statuses": [500, 502, 503, 504],
+                        "failures": 3
+                    },
+                    "healthy": {
+                        "successes": 2
+                    }
+                }
+            }')
+            print_info "  Added api-breaker circuit breaker"
+        fi
+
         # Create/Update route with uris array (supports both root and wildcard)
         local response=$(curl -s -w "\n%{http_code}" -X PUT \
             "${APISIX_ADMIN_URL}/apisix/admin/routes/${route_name}" \

--- a/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
@@ -111,6 +111,24 @@ data:
             print_info "  Added JWT auth requirement"
         fi
 
+        # Add circuit breaker for model_service to prevent cascading failures
+        if [[ "$service_name" == "model_service" ]]; then
+            plugins=$(echo "$plugins" | jq '. + {
+                "api-breaker": {
+                    "break_response_code": 502,
+                    "max_breaker_sec": 15,
+                    "unhealthy": {
+                        "http_statuses": [500, 502, 503, 504],
+                        "failures": 3
+                    },
+                    "healthy": {
+                        "successes": 2
+                    }
+                }
+            }')
+            print_info "  Added api-breaker circuit breaker"
+        fi
+
         # Create/Update route with uris array (supports both root and wildcard)
         local response=$(curl -s -w "\n%{http_code}" -X PUT \
             "${APISIX_ADMIN_URL}/apisix/admin/routes/${route_name}" \

--- a/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
@@ -111,6 +111,24 @@ data:
             print_info "  Added JWT auth requirement"
         fi
 
+        # Add circuit breaker for model_service to prevent cascading failures
+        if [[ "$service_name" == "model_service" ]]; then
+            plugins=$(echo "$plugins" | jq '. + {
+                "api-breaker": {
+                    "break_response_code": 502,
+                    "max_breaker_sec": 15,
+                    "unhealthy": {
+                        "http_statuses": [500, 502, 503, 504],
+                        "failures": 3
+                    },
+                    "healthy": {
+                        "successes": 2
+                    }
+                }
+            }')
+            print_info "  Added api-breaker circuit breaker"
+        fi
+
         # Create/Update route with uris array (supports both root and wildcard)
         local response=$(curl -s -w "\n%{http_code}" -X PUT \
             "${APISIX_ADMIN_URL}/apisix/admin/routes/${route_name}" \


### PR DESCRIPTION
## Summary

- Adds APISIX \`api-breaker\` plugin to the \`model_service\` route in consul-apisix-sync across all environments (local, staging, production)
- Opens circuit after 3 consecutive 5xx errors, returns 502 immediately (fast failure)
- Half-open after 15s, closes after 2 successful probes
- Monitors HTTP 500, 502, 503, 504 status codes

## Config

\`\`\`json
{
  "api-breaker": {
    "break_response_code": 502,
    "max_breaker_sec": 15,
    "unhealthy": { "http_statuses": [500, 502, 503, 504], "failures": 3 },
    "healthy": { "successes": 2 }
  }
}
\`\`\`

## Files Changed

| File | Change |
|------|--------|
| \`deployments/kubernetes/local/manifests/consul-apisix-sync.yaml\` | Add api-breaker plugin for model_service |
| \`deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml\` | Same |
| \`deployments/kubernetes/production/manifests/consul-apisix-sync.yaml\` | Same |

Related to xenoISA/isA_Model#147
Parent Epic: xenoISA/isA_Model#144

🤖 Generated with [Claude Code](https://claude.com/claude-code)