### PR TITLE
feat(infra): move APISIX admin API key to K8s Secret

### DIFF
--- a/deployments/kubernetes/production/README.md
+++ b/deployments/kubernetes/production/README.md
@@ -199,12 +199,12 @@ kubectl exec -n isa-cloud-production consul-server-0 -- consul operator raft lis
 # Check routes
 kubectl exec -n isa-cloud-production <apisix-pod> -- \
   curl -s http://localhost:9180/apisix/admin/routes \
-  -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1"
+  -H "X-API-KEY: $(kubectl get secret apisix-admin-key -n isa-cloud-production -o jsonpath='{.data.admin-key}' | base64 -d)"
 
 # Check upstreams
 kubectl exec -n isa-cloud-production <apisix-pod> -- \
   curl -s http://localhost:9180/apisix/admin/upstreams \
-  -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1"
+  -H "X-API-KEY: $(kubectl get secret apisix-admin-key -n isa-cloud-production -o jsonpath='{.data.admin-key}' | base64 -d)"
 ```
 
 ## Emergency Procedures

--- a/deployments/kubernetes/production/manifests/apisix-secrets.yaml
+++ b/deployments/kubernetes/production/manifests/apisix-secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apisix-admin-key
+  namespace: isa-cloud-production
+  labels:
+    app: apisix
+    tier: infrastructure
+type: Opaque
+stringData:
+  # IMPORTANT: Replace this placeholder with a unique, rotated key before deploying.
+  # In CI/CD, inject via: kubectl create secret generic apisix-admin-key \
+  #   --from-literal=admin-key=<generated-key> -n isa-cloud-production --dry-run=client -o yaml | kubectl apply -f -
+  admin-key: "REPLACE_WITH_PRODUCTION_KEY"

--- a/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
@@ -25,7 +25,7 @@ data:
     # Configuration
     CONSUL_URL="${CONSUL_URL:-http://consul-ui.isa-cloud-production.svc.cluster.local}"
     APISIX_ADMIN_URL="${APISIX_ADMIN_URL:-http://apisix-admin.isa-cloud-production.svc.cluster.local:9180}"
-    ADMIN_KEY="${APISIX_ADMIN_KEY:-edd1c9f034335f136f87ad84b625c8f1}"
+    ADMIN_KEY="${APISIX_ADMIN_KEY:?APISIX_ADMIN_KEY must be set via K8s Secret}"
 
     # Functions
     print_success() { echo -e "${GREEN}OK  $1${NC}"; }
@@ -380,7 +380,10 @@ spec:
                 - name: APISIX_ADMIN_URL
                   value: "http://apisix-admin.isa-cloud-production.svc.cluster.local:9180"
                 - name: APISIX_ADMIN_KEY
-                  value: "edd1c9f034335f136f87ad84b625c8f1"
+                  valueFrom:
+                    secretKeyRef:
+                      name: apisix-admin-key
+                      key: admin-key
                 # SECURITY: Configure allowed CORS origins (comma-separated)
                 # WARNING: Never use '*' in production with credentials
                 - name: CORS_ALLOWED_ORIGINS

--- a/deployments/kubernetes/production/scripts/check-services.sh
+++ b/deployments/kubernetes/production/scripts/check-services.sh
@@ -175,7 +175,7 @@ check_helm_release "apisix"
 apisix_pod=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/name=apisix" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
 if [ -n "$apisix_pod" ]; then
     route_count=$(kubectl exec -n "$NAMESPACE" "$apisix_pod" -- \
-        curl -s http://localhost:9180/apisix/admin/routes -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" 2>/dev/null | \
+        curl -s http://localhost:9180/apisix/admin/routes -H "X-API-KEY: $(kubectl get secret apisix-admin-key -n $NAMESPACE -o jsonpath='{.data.admin-key}' | base64 -d)" 2>/dev/null | \
         grep -o '"total":[0-9]*' | cut -d: -f2 || echo "0")
     echo -e "     ${CYAN}Routes: ${route_count:-0}${NC}"
 fi

--- a/deployments/kubernetes/production/values/apisix.yaml
+++ b/deployments/kubernetes/production/values/apisix.yaml
@@ -37,8 +37,10 @@ apisix:
     type: ClusterIP
     port: 9180
     servicePort: 9180
+    # Admin key injected via: helm install --set apisix.admin.credentials.admin=<key>
+    # Key stored in K8s Secret 'apisix-admin-key' (see manifests/apisix-secrets.yaml)
     credentials:
-      admin: "edd1c9f034335f136f87ad84b625c8f1"
+      admin: ""
     allow:
       ipList:
         - 10.0.0.0/8

--- a/deployments/kubernetes/staging/README.md
+++ b/deployments/kubernetes/staging/README.md
@@ -151,7 +151,7 @@ kubectl logs -n isa-cloud-staging etcd-0
 # Check APISIX routes
 kubectl exec -n isa-cloud-staging <apisix-pod> -- \
   curl -s http://localhost:9180/apisix/admin/routes \
-  -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1"
+  -H "X-API-KEY: $(kubectl get secret apisix-admin-key -n isa-cloud-staging -o jsonpath='{.data.admin-key}' | base64 -d)"
 
 # Check APISIX logs
 kubectl logs -n isa-cloud-staging -l app.kubernetes.io/name=apisix

--- a/deployments/kubernetes/staging/manifests/apisix-secrets.yaml
+++ b/deployments/kubernetes/staging/manifests/apisix-secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apisix-admin-key
+  namespace: isa-cloud-staging
+  labels:
+    app: apisix
+    tier: infrastructure
+type: Opaque
+stringData:
+  # IMPORTANT: Replace this placeholder with a unique key before deploying.
+  # In CI/CD, inject via: kubectl create secret generic apisix-admin-key \
+  #   --from-literal=admin-key=<generated-key> -n isa-cloud-staging --dry-run=client -o yaml | kubectl apply -f -
+  admin-key: "REPLACE_WITH_STAGING_KEY"

--- a/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
@@ -25,7 +25,7 @@ data:
     # Configuration
     CONSUL_URL="${CONSUL_URL:-http://consul-ui.isa-cloud-staging.svc.cluster.local}"
     APISIX_ADMIN_URL="${APISIX_ADMIN_URL:-http://apisix-admin.isa-cloud-staging.svc.cluster.local:9180}"
-    ADMIN_KEY="${APISIX_ADMIN_KEY:-edd1c9f034335f136f87ad84b625c8f1}"
+    ADMIN_KEY="${APISIX_ADMIN_KEY:?APISIX_ADMIN_KEY must be set via K8s Secret}"
 
     # Functions
     print_success() { echo -e "${GREEN}OK  $1${NC}"; }
@@ -380,7 +380,10 @@ spec:
                 - name: APISIX_ADMIN_URL
                   value: "http://apisix-admin.isa-cloud-staging.svc.cluster.local:9180"
                 - name: APISIX_ADMIN_KEY
-                  value: "edd1c9f034335f136f87ad84b625c8f1"
+                  valueFrom:
+                    secretKeyRef:
+                      name: apisix-admin-key
+                      key: admin-key
                 # SECURITY: Configure allowed CORS origins (comma-separated)
                 # WARNING: Never use '*' in production/staging with credentials
                 - name: CORS_ALLOWED_ORIGINS

--- a/deployments/kubernetes/staging/scripts/check-services.sh
+++ b/deployments/kubernetes/staging/scripts/check-services.sh
@@ -97,7 +97,7 @@ check_apisix_routes() {
     if [ -n "$apisix_pod" ]; then
         # Try to get route count via admin API
         local route_count=$(kubectl exec -n "$NAMESPACE" "$apisix_pod" -- \
-            curl -s http://localhost:9180/apisix/admin/routes -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" 2>/dev/null | \
+            curl -s http://localhost:9180/apisix/admin/routes -H "X-API-KEY: $(kubectl get secret apisix-admin-key -n $NAMESPACE -o jsonpath='{.data.admin-key}' | base64 -d)" 2>/dev/null | \
             grep -o '"total":[0-9]*' | cut -d: -f2 || echo "0")
         echo -e "  ${GREEN}[OK]${NC} Routes configured: ${route_count:-0}"
     else

--- a/deployments/kubernetes/staging/values/apisix.yaml
+++ b/deployments/kubernetes/staging/values/apisix.yaml
@@ -39,8 +39,10 @@ apisix:
     port: 9180
     servicePort: 9180
     nodePort: 30180
+    # Admin key injected via: helm install --set apisix.admin.credentials.admin=<key>
+    # Key stored in K8s Secret 'apisix-admin-key' (see manifests/apisix-secrets.yaml)
     credentials:
-      admin: "edd1c9f034335f136f87ad84b625c8f1"
+      admin: ""
     allow:
       ipList:
         - 0.0.0.0/0


### PR DESCRIPTION
## Summary

- Move hardcoded APISIX admin API key (`edd1c9...`) from plaintext manifests into K8s Secrets for production and staging
- CronJob `consul-apisix-sync` now reads key via `secretKeyRef` instead of plaintext `value`
- Sync script uses `:?` (fail-fast) instead of hardcoded fallback for prod/staging
- APISIX Helm values cleared — key injected via `helm install --set` from Secret
- `check-services.sh` and READMEs updated to read key from Secret at runtime
- Local environment unchanged (default key acceptable for dev)

Fixes xenoISA/isA_MCP#136
**Parent Epic**: xenoISA/isA_MCP#130

## Files Changed

| File | Change |
|------|--------|
| `production/manifests/apisix-secrets.yaml` | **New** — K8s Secret for production |
| `staging/manifests/apisix-secrets.yaml` | **New** — K8s Secret for staging |
| `production/manifests/consul-apisix-sync.yaml` | `secretKeyRef` + fail-fast fallback |
| `staging/manifests/consul-apisix-sync.yaml` | `secretKeyRef` + fail-fast fallback |
| `production/values/apisix.yaml` | Removed plaintext key |
| `staging/values/apisix.yaml` | Removed plaintext key |
| `production/scripts/check-services.sh` | Read key from Secret |
| `staging/scripts/check-services.sh` | Read key from Secret |
| `production/README.md` | Updated examples |
| `staging/README.md` | Updated examples |

## Deployment Notes

Before applying, create the actual secrets with rotated keys:
```bash
# Production (use a unique, rotated key)
kubectl create secret generic apisix-admin-key \
  --from-literal=admin-key=$(openssl rand -hex 16) \
  -n isa-cloud-production --dry-run=client -o yaml | kubectl apply -f -

# Staging (use a different key)
kubectl create secret generic apisix-admin-key \
  --from-literal=admin-key=$(openssl rand -hex 16) \
  -n isa-cloud-staging --dry-run=client -o yaml | kubectl apply -f -
```

Then redeploy APISIX with the key from the secret:
```bash
ADMIN_KEY=$(kubectl get secret apisix-admin-key -n isa-cloud-production -o jsonpath='{.data.admin-key}' | base64 -d)
helm upgrade apisix apisix/apisix -n isa-cloud-production -f production/values/apisix.yaml --set apisix.admin.credentials.admin=$ADMIN_KEY
```

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | N/A | Infra-only change |
| L2 Component | N/A | Infra-only change |
| L3 Integration | N/A | Infra-only change |
| L4 API | N/A | Infra-only change |
| L5 Smoke | Manual | Verify CronJob reads secret, APISIX admin API responds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)