### PR TITLE
feat(infra): deploy Vault + ESO for production secret management

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -298,31 +298,58 @@ kubectl apply -f kubernetes/staging/secrets/infrastructure-secrets.local.yaml
 rm kubernetes/staging/secrets/infrastructure-secrets.local.yaml
 ```
 
-### Production (Recommended: External Secrets)
+### Production (Vault + External Secrets Operator)
+
+Production secrets are managed by **HashiCorp Vault** (HA with Consul backend) and synced to
+K8s Secrets via the **External Secrets Operator (ESO)**.
+
+```
+Vault (stores secrets)
+  └── ClusterSecretStore (ESO connects to Vault via K8s auth)
+       └── ExternalSecret CRs (map Vault paths → K8s Secrets)
+            └── K8s Secrets (postgresql-secret, redis-secret, etc.)
+```
+
+#### First-time setup
 
 ```bash
-# Install External Secrets Operator
-helm repo add external-secrets https://charts.external-secrets.io
-helm install external-secrets external-secrets/external-secrets -n external-secrets --create-namespace
+# 1. Deploy Vault + ESO (via deploy script or ArgoCD)
+cd kubernetes/production/scripts
+./deploy.sh secrets
 
-# Configure SecretStore for AWS Secrets Manager
-kubectl apply -f - <<EOF
-apiVersion: external-secrets.io/v1beta1
-kind: ClusterSecretStore
-metadata:
-  name: aws-secrets-manager
-spec:
-  provider:
-    aws:
-      service: SecretsManager
-      region: us-west-2
-      auth:
-        jwt:
-          serviceAccountRef:
-            name: external-secrets-sa
-            namespace: external-secrets
-EOF
+# 2. Initialize Vault, unseal, configure auth, seed secrets
+./vault-init.sh
+
+# 3. Verify secrets are synced
+kubectl get externalsecret -n isa-cloud-production
 ```
+
+#### Day-2 operations
+
+```bash
+# Check Vault status
+./vault-init.sh status
+
+# Unseal after pod restart
+./vault-init.sh unseal
+
+# Update/add secrets
+./vault-init.sh seed
+
+# Force ESO re-sync
+kubectl annotate externalsecret -n isa-cloud-production --all force-sync=$(date +%s)
+```
+
+#### Key files
+
+| File | Purpose |
+|------|---------|
+| `argocd/apps/production/secret-management.yaml` | ArgoCD apps for Vault + ESO |
+| `kubernetes/production/values/vault.yaml` | Vault Helm values (HA, Consul backend) |
+| `kubernetes/production/values/external-secrets.yaml` | ESO Helm values |
+| `kubernetes/production/manifests/cluster-secret-store.yaml` | ClusterSecretStore CR (Vault backend) |
+| `kubernetes/production/manifests/external-secrets.yaml` | ExternalSecret CRs for all infra secrets |
+| `kubernetes/production/scripts/vault-init.sh` | Init, unseal, configure, and seed Vault |
 
 ### Local Credentials
 
@@ -346,8 +373,10 @@ EOF
 # Verify kubectl context
 kubectl config current-context
 
-# Create secrets FIRST
-kubectl apply -f kubernetes/production/secrets/infrastructure-secrets.local.yaml
+# Deploy Vault + ESO and seed secrets FIRST
+cd kubernetes/production/scripts
+./deploy.sh secrets
+./vault-init.sh
 ```
 
 ### Deploy Infrastructure

--- a/deployments/argocd/apps/production/kustomization.yaml
+++ b/deployments/argocd/apps/production/kustomization.yaml
@@ -7,6 +7,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - secret-management.yaml
   - core-services.yaml
   - os-services.yaml
   - user-services-appset.yaml

