### PR TITLE
feat(infra): add Consul watch for near-instant APISIX route sync

### DIFF
--- a/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
@@ -356,6 +356,108 @@ data:
     # Run
     main
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: consul-apisix-watch-script
+  namespace: isa-cloud-local
+  labels:
+    app: consul-apisix-watch
+    tier: infrastructure
+data:
+  watch_handler.sh: |
+    #!/bin/bash
+    # Consul watch handler — debounced route sync
+    # Triggered by `consul watch -type=services` on any service catalog change.
+    # Uses a lock file + cooldown to prevent rapid-fire syncs during rolling deployments.
+
+    LOCK_FILE="/tmp/consul-apisix-sync.lock"
+    COOLDOWN_FILE="/tmp/consul-apisix-sync.last"
+    COOLDOWN_SECONDS=5
+
+    # Debounce: skip if last sync was < COOLDOWN_SECONDS ago
+    if [ -f "$COOLDOWN_FILE" ]; then
+        last_run=$(cat "$COOLDOWN_FILE")
+        now=$(date +%s)
+        elapsed=$((now - last_run))
+        if [ "$elapsed" -lt "$COOLDOWN_SECONDS" ]; then
+            echo "INFO Debounce: last sync ${elapsed}s ago, skipping (cooldown=${COOLDOWN_SECONDS}s)"
+            exit 0
+        fi
+    fi
+
+    # Lock: prevent concurrent syncs
+    exec 200>"$LOCK_FILE"
+    if ! flock -n 200; then
+        echo "INFO Sync already in progress, skipping"
+        exit 0
+    fi
+
+    date +%s > "$COOLDOWN_FILE"
+    echo "INFO Consul service change detected, triggering route sync..."
+    bash /scripts/sync_routes.sh
+    echo "INFO Watch-triggered sync complete"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consul-apisix-watch
+  namespace: isa-cloud-local
+  labels:
+    app: consul-apisix-watch
+    tier: infrastructure
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: consul-apisix-watch
+  template:
+    metadata:
+      labels:
+        app: consul-apisix-watch
+    spec:
+      containers:
+        - name: watch
+          image: hashicorp/consul:1.17
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache bash curl jq > /dev/null 2>&1
+              echo "INFO Starting Consul watch for service changes..."
+              consul watch \
+                -type=services \
+                -http-addr="${CONSUL_URL}" \
+                /watch-scripts/watch_handler.sh
+          volumeMounts:
+            - name: sync-script
+              mountPath: /scripts
+            - name: watch-script
+              mountPath: /watch-scripts
+          env:
+            - name: CONSUL_URL
+              value: "http://consul-ui.isa-cloud-local.svc.cluster.local"
+            - name: APISIX_ADMIN_URL
+              value: "http://apisix-admin.isa-cloud-local.svc.cluster.local:9180"
+            - name: APISIX_ADMIN_KEY
+              value: "edd1c9f034335f136f87ad84b625c8f1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+      volumes:
+        - name: sync-script
+          configMap:
+            name: consul-apisix-sync-script
+            defaultMode: 0755
+        - name: watch-script
+          configMap:
+            name: consul-apisix-watch-script
+            defaultMode: 0755
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -365,7 +467,7 @@ metadata:
     app: consul-apisix-sync
     tier: infrastructure
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "*/15 * * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid

