### PR TITLE
Add unit tests for shared Prometheus metrics client

### DIFF
--- a/isA_common/tests/unit/test_metrics_unit.py
+++ b/isA_common/tests/unit/test_metrics_unit.py
@@ -2,7 +2,15 @@
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
-from prometheus_client import CollectorRegistry
+try:
+    from prometheus_client import CollectorRegistry
+    _HAS_PROMETHEUS = True
+except ImportError:
+    _HAS_PROMETHEUS = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_PROMETHEUS, reason="prometheus_client not installed"
+)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Adds 40 unit tests for `isa_common.metrics` covering naming convention, path normalization, metric factory functions, no-op fallback, `setup_metrics()`, and `metrics_text()`
- Completes the final acceptance criterion for #93 — the metrics module implementation was already in place

Fixes #93

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 40 | Pass |
| L2 Component | N/A | N/A |
| L3 Integration | N/A | N/A |
| L4 API | N/A | N/A |
| L5 Smoke | N/A | N/A |

### Test Groups
- **TestMetricName** (6): `isa_{service}_{name}` convention, dash/space handling, prefix dedup
- **TestNormalizePath** (7): UUID replacement, numeric ID collapsing, edge cases
- **TestNoOpMetric** (4): Safe no-op for all metric operations when prometheus_client absent
- **TestBucketConfigs** (5): Bucket ordering and relative sizing invariants
- **TestCreateCounter/Histogram/Gauge** (6): Factory functions with isolated registries
- **TestGracefulDegradation** (4): All factories return NoOp when prometheus_client unavailable
- **TestSetupMetrics** (5): Middleware registration, route addition, common metric init
- **TestMetricsText** (2): Prometheus text format output
- **TestExcludedPaths** (1): Default health/metrics paths excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)