### PR TITLE
feat(infra): configure Prometheus service discovery and scrape targets

### DIFF
--- a/configs/local/prometheus.yml
+++ b/configs/local/prometheus.yml
@@ -13,21 +13,29 @@ scrape_configs:
       - targets: ['localhost:9090']
 
   # isA platform services (docker-compose)
-  # Add service targets as they expose /metrics endpoints
+  # Services use isa_common.metrics.setup_metrics() which exposes /metrics
   - job_name: 'isa-services'
-    static_configs: []
-    # Example — uncomment when services expose metrics:
-    # - targets: ['isa-gateway:8080']
-    #   labels:
-    #     app: isa-gateway
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['isa-gateway:8000']
+        labels:
+          app: isa-gateway
+      - targets: ['isa-mcp:8081']
+        labels:
+          app: isa-mcp
+      - targets: ['isa-model:8082']
+        labels:
+          app: isa-model
+      - targets: ['isa-agent:8080']
+        labels:
+          app: isa-agent
 
-  # Infrastructure services with metrics support
-  # Redis requires redis-exporter sidecar — uncomment when available:
-  # - job_name: 'redis'
-  #   static_configs:
-  #     - targets: ['redis-exporter:9121']
-  #       labels:
-  #         app: redis
+  # Infrastructure exporters
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['redis-exporter:9121']
+        labels:
+          app: redis
 
   - job_name: 'nats'
     metrics_path: /metrics
@@ -35,3 +43,16 @@ scrape_configs:
       - targets: ['nats:8222']
         labels:
           app: nats
+
+  - job_name: 'postgresql'
+    static_configs:
+      - targets: ['postgres-exporter:9187']
+        labels:
+          app: postgresql
+
+  - job_name: 'minio'
+    metrics_path: /minio/v2/metrics/cluster
+    static_configs:
+      - targets: ['minio:9000']
+        labels:
+          app: minio

--- a/deployments/kubernetes/local/values/minio.yaml
+++ b/deployments/kubernetes/local/values/minio.yaml
@@ -55,7 +55,7 @@ podLabels:
   tier: infrastructure
   environment: local
 
-# Disable metrics for local
+# Metrics
 metrics:
   serviceMonitor:
-    enabled: false
+    enabled: false  # No Prometheus Operator in local — uses annotation-based scraping instead

--- a/deployments/kubernetes/local/values/postgresql.yaml
+++ b/deployments/kubernetes/local/values/postgresql.yaml
@@ -51,6 +51,13 @@ primary:
     nodePorts:
       postgresql: 30432  # NodePort must be 30000-32767
 
-# Disable metrics for lighter footprint
+# Metrics (postgres-exporter sidecar)
 metrics:
-  enabled: false
+  enabled: true
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi

--- a/deployments/kubernetes/local/values/redis.yaml
+++ b/deployments/kubernetes/local/values/redis.yaml
@@ -45,6 +45,13 @@ master:
 replica:
   replicaCount: 0
 
-# Disable metrics for lighter footprint
+# Metrics (redis-exporter sidecar)
 metrics:
-  enabled: false
+  enabled: true
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi

--- a/deployments/kubernetes/production/manifests/prometheus-service-monitors.yaml
+++ b/deployments/kubernetes/production/manifests/prometheus-service-monitors.yaml
@@ -1,0 +1,166 @@
+# ServiceMonitor CRDs for isA platform services
+# Requires: Prometheus Operator (kube-prometheus-stack) in the cluster.
+# These complement the per-chart serviceMonitor configs (Redis, PostgreSQL, etc.)
+# by covering isA application services that use isa_common.metrics.setup_metrics().
+#
+# All ServiceMonitors use the label "release: prometheus" for operator discovery.
+---
+# isA Application Services — auto-discovers any service with prometheus.io annotations
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: isa-application-services
+  namespace: isa-cloud-production
+  labels:
+    release: prometheus
+    tier: application
+spec:
+  namespaceSelector:
+    matchNames:
+      - isa-cloud-production
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/part-of
+        operator: In
+        values:
+          - isa-platform
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      honorLabels: true
+---
+# isA Gateway — primary entry point, higher scrape frequency
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: isa-gateway
+  namespace: isa-cloud-production
+  labels:
+    release: prometheus
+    tier: application
+spec:
+  namespaceSelector:
+    matchNames:
+      - isa-cloud-production
+  selector:
+    matchLabels:
+      app: isa-gateway
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s
+---
+# isA MCP Tool Server
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: isa-mcp
+  namespace: isa-cloud-production
+  labels:
+    release: prometheus
+    tier: application
+spec:
+  namespaceSelector:
+    matchNames:
+      - isa-cloud-production
+  selector:
+    matchLabels:
+      app: isa-mcp
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+# isA Model Router
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: isa-model
+  namespace: isa-cloud-production
+  labels:
+    release: prometheus
+    tier: application
+spec:
+  namespaceSelector:
+    matchNames:
+      - isa-cloud-production
+  selector:
+    matchLabels:
+      app: isa-model
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+# isA Agent Service
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: isa-agent
+  namespace: isa-cloud-production
+  labels:
+    release: prometheus
+    tier: application
+spec:
+  namespaceSelector:
+    matchNames:
+      - isa-cloud-production
+  selector:
+    matchLabels:
+      app: isa-agent
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+# APISIX Gateway — scrape its built-in Prometheus plugin
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: apisix-gateway
+  namespace: isa-cloud-production
+  labels:
+    release: prometheus
+    tier: infrastructure
+spec:
+  namespaceSelector:
+    matchNames:
+      - isa-cloud-production
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: apisix
+  endpoints:
+    - port: prometheus
+      path: /apisix/prometheus/metrics
+      interval: 15s
+      scrapeTimeout: 10s
+---
+# Consul — scrape telemetry endpoint
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: consul
+  namespace: isa-cloud-production
+  labels:
+    release: prometheus
+    tier: infrastructure
+spec:
+  namespaceSelector:
+    matchNames:
+      - isa-cloud-production
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: consul
+  endpoints:
+    - port: http
+      path: /v1/agent/metrics
+      params:
+        format: ["prometheus"]
+      interval: 30s
+      scrapeTimeout: 10s


### PR DESCRIPTION
## Summary
- Populate local docker-compose Prometheus with isA service scrape targets and infrastructure exporter jobs (Redis, PostgreSQL, MinIO)
- Enable metrics exporter sidecars for Redis and PostgreSQL in local K8s Helm values
- Add production ServiceMonitor CRDs for all isA application services (gateway, mcp, model, agent) plus APISIX and Consul

Fixes #68
**Parent Epic**: #62

## Test plan
- [ ] `helm upgrade prometheus` in local cluster and verify new scrape targets appear in Prometheus UI (`/targets`)
- [ ] Verify `up{}` metric shows Redis and PostgreSQL exporter targets
- [ ] Apply ServiceMonitor CRDs to production namespace and verify Prometheus Operator picks them up
- [ ] Check Grafana for `isa_*` metrics from application services

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 0 | N/A (infra config) |
| L5 Smoke | Manual | See test plan above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)