--- a/deployments/argocd/apps/production/secret-management.yaml
+++ b/deployments/argocd/apps/production/secret-management.yaml
@@ -1,0 +1,139 @@
+# =============================================================================
+# Secret Management - Production
+# =============================================================================
+# Deploys HashiCorp Vault (HA) + External Secrets Operator.
+# Vault stores secrets, ESO syncs them to K8s Secrets.
+#
+# Sync order (via sync waves):
+#   Wave -2: Vault operator (must be running first)
+#   Wave -1: External Secrets Operator (must be running before ExternalSecrets)
+#   Wave  0: ClusterSecretStore + ExternalSecret CRs (created by manifests/)
+#
+# IMPORTANT: After first deploy, run vault-init.sh to initialize and unseal Vault.
+# =============================================================================
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault-production
+  namespace: argocd
+  labels:
+    app: vault
+    environment: production
+    tier: infrastructure
+    critical: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: isa-deployments
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: isa-alerts
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://helm.releases.hashicorp.com
+    chart: vault
+    targetRevision: 0.28.*
+    helm:
+      valueFiles: []
+      values: |
+        global:
+          enabled: true
+        server:
+          ha:
+            enabled: true
+            replicas: 3
+            raft:
+              enabled: false
+            config: |
+              ui = true
+              listener "tcp" {
+                tls_disable = 1
+                address = "[::]:8200"
+                cluster_address = "[::]:8201"
+              }
+              storage "consul" {
+                path = "vault/"
+                address = "consul-server.isa-cloud-production.svc.cluster.local:8500"
+              }
+              service_registration "kubernetes" {}
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          auditStorage:
+            enabled: true
+            size: 10Gi
+          dataStorage:
+            enabled: false
+          standalone:
+            enabled: false
+        injector:
+          enabled: false
+        ui:
+          enabled: true
+          serviceType: ClusterIP
+        csi:
+          enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: isa-cloud-production
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets-production
+  namespace: argocd
+  labels:
+    app: external-secrets
+    environment: production
+    tier: infrastructure
+    critical: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: isa-deployments
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: isa-alerts
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://charts.external-secrets.io
+    chart: external-secrets
+    targetRevision: 0.10.*
+    helm:
+      values: |
+        installCRDs: true
+        replicaCount: 2
+        webhook:
+          replicaCount: 2
+        certController:
+          replicaCount: 1
+        leaderElect: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/deployments/kubernetes/production/manifests/apisix-secrets.yaml
+++ b/deployments/kubernetes/production/manifests/apisix-secrets.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: This secret is now managed by Vault + External Secrets Operator.
+# See: manifests/external-secrets.yaml (apisix-external-secret)
+# Kept as reference only — do NOT apply directly.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,7 +11,4 @@ metadata:
     tier: infrastructure
 type: Opaque
 stringData:
-  # IMPORTANT: Replace this placeholder with a unique, rotated key before deploying.
-  # In CI/CD, inject via: kubectl create secret generic apisix-admin-key \
-  #   --from-literal=admin-key=<generated-key> -n isa-cloud-production --dry-run=client -o yaml | kubectl apply -f -
-  admin-key: "REPLACE_WITH_PRODUCTION_KEY"
+  admin-key: "MANAGED_BY_VAULT_ESO"

--- a/deployments/kubernetes/production/manifests/cluster-secret-store.yaml
+++ b/deployments/kubernetes/production/manifests/cluster-secret-store.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# ClusterSecretStore - Vault Backend
+# =============================================================================
+# Connects the External Secrets Operator to HashiCorp Vault.
+# Uses Kubernetes auth so ESO authenticates via its ServiceAccount token.
+#
+# Prerequisites:
+#   1. Vault is initialized and unsealed (run vault-init.sh)
+#   2. Vault Kubernetes auth is enabled (vault-init.sh handles this)
+#   3. External Secrets Operator is running
+# =============================================================================
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: vault-backend
+  labels:
+    app: external-secrets
+    tier: infrastructure
+    environment: production
+spec:
+  provider:
+    vault:
+      server: "http://vault.isa-cloud-production.svc.cluster.local:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "external-secrets"
+          serviceAccountRef:
+            name: "external-secrets"
+            namespace: "external-secrets"