--- a/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
@@ -361,6 +361,115 @@ data:
     # Run
     main
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: consul-apisix-watch-script
+  namespace: isa-cloud-production
+  labels:
+    app: consul-apisix-watch
+    tier: infrastructure
+data:
+  watch_handler.sh: |
+    #!/bin/bash
+    # Consul watch handler — debounced route sync
+    # Triggered by `consul watch -type=services` on any service catalog change.
+    # Uses a lock file + cooldown to prevent rapid-fire syncs during rolling deployments.
+
+    LOCK_FILE="/tmp/consul-apisix-sync.lock"
+    COOLDOWN_FILE="/tmp/consul-apisix-sync.last"
+    COOLDOWN_SECONDS=5
+
+    # Debounce: skip if last sync was < COOLDOWN_SECONDS ago
+    if [ -f "$COOLDOWN_FILE" ]; then
+        last_run=$(cat "$COOLDOWN_FILE")
+        now=$(date +%s)
+        elapsed=$((now - last_run))
+        if [ "$elapsed" -lt "$COOLDOWN_SECONDS" ]; then
+            echo "INFO Debounce: last sync ${elapsed}s ago, skipping (cooldown=${COOLDOWN_SECONDS}s)"
+            exit 0
+        fi
+    fi
+
+    # Lock: prevent concurrent syncs
+    exec 200>"$LOCK_FILE"
+    if ! flock -n 200; then
+        echo "INFO Sync already in progress, skipping"
+        exit 0
+    fi
+
+    date +%s > "$COOLDOWN_FILE"
+    echo "INFO Consul service change detected, triggering route sync..."
+    bash /scripts/sync_routes.sh
+    echo "INFO Watch-triggered sync complete"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consul-apisix-watch
+  namespace: isa-cloud-production
+  labels:
+    app: consul-apisix-watch
+    tier: infrastructure
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: consul-apisix-watch
+  template:
+    metadata:
+      labels:
+        app: consul-apisix-watch
+    spec:
+      containers:
+        - name: watch
+          image: hashicorp/consul:1.17
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache bash curl jq > /dev/null 2>&1
+              echo "INFO Starting Consul watch for service changes..."
+              consul watch \
+                -type=services \
+                -http-addr="${CONSUL_URL}" \
+                /watch-scripts/watch_handler.sh
+          volumeMounts:
+            - name: sync-script
+              mountPath: /scripts
+            - name: watch-script
+              mountPath: /watch-scripts
+          env:
+            - name: CONSUL_URL
+              value: "http://consul-ui.isa-cloud-production.svc.cluster.local"
+            - name: APISIX_ADMIN_URL
+              value: "http://apisix-admin.isa-cloud-production.svc.cluster.local:9180"
+            - name: APISIX_ADMIN_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: apisix-admin-key
+                  key: admin-key
+            - name: REDIS_HOST
+              value: "redis-master.isa-cloud-production.svc.cluster.local"
+            - name: CORS_ALLOWED_ORIGINS
+              value: "https://app.isa-cloud.example.com,https://www.isa-cloud.example.com"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+      volumes:
+        - name: sync-script
+          configMap:
+            name: consul-apisix-sync-script
+            defaultMode: 0755
+        - name: watch-script
+          configMap:
+            name: consul-apisix-watch-script
+            defaultMode: 0755
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -370,7 +479,7 @@ metadata:
     app: consul-apisix-sync
     tier: infrastructure
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "*/15 * * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid

