### PR TITLE
fix(core): fix client bugs in MinIO, LocalStorage, MQTT, DuckDB

### DIFF
--- a/isA_common/isa_common/async_duckdb_client.py
+++ b/isA_common/isa_common/async_duckdb_client.py
@@ -120,7 +120,7 @@ class AsyncDuckDBClient(AsyncBaseClient):
         if self._conn:
             self._conn.close()
             self._conn = None
-        self._executor.shutdown(wait=False)
+        self._executor.shutdown(wait=True, cancel_futures=True)
 
     async def _run_in_executor(self, func, *args, **kwargs):
         """Run blocking DuckDB operation in thread pool."""

--- a/isA_common/isa_common/async_local_storage_client.py
+++ b/isA_common/isa_common/async_local_storage_client.py
@@ -107,10 +107,22 @@ class AsyncLocalStorageClient(AsyncBaseClient):
         return self._get_user_path() / safe_bucket
 
     def _get_object_path(self, bucket_name: str, object_key: str) -> Path:
-        """Get full path for an object."""
+        """Get full path for an object.
+
+        Validates that the resolved path stays within the bucket directory
+        to prevent path traversal attacks.
+        """
         bucket_path = self._get_bucket_path(bucket_name)
         # Preserve object key path structure
-        return bucket_path / object_key
+        object_path = bucket_path / object_key
+        # Prevent path traversal (e.g. ../../etc/passwd)
+        try:
+            object_path.resolve().relative_to(bucket_path.resolve())
+        except ValueError:
+            raise ValueError(
+                f"Invalid object key '{object_key}': path traversal detected"
+            )
+        return object_path
 
     def _get_metadata_path(self, object_path: Path) -> Path:
         """Get metadata sidecar file path."""

--- a/isA_common/isa_common/async_minio_client.py
+++ b/isA_common/isa_common/async_minio_client.py
@@ -99,7 +99,7 @@ class AsyncMinIOClient(AsyncBaseClient):
     async def _connect(self) -> None:
         """Create aioboto3 session."""
         self._session = aioboto3.Session()
-        self._self._logger.info(f"Created aioboto3 session for {self._endpoint_url}")
+        self._logger.info(f"Created aioboto3 session for {self._endpoint_url}")
 
     async def _disconnect(self) -> None:
         """Close aioboto3 session."""

--- a/isA_common/isa_common/async_mqtt_client.py
+++ b/isA_common/isa_common/async_mqtt_client.py
@@ -17,7 +17,7 @@ import asyncio
 import json
 import uuid
 from typing import List, Dict, Optional, AsyncIterator, Any
-from datetime import datetime
+from datetime import datetime, timezone
 
 import aiomqtt
 
@@ -83,7 +83,8 @@ class AsyncMQTTClient(AsyncBaseClient):
         self._logger.info(f"MQTT client ready for {self._host}:{self._port}")
 
     async def _disconnect(self) -> None:
-        """Close MQTT connection state."""
+        """Close MQTT connection state and clean up subscriptions."""
+        self._subscriptions.clear()
         self._sessions.clear()
 
     def _get_client_config(self) -> Dict:
@@ -135,7 +136,7 @@ class AsyncMQTTClient(AsyncBaseClient):
             self._sessions[session_id] = {
                 'client_id': client_id,
                 'username': username,
-                'connected_at': datetime.utcnow().isoformat(),
+                'connected_at': datetime.now(timezone.utc).isoformat(),
                 'messages_sent': 0,
                 'messages_received': 0
             }
@@ -288,7 +289,7 @@ class AsyncMQTTClient(AsyncBaseClient):
                         'payload': message.payload,
                         'qos': message.qos,
                         'retained': message.retain,
-                        'timestamp': datetime.utcnow().isoformat()
+                        'timestamp': datetime.now(timezone.utc).isoformat()
                     }
 
         except Exception as e:
@@ -324,7 +325,7 @@ class AsyncMQTTClient(AsyncBaseClient):
                         'payload': message.payload,
                         'qos': message.qos,
                         'retained': message.retain,
-                        'timestamp': datetime.utcnow().isoformat()
+                        'timestamp': datetime.now(timezone.utc).isoformat()
                     }
 
         except Exception as e:
@@ -374,8 +375,8 @@ class AsyncMQTTClient(AsyncBaseClient):
                 'device_name': device_name,
                 'device_type': device_type,
                 'status': 1,  # online
-                'registered_at': datetime.utcnow().isoformat(),
-                'last_seen': datetime.utcnow().isoformat(),
+                'registered_at': datetime.now(timezone.utc).isoformat(),
+                'last_seen': datetime.now(timezone.utc).isoformat(),
                 'metadata': metadata or {},
                 'subscribed_topics': [],
                 'messages_sent': 0,
@@ -440,7 +441,7 @@ class AsyncMQTTClient(AsyncBaseClient):
         try:
             if device_id in self._devices:
                 self._devices[device_id]['status'] = status
-                self._devices[device_id]['last_seen'] = datetime.utcnow().isoformat()
+                self._devices[device_id]['last_seen'] = datetime.now(timezone.utc).isoformat()
                 if metadata:
                     self._devices[device_id]['metadata'].update(metadata)
 
@@ -546,7 +547,7 @@ class AsyncMQTTClient(AsyncBaseClient):
                                     'topic': str(message.topic),
                                     'payload': message.payload,
                                     'qos': message.qos,
-                                    'timestamp': datetime.utcnow().isoformat()
+                                    'timestamp': datetime.now(timezone.utc).isoformat()
                                 }
                             break
                 except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary
- **AsyncMinIOClient**: fix `self._self._logger` typo in `_connect()` that caused `AttributeError` on every connection attempt
- **AsyncLocalStorageClient**: add path traversal validation in `_get_object_path()` to prevent `../../` escapes
- **AsyncMQTTClient**: replace 7x deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`; clear subscriptions on `_disconnect()`
- **AsyncDuckDBClient**: use `shutdown(wait=True, cancel_futures=True)` to prevent orphaned threads

Fixes #117, #118, #120, #123. Partial fix for #122.

**Parent Epic**: #92

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 205 | Pass |
| L2 Component | 42 | Pass |
| L3 Integration | N/A | — |
| L4 API | N/A | — |
| L5 Smoke | N/A | — |

## Test plan
- [x] All 247 existing unit + component tests pass
- [ ] Manual: verify AsyncMinIOClient connects without AttributeError
- [ ] Manual: verify LocalStorage rejects `../` in object keys
- [ ] Manual: verify MQTT client has no deprecation warnings on Python 3.12+

🤖 Generated with [Claude Code](https://claude.com/claude-code)