--- a/deployments/kubernetes/production/manifests/external-secrets.yaml
+++ b/deployments/kubernetes/production/manifests/external-secrets.yaml
@@ -1,0 +1,168 @@
+# =============================================================================
+# ExternalSecret CRs - Production Infrastructure Secrets
+# =============================================================================
+# Each ExternalSecret syncs a Vault secret path to a native K8s Secret.
+# Vault paths follow: secret/data/isa-cloud/production/<service>
+# Refresh interval: 1h (secrets re-synced from Vault hourly).
+#
+# The K8s Secret names match what the Helm values already expect:
+#   postgresql-secret, redis-secret, neo4j-secret, minio-secret, emqx-secret
+#
+# To populate these secrets in Vault, run: vault-init.sh seed
+# =============================================================================
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: postgresql-external-secret
+  namespace: isa-cloud-production
+  labels:
+    app.kubernetes.io/component: postgresql
+    tier: infrastructure
+    environment: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: postgresql-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: postgresql-password
+      remoteRef:
+        key: secret/data/isa-cloud/production/postgresql
+        property: password
+    - secretKey: postgresql-replication-password
+      remoteRef:
+        key: secret/data/isa-cloud/production/postgresql
+        property: replication-password
+    - secretKey: pgpool-admin-password
+      remoteRef:
+        key: secret/data/isa-cloud/production/postgresql
+        property: pgpool-admin-password
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: redis-external-secret
+  namespace: isa-cloud-production
+  labels:
+    app.kubernetes.io/component: redis
+    tier: infrastructure
+    environment: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: redis-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: redis-password
+      remoteRef:
+        key: secret/data/isa-cloud/production/redis
+        property: password
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: neo4j-external-secret
+  namespace: isa-cloud-production
+  labels:
+    app.kubernetes.io/component: neo4j
+    tier: infrastructure
+    environment: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: neo4j-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: neo4j-password
+      remoteRef:
+        key: secret/data/isa-cloud/production/neo4j
+        property: password
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-external-secret
+  namespace: isa-cloud-production
+  labels:
+    app.kubernetes.io/component: minio
+    tier: infrastructure
+    environment: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: minio-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: root-user
+      remoteRef:
+        key: secret/data/isa-cloud/production/minio
+        property: root-user
+    - secretKey: root-password
+      remoteRef:
+        key: secret/data/isa-cloud/production/minio
+        property: root-password
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: emqx-external-secret
+  namespace: isa-cloud-production
+  labels:
+    app.kubernetes.io/component: emqx
+    tier: infrastructure
+    environment: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: emqx-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: EMQX_DASHBOARD__DEFAULT_PASSWORD
+      remoteRef:
+        key: secret/data/isa-cloud/production/emqx
+        property: dashboard-password
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: apisix-external-secret
+  namespace: isa-cloud-production
+  labels:
+    app.kubernetes.io/component: apisix
+    tier: infrastructure
+    environment: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: apisix-admin-key
+    creationPolicy: Owner
+  data:
+    - secretKey: admin-key
+      remoteRef:
+        key: secret/data/isa-cloud/production/apisix
+        property: admin-key

--- a/deployments/kubernetes/production/scripts/deploy.sh
+++ b/deployments/kubernetes/production/scripts/deploy.sh
@@ -6,6 +6,7 @@
 # Production deployments should go through CI/CD pipeline (ArgoCD).
 #
 # Usage:
+#   ./deploy.sh secrets            # Deploy Vault + ESO (run first!)
 #   ./deploy.sh infrastructure    # Deploy HA infrastructure
 #   ./deploy.sh services          # Deploy application services (ArgoCD)
 #   ./deploy.sh mlplatform        # Deploy ML platform (Ray, MLflow, JupyterHub)