--- a/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
@@ -361,6 +361,115 @@ data:
     # Run
     main
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: consul-apisix-watch-script
+  namespace: isa-cloud-staging
+  labels:
+    app: consul-apisix-watch
+    tier: infrastructure
+data:
+  watch_handler.sh: |
+    #!/bin/bash
+    # Consul watch handler — debounced route sync
+    # Triggered by `consul watch -type=services` on any service catalog change.
+    # Uses a lock file + cooldown to prevent rapid-fire syncs during rolling deployments.
+
+    LOCK_FILE="/tmp/consul-apisix-sync.lock"
+    COOLDOWN_FILE="/tmp/consul-apisix-sync.last"
+    COOLDOWN_SECONDS=5
+
+    # Debounce: skip if last sync was < COOLDOWN_SECONDS ago
+    if [ -f "$COOLDOWN_FILE" ]; then
+        last_run=$(cat "$COOLDOWN_FILE")
+        now=$(date +%s)
+        elapsed=$((now - last_run))
+        if [ "$elapsed" -lt "$COOLDOWN_SECONDS" ]; then
+            echo "INFO Debounce: last sync ${elapsed}s ago, skipping (cooldown=${COOLDOWN_SECONDS}s)"
+            exit 0
+        fi
+    fi
+
+    # Lock: prevent concurrent syncs
+    exec 200>"$LOCK_FILE"
+    if ! flock -n 200; then
+        echo "INFO Sync already in progress, skipping"
+        exit 0
+    fi
+
+    date +%s > "$COOLDOWN_FILE"
+    echo "INFO Consul service change detected, triggering route sync..."
+    bash /scripts/sync_routes.sh
+    echo "INFO Watch-triggered sync complete"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consul-apisix-watch
+  namespace: isa-cloud-staging
+  labels:
+    app: consul-apisix-watch
+    tier: infrastructure
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: consul-apisix-watch
+  template:
+    metadata:
+      labels:
+        app: consul-apisix-watch
+    spec:
+      containers:
+        - name: watch
+          image: hashicorp/consul:1.17
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache bash curl jq > /dev/null 2>&1
+              echo "INFO Starting Consul watch for service changes..."
+              consul watch \
+                -type=services \
+                -http-addr="${CONSUL_URL}" \
+                /watch-scripts/watch_handler.sh
+          volumeMounts:
+            - name: sync-script
+              mountPath: /scripts
+            - name: watch-script
+              mountPath: /watch-scripts
+          env:
+            - name: CONSUL_URL
+              value: "http://consul-ui.isa-cloud-staging.svc.cluster.local"
+            - name: APISIX_ADMIN_URL
+              value: "http://apisix-admin.isa-cloud-staging.svc.cluster.local:9180"
+            - name: APISIX_ADMIN_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: apisix-admin-key
+                  key: admin-key
+            - name: REDIS_HOST
+              value: "redis-master.isa-cloud-staging.svc.cluster.local"
+            - name: CORS_ALLOWED_ORIGINS
+              value: "https://app.isa-cloud.example.com,https://staging.isa-cloud.example.com"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+      volumes:
+        - name: sync-script
+          configMap:
+            name: consul-apisix-sync-script
+            defaultMode: 0755
+        - name: watch-script
+          configMap:
+            name: consul-apisix-watch-script
+            defaultMode: 0755
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -370,7 +479,7 @@ metadata:
     app: consul-apisix-sync
     tier: infrastructure
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "*/15 * * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid


### PR DESCRIPTION
## Summary

- Add `consul-apisix-watch` Deployment using `consul watch -type=services` to trigger route sync immediately on Consul service catalog changes (register/deregister)
- Add debounced watch handler with 5s cooldown and `flock` to prevent rapid-fire or concurrent syncs during rolling deployments
- Reduce CronJob schedule from `*/5` to `*/15` — retained as fallback reconciliation only
- Applied consistently across local, staging, and production environments

Fixes xenoISA/isA_MCP#137
Related to xenoISA/isA_MCP#130

## How It Works

```
Service registers/deregisters in Consul
  → consul watch detects catalog change (blocking query, near-instant)
  → watch_handler.sh runs (debounced, locked)
  → calls existing sync_routes.sh
  → APISIX routes updated within ~5-10s
```

CronJob still runs every 15 min as a safety net for any missed events.

## Test Plan

- [ ] Deploy to local KIND cluster, register a new service in Consul, verify APISIX route appears within 10s
- [ ] Verify debounce: rapid service changes only trigger one sync per 5s window
- [ ] Verify CronJob still runs at 15-min intervals as reconciliation
- [ ] Verify watch pod restarts cleanly if Consul is temporarily unavailable
- [ ] Verify staging and production manifests match expected namespace/secret references

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | N/A | Infra manifests |
| L2 Component | N/A | Infra manifests |
| L3 Integration | Manual | Deploy to KIND |
| L4 API | N/A | No API changes |
| L5 Smoke | Manual | End-to-end sync timing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)