### PR TITLE
feat(infra): add PodDisruptionBudget to isa-service Helm chart

### DIFF
--- a/deployments/charts/isa-service/templates/pdb.yaml
+++ b/deployments/charts/isa-service/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (int (default .Values.replicas .Values.autoscaling.minReplicas)) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+{{- end }}

--- a/deployments/charts/isa-service/values.yaml
+++ b/deployments/charts/isa-service/values.yaml
@@ -60,6 +60,13 @@ autoscaling:
   targetCPUUtilization: 70
   targetMemoryUtilization: 80
 
+# Pod Disruption Budget (enabled by default when replicas > 1)
+podDisruptionBudget:
+  enabled: true
+  # Set one of minAvailable or maxUnavailable (not both)
+  # minAvailable: 1
+  maxUnavailable: 1
+
 # Health checks
 health:
   path: /health


### PR DESCRIPTION
## Summary
- Added `pdb.yaml` template to `deployments/charts/isa-service/templates/`
- PDB is enabled by default when `replicas > 1` (or `autoscaling.minReplicas > 1`)
- Configurable via `podDisruptionBudget.maxUnavailable` (default: 1) or `podDisruptionBudget.minAvailable`

Fixes #73
**Parent Epic**: #62

## Test plan
- [x] `helm lint` passes
- [x] PDB renders correctly with `replicas=3` (maxUnavailable: 1)
- [x] PDB is not rendered with `replicas=1, minReplicas=1`
- [ ] Verify PDB works during a rolling update in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)