@@ -73,12 +74,13 @@ check_prerequisites() {
         kubectl create namespace ${NAMESPACE}
     fi
 
-    # Check secrets exist
+    # Check secrets exist (created by Vault + ESO, or manually)
     local required_secrets=("postgresql-secret" "redis-secret" "neo4j-secret" "minio-secret")
     for secret in "${required_secrets[@]}"; do
         if ! kubectl get secret ${secret} -n ${NAMESPACE} &>/dev/null; then
             log_error "Required secret '${secret}' not found in ${NAMESPACE}"
-            log_error "Please create secrets before deploying. See secrets/infrastructure-secrets.yaml"
+            log_error "Ensure Vault + ESO are deployed and secrets are seeded."
+            log_error "Run: ./vault-init.sh (first time) or ./vault-init.sh status (check)"
             exit 1
         fi
     done
@@ -93,6 +95,7 @@ setup_helm_repos() {
     local repos=(
         "bitnami https://charts.bitnami.com/bitnami"
         "hashicorp https://helm.releases.hashicorp.com"
+        "external-secrets https://charts.external-secrets.io"
         "apisix https://charts.apiseven.com"
         "nats https://nats-io.github.io/k8s/helm/charts"
         "qdrant https://qdrant.github.io/qdrant-helm"
@@ -112,6 +115,37 @@ setup_helm_repos() {
 
     helm repo update
     log_info "Helm repositories configured"
+}
+
+# Deploy Vault + External Secrets Operator
+deploy_secrets() {
+    log_info "Deploying secret management (Vault + ESO)..."
+    confirm "This will deploy HashiCorp Vault and External Secrets Operator. Continue?"
+
+    setup_helm_repos
+
+    # 1. Deploy Vault HA
+    log_step "Deploying HashiCorp Vault (HA with Consul backend)..."
+    helm upgrade --install vault hashicorp/vault \
+        -n ${NAMESPACE} \
+        -f ${VALUES_DIR}/vault.yaml \
+        --wait --timeout ${TIMEOUT}
+
+    # 2. Deploy External Secrets Operator
+    log_step "Deploying External Secrets Operator..."
+    helm upgrade --install external-secrets external-secrets/external-secrets \
+        -n external-secrets --create-namespace \
+        -f ${VALUES_DIR}/external-secrets.yaml \
+        --wait --timeout ${TIMEOUT}
+
+    # 3. Apply ClusterSecretStore and ExternalSecret CRs
+    log_step "Applying ClusterSecretStore and ExternalSecret manifests..."
+    kubectl apply -f "${MANIFESTS_DIR}/cluster-secret-store.yaml"
+    kubectl apply -f "${MANIFESTS_DIR}/external-secrets.yaml"
+
+    log_info "Secret management deployed!"
+    log_warn "If this is the first deployment, run: ./vault-init.sh"
+    log_warn "This will initialize Vault, unseal it, and seed secrets."
 }
 
 # Deploy etcd HA cluster
@@ -378,6 +412,7 @@ deploy_all() {
     log_info "Starting full production deployment..."
     confirm "This will deploy ALL components to PRODUCTION. Are you absolutely sure?"
 
+    deploy_secrets
     check_prerequisites
     deploy_infrastructure
     deploy_mlplatform
@@ -392,6 +427,7 @@ usage() {
     echo "Usage: $0 <command>"
     echo ""
     echo "Commands:"
+    echo "  secrets           Deploy Vault + External Secrets Operator"
     echo "  infrastructure    Deploy HA infrastructure (etcd, PostgreSQL, Redis, etc.)"
     echo "  services          Deploy application services via ArgoCD"
     echo "  mlplatform        Deploy ML platform (Ray, MLflow, JupyterHub)"
@@ -416,6 +452,9 @@ main() {
     shift || true
 
     case "${command}" in
+        secrets)
+            deploy_secrets
+            ;;
         infrastructure)
             check_prerequisites
             deploy_infrastructure

--- a/deployments/kubernetes/production/scripts/vault-init.sh
+++ b/deployments/kubernetes/production/scripts/vault-init.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+# =============================================================================
+# Vault Initialization & Secret Seeding Script
+# =============================================================================
+# Run ONCE after deploying Vault for the first time.
+# This script:
+#   1. Initializes Vault (generates unseal keys + root token)
+#   2. Unseals all Vault pods
+#   3. Enables the KV v2 secrets engine
+#   4. Enables Kubernetes auth for ESO
+#   5. Seeds initial infrastructure secrets (interactive prompts)
+#
+# Usage:
+#   ./vault-init.sh              # Full init + unseal + auth + seed
+#   ./vault-init.sh unseal       # Unseal only (after pod restart)
+#   ./vault-init.sh seed         # Seed/update secrets only
+#   ./vault-init.sh status       # Check Vault status
+#
+# IMPORTANT: Store the unseal keys and root token securely!
+#            The init output is saved to vault-init-keys.json (delete after saving).
+# =============================================================================
+
+set -e
+
+NAMESPACE="isa-cloud-production"
+VAULT_POD="vault-0"
+VAULT_PODS=("vault-0" "vault-1" "vault-2")
+KEYS_FILE="vault-init-keys.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_step() { echo -e "${CYAN}[STEP]${NC} $1"; }
+
+vault_exec() {
+    kubectl exec -n ${NAMESPACE} ${VAULT_POD} -- vault "$@"
+}
+
+# Check if Vault pods are running
+check_vault_pods() {
+    log_step "Checking Vault pods..."
+    for pod in "${VAULT_PODS[@]}"; do
+        if ! kubectl get pod -n ${NAMESPACE} ${pod} &>/dev/null; then
+            log_error "Vault pod ${pod} not found. Deploy Vault first."
+            exit 1
+        fi
+    done
+    log_info "All Vault pods found"
+}
+
+# Initialize Vault
+init_vault() {
+    log_step "Initializing Vault..."
+
+    # Check if already initialized
+    local status
+    status=$(kubectl exec -n ${NAMESPACE} ${VAULT_POD} -- vault status -format=json 2>/dev/null || true)
+    if echo "$status" | grep -q '"initialized":true'; then
+        log_warn "Vault is already initialized. Skipping init."
+        return 0
+    fi
+
+    # Initialize with 5 key shares, 3 threshold
+    kubectl exec -n ${NAMESPACE} ${VAULT_POD} -- \
+        vault operator init -key-shares=5 -key-threshold=3 -format=json > "${KEYS_FILE}"
+
+    log_info "Vault initialized. Keys saved to ${KEYS_FILE}"
+    log_warn "CRITICAL: Save the unseal keys and root token securely, then delete ${KEYS_FILE}!"
+    echo ""
+    echo "Root Token: $(jq -r '.root_token' ${KEYS_FILE})"
+    echo "Unseal Keys:"
+    jq -r '.unseal_keys_b64[]' ${KEYS_FILE} | head -5
+    echo ""
+}
+
+# Unseal all Vault pods
+unseal_vault() {
+    log_step "Unsealing Vault pods..."
+
+    if [ ! -f "${KEYS_FILE}" ]; then
+        log_error "Keys file not found: ${KEYS_FILE}"
+        log_info "Provide unseal keys manually:"
+        read -sp "Unseal Key 1: " key1; echo
+        read -sp "Unseal Key 2: " key2; echo
+        read -sp "Unseal Key 3: " key3; echo
+        local keys=("$key1" "$key2" "$key3")
+    else
+        local keys=()
+        while IFS= read -r key; do
+            keys+=("$key")
+        done < <(jq -r '.unseal_keys_b64[:3][]' "${KEYS_FILE}")
+    fi
+
+    for pod in "${VAULT_PODS[@]}"; do
+        log_info "Unsealing ${pod}..."
+        for key in "${keys[@]}"; do
+            kubectl exec -n ${NAMESPACE} ${pod} -- vault operator unseal "${key}" &>/dev/null || true
+        done
+    done
+
+    # Verify
+    for pod in "${VAULT_PODS[@]}"; do
+        local sealed
+        sealed=$(kubectl exec -n ${NAMESPACE} ${pod} -- vault status -format=json 2>/dev/null | jq -r '.sealed')
+        if [ "$sealed" = "false" ]; then
+            log_info "${pod}: unsealed"
+        else
+            log_error "${pod}: still sealed!"
+        fi
+    done
+}
+
+# Configure Vault for ESO
+configure_vault() {
+    log_step "Configuring Vault..."
+
+    # Login with root token
+    local root_token
+    if [ -f "${KEYS_FILE}" ]; then
+        root_token=$(jq -r '.root_token' "${KEYS_FILE}")
+    else
+        read -sp "Root Token: " root_token; echo
+    fi
+
+    kubectl exec -n ${NAMESPACE} ${VAULT_POD} -- vault login "${root_token}" &>/dev/null
+
+    # Enable KV v2 secrets engine
+    log_info "Enabling KV v2 secrets engine at 'secret/'..."
+    vault_exec secrets enable -path=secret kv-v2 2>/dev/null || log_warn "KV v2 already enabled"
+
+    # Enable Kubernetes auth
+    log_info "Enabling Kubernetes auth..."
+    vault_exec auth enable kubernetes 2>/dev/null || log_warn "Kubernetes auth already enabled"
+
+    # Configure Kubernetes auth to use in-cluster config
+    vault_exec write auth/kubernetes/config \
+        kubernetes_host="https://kubernetes.default.svc.cluster.local:443"
+
+    # Create policy for ESO to read secrets
+    log_info "Creating ESO read policy..."
+    kubectl exec -n ${NAMESPACE} ${VAULT_POD} -- /bin/sh -c 'vault policy write external-secrets - <<POLICY
+path "secret/data/isa-cloud/*" {
+  capabilities = ["read"]
+}
+path "secret/metadata/isa-cloud/*" {
+  capabilities = ["read", "list"]
+}
+POLICY'
+
+    # Create Kubernetes auth role for ESO
+    log_info "Creating Kubernetes auth role for ESO..."
+    vault_exec write auth/kubernetes/role/external-secrets \
+        bound_service_account_names=external-secrets \
+        bound_service_account_namespaces=external-secrets \
+        policies=external-secrets \
+        ttl=1h
+
+    log_info "Vault configured for ESO"
+}
+
+# Seed infrastructure secrets
+seed_secrets() {
+    log_step "Seeding infrastructure secrets in Vault..."
+    log_warn "You will be prompted for each secret value."
+    echo ""
+
+    # Login
+    local root_token
+    if [ -f "${KEYS_FILE}" ]; then
+        root_token=$(jq -r '.root_token' "${KEYS_FILE}")
+    else
+        read -sp "Root Token: " root_token; echo
+    fi
+    kubectl exec -n ${NAMESPACE} ${VAULT_POD} -- vault login "${root_token}" &>/dev/null
+
+    # PostgreSQL
+    log_info "PostgreSQL secrets:"
+    read -sp "  postgresql-password: " pg_pass; echo
+    read -sp "  replication-password: " pg_repl; echo
+    read -sp "  pgpool-admin-password: " pg_pool; echo
+    vault_exec kv put secret/isa-cloud/production/postgresql \
+        password="${pg_pass}" \
+        replication-password="${pg_repl}" \
+        pgpool-admin-password="${pg_pool}"
+    log_info "PostgreSQL secrets stored"
+
+    # Redis
+    log_info "Redis secrets:"
+    read -sp "  redis-password: " redis_pass; echo
+    vault_exec kv put secret/isa-cloud/production/redis \
+        password="${redis_pass}"
+    log_info "Redis secrets stored"
+
+    # Neo4j
+    log_info "Neo4j secrets:"
+    read -sp "  neo4j-password: " neo4j_pass; echo
+    vault_exec kv put secret/isa-cloud/production/neo4j \
+        password="${neo4j_pass}"
+    log_info "Neo4j secrets stored"
+
+    # MinIO
+    log_info "MinIO secrets:"
+    read -p "  root-user [minioadmin]: " minio_user
+    minio_user=${minio_user:-minioadmin}
+    read -sp "  root-password: " minio_pass; echo
+    vault_exec kv put secret/isa-cloud/production/minio \
+        root-user="${minio_user}" \
+        root-password="${minio_pass}"
+    log_info "MinIO secrets stored"
+
+    # EMQX
+    log_info "EMQX secrets:"
+    read -sp "  dashboard-password: " emqx_pass; echo
+    vault_exec kv put secret/isa-cloud/production/emqx \
+        dashboard-password="${emqx_pass}"
+    log_info "EMQX secrets stored"
+
+    # APISIX
+    log_info "APISIX secrets:"
+    read -sp "  admin-key: " apisix_key; echo
+    vault_exec kv put secret/isa-cloud/production/apisix \
+        admin-key="${apisix_key}"
+    log_info "APISIX secrets stored"
+
+    echo ""
+    log_info "All infrastructure secrets seeded in Vault"
+    log_info "ESO will sync them to K8s Secrets within the refresh interval (1h)"
+    log_info "To force immediate sync: kubectl annotate externalsecret -n isa-cloud-production --all force-sync=$(date +%s)"
+}
+
+# Check Vault status
+check_status() {
+    log_step "Vault status:"
+    echo ""
+
+    for pod in "${VAULT_PODS[@]}"; do
+        echo -e "${CYAN}--- ${pod} ---${NC}"
+        kubectl exec -n ${NAMESPACE} ${pod} -- vault status 2>/dev/null || echo "  Not reachable"
+        echo ""
+    done
+
+    # Check ExternalSecrets sync status
+    echo -e "${CYAN}--- ExternalSecret sync status ---${NC}"
+    kubectl get externalsecret -n isa-cloud-production 2>/dev/null || echo "  No ExternalSecrets found"
+}
+
+# Full initialization
+full_init() {
+    check_vault_pods
+    init_vault
+    unseal_vault
+    configure_vault
+    seed_secrets
+
+    echo ""
+    log_info "Vault fully initialized and configured!"
+    log_warn "REMINDER: Save unseal keys + root token securely, then delete ${KEYS_FILE}"
+}
+
+# Main
+main() {
+    local command="${1:-}"
+
+    case "${command}" in
+        unseal)
+            check_vault_pods
+            unseal_vault
+            ;;
+        seed)
+            check_vault_pods
+            seed_secrets
+            ;;
+        status)
+            check_status
+            ;;
+        configure)
+            check_vault_pods
+            configure_vault
+            ;;
+        -h|--help)
+            echo "Usage: $0 [unseal|seed|status|configure]"
+            echo "  (no args)   Full init + unseal + configure + seed"
+            echo "  unseal      Unseal Vault pods (after restart)"
+            echo "  seed        Seed/update secrets interactively"
+            echo "  status      Check Vault and ExternalSecret status"
+            echo "  configure   Re-run Vault auth/policy configuration"
+            ;;
+        "")
+            full_init
+            ;;
+        *)
+            log_error "Unknown command: ${command}"
+            echo "Usage: $0 [unseal|seed|status|configure]"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/deployments/kubernetes/production/values/external-secrets.yaml
+++ b/deployments/kubernetes/production/values/external-secrets.yaml
@@ -1,0 +1,52 @@
+# External Secrets Operator Helm Values - PRODUCTION
+# Chart: external-secrets/external-secrets
+# Install: helm install external-secrets external-secrets/external-secrets \
+#   -n external-secrets --create-namespace -f production/values/external-secrets.yaml
+#
+# ESO syncs secrets from HashiCorp Vault into native K8s Secrets.
+# ClusterSecretStore and ExternalSecret CRs are in manifests/.
+
+installCRDs: true
+
+replicaCount: 2
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# Webhook for validation
+webhook:
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+# Cert controller for webhook TLS
+certController:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+# Metrics for Prometheus scraping
+serviceMonitor:
+  enabled: false  # Enable when Prometheus is deployed (#68)
+
+# Log level
+log:
+  level: info
+
+# Leader election for HA
+leaderElect: true

--- a/deployments/kubernetes/production/values/vault.yaml
+++ b/deployments/kubernetes/production/values/vault.yaml
@@ -1,0 +1,98 @@
+# HashiCorp Vault Helm Values - PRODUCTION
+# Chart: hashicorp/vault
+# Install: helm install vault hashicorp/vault -n isa-cloud-production -f production/values/vault.yaml
+#
+# Vault uses Consul as its storage backend (already deployed in the cluster).
+# HA mode with 3 replicas for production resilience.
+
+global:
+  enabled: true
+
+server:
+  enabled: true
+
+  # HA mode with Consul storage backend
+  ha:
+    enabled: true
+    replicas: 3
+
+    # Raft is simpler but we already have Consul — use it as the backend
+    raft:
+      enabled: false
+
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+
+      storage "consul" {
+        path = "vault/"
+        address = "consul-server.isa-cloud-production.svc.cluster.local:8500"
+      }
+
+      service_registration "kubernetes" {}
+
+      # Seal configuration — use Kubernetes auth by default.
+      # For auto-unseal, configure a transit seal or cloud KMS.
+      # See vault-init.sh for manual unseal workflow.
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+  # Persistent audit logs
+  auditStorage:
+    enabled: true
+    size: 10Gi
+
+  # Data storage (handled by Consul, but keep for audit)
+  dataStorage:
+    enabled: false
+
+  # Readiness/liveness probes
+  readinessProbe:
+    enabled: true
+    path: "/v1/sys/health?standbyok=true&sealedcode=204&uninitcode=204"
+  livenessProbe:
+    enabled: true
+    path: "/v1/sys/health?standbyok=true"
+    initialDelaySeconds: 60
+
+  # Service configuration
+  service:
+    enabled: true
+    type: ClusterIP
+    port: 8200
+
+  # Standalone mode (disabled — using HA)
+  standalone:
+    enabled: false
+
+# =============================================================================
+# INJECTOR (Vault Agent Sidecar Injector)
+# =============================================================================
+# Disabled — we use External Secrets Operator instead of the injector.
+# ESO creates native K8s Secrets, which is simpler and works with any workload.
+injector:
+  enabled: false
+
+# =============================================================================
+# UI
+# =============================================================================
+ui:
+  enabled: true
+  serviceType: ClusterIP
+
+# =============================================================================
+# CSI PROVIDER
+# =============================================================================
+csi:
+  enabled: false


### PR DESCRIPTION
## Summary

Replaces manual `<REPLACE_WITH_STRONG_PASSWORD>` secret templates with **HashiCorp Vault** (HA, Consul backend) and **External Secrets Operator** for automated production secret management. Vault stores secrets centrally with audit logging, and ESO syncs them to native K8s Secrets via ExternalSecret CRs.

## Changes

- **Vault Helm values** (`values/vault.yaml`): HA mode with 3 replicas, Consul storage backend, audit logging enabled
- **ESO Helm values** (`values/external-secrets.yaml`): 2 replicas, HA webhook, leader election
- **ArgoCD apps** (`secret-management.yaml`): Sync-wave ordering — Vault (wave -2) → ESO (wave -1) → CRs (wave 0)
- **ClusterSecretStore** (`cluster-secret-store.yaml`): Connects ESO to Vault via Kubernetes auth
- **6 ExternalSecret CRs** (`external-secrets.yaml`): postgresql, redis, neo4j, minio, emqx, apisix — maps Vault paths to the K8s Secret names Helm values already expect
- **vault-init.sh**: Interactive script for init, unseal, K8s auth config, and secret seeding
- **deploy.sh**: Added `secrets` command, ESO Helm repo, updated prerequisite messages
- **README.md**: Full Vault + ESO workflow docs replacing the old AWS Secrets Manager snippet
- **apisix-secrets.yaml**: Marked deprecated (now managed by ESO)

## Architecture

```
Vault (HA, Consul backend)
  └── ClusterSecretStore (K8s auth)
       └── ExternalSecret CRs (hourly refresh)
            └── K8s Secrets (postgresql-secret, redis-secret, etc.)
```

## Deployment Flow

```bash
./deploy.sh secrets       # Install Vault + ESO
./vault-init.sh           # Init → unseal → configure K8s auth → seed secrets
./deploy.sh infrastructure # Services find secrets ready
```

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | YAML validation | Pass |
| L2 Component | Shell syntax check | Pass |
| L3 Integration | - | N/A (requires cluster) |
| L4 API | - | N/A |
| L5 Smoke | - | N/A (deploy to staging first) |

## Related Issues
Fixes #67
**Parent Epic**: #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)