### PR TITLE
fix(core): fix deprecated datetime, resource leaks, and executor shutdown

### DIFF
--- a/isA_common/isa_common/async_chroma_client.py
+++ b/isA_common/isa_common/async_chroma_client.py
@@ -100,7 +100,7 @@ class AsyncChromaClient(AsyncBaseClient):
             self._client = None
 
         if self._executor:
-            self._executor.shutdown(wait=False)
+            self._executor.shutdown(wait=True, cancel_futures=True)
             self._executor = None
 
     def _run_sync(self, func, *args, **kwargs):

--- a/isA_common/isa_common/async_local_storage_client.py
+++ b/isA_common/isa_common/async_local_storage_client.py
@@ -82,7 +82,7 @@ class AsyncLocalStorageClient(AsyncBaseClient):
     async def _disconnect(self) -> None:
         """Cleanup."""
         if self._executor:
-            self._executor.shutdown(wait=False)
+            self._executor.shutdown(wait=True, cancel_futures=True)
             self._executor = None
 
     def _get_user_path(self) -> Path:

--- a/isA_common/isa_common/async_mqtt_client.py
+++ b/isA_common/isa_common/async_mqtt_client.py
@@ -82,6 +82,16 @@ class AsyncMQTTClient(AsyncBaseClient):
         """MQTT uses context manager for connections, just log ready state."""
         self._logger.info(f"MQTT client ready for {self._host}:{self._port}")
 
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Clean up MQTT resources on context exit."""
+        try:
+            self._subscriptions.clear()
+            self._sessions.clear()
+            self._devices.clear()
+        except Exception as e:
+            self._logger.debug(f"MQTT cleanup during exit: {e}")
+        await self.close()
+
     async def _disconnect(self) -> None:
         """Close MQTT connection state and clean up subscriptions."""
         self._subscriptions.clear()

--- a/isA_common/isa_common/async_nats_client.py
+++ b/isA_common/isa_common/async_nats_client.py
@@ -231,6 +231,20 @@ class AsyncNATSClient(AsyncBaseClient):
             self._js = None
         self._connected = False
 
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Clean up NATS resources on context exit."""
+        try:
+            # Unsubscribe all active subscriptions
+            for subject, sub in list(self._subscriptions.items()):
+                try:
+                    await sub.unsubscribe()
+                except Exception as e:
+                    self._logger.debug(f"NATS unsubscribe {subject} during exit: {e}")
+            self._subscriptions.clear()
+        except Exception as e:
+            self._logger.debug(f"NATS subscription cleanup during exit: {e}")
+        await self.close()
+
     async def close(self) -> None:
         """Close NATS connection even if state flag is stale."""
         if self._nc is not None or self._connected:

--- a/isA_common/isa_common/events/base_event_models.py
+++ b/isA_common/isa_common/events/base_event_models.py
@@ -6,7 +6,7 @@ Base Event Models
 Generic event models that can be extended by business-specific implementations.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Dict, Any
 from decimal import Decimal
 from pydantic import BaseModel, Field
@@ -19,11 +19,11 @@ class EventMetadata(BaseModel):
     This provides consistent tracking across all event types.
     """
     event_id: str = Field(
-        default_factory=lambda: f"evt_{datetime.utcnow().timestamp()}",
+        default_factory=lambda: f"evt_{datetime.now(timezone.utc).timestamp()}",
         description="Unique event identifier"
     )
     timestamp: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=lambda: datetime.now(timezone.utc),
         description="Event creation timestamp"
     )
     source_service: Optional[str] = Field(

--- a/isA_common/isa_common/events/billing_events.py
+++ b/isA_common/isa_common/events/billing_events.py
@@ -7,7 +7,7 @@ This provides loose coupling, better scalability, and fault tolerance.
 
 from enum import Enum
 from typing import Optional, Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from pydantic import BaseModel, Field
 
@@ -55,7 +55,7 @@ class UsageEvent(BaseModel):
     Example: usage.recorded.gpt-4, usage.recorded.dall-e-3
     """
     event_type: str = EventType.USAGE_RECORDED
-    event_id: str = Field(default_factory=lambda: f"evt_{datetime.utcnow().timestamp()}")
+    event_id: str = Field(default_factory=lambda: f"evt_{datetime.now(timezone.utc).timestamp()}")
 
     # User context
     user_id: str = Field(..., description="User who triggered the usage")
@@ -73,7 +73,7 @@ class UsageEvent(BaseModel):
 
     # Metadata
     usage_details: Dict[str, Any] = Field(default_factory=dict, description="Additional context")
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     class Config:
         json_encoders = {
@@ -96,7 +96,7 @@ class BillingCalculatedEvent(BaseModel):
     NATS Subject: billing.calculated
     """
     event_type: str = EventType.COST_CALCULATED
-    event_id: str = Field(default_factory=lambda: f"evt_{datetime.utcnow().timestamp()}")
+    event_id: str = Field(default_factory=lambda: f"evt_{datetime.now(timezone.utc).timestamp()}")
 
     # References
     user_id: str
@@ -123,7 +123,7 @@ class BillingCalculatedEvent(BaseModel):
     is_free_tier: bool = False
     is_included_in_subscription: bool = False
 
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     class Config:
         json_encoders = {
@@ -142,7 +142,7 @@ class BillingErrorEvent(BaseModel):
     NATS Subject: billing.failed
     """
     event_type: str = EventType.BILLING_FAILED
-    event_id: str = Field(default_factory=lambda: f"evt_{datetime.utcnow().timestamp()}")
+    event_id: str = Field(default_factory=lambda: f"evt_{datetime.now(timezone.utc).timestamp()}")
 
     user_id: str
     usage_event_id: str
@@ -152,7 +152,7 @@ class BillingErrorEvent(BaseModel):
     error_message: str
     retry_count: int = 0
 
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     class Config:
         json_encoders = {
@@ -174,7 +174,7 @@ class TokensDeductedEvent(BaseModel):
     NATS Subject: wallet.tokens.deducted
     """
     event_type: str = EventType.TOKENS_DEDUCTED
-    event_id: str = Field(default_factory=lambda: f"evt_{datetime.utcnow().timestamp()}")
+    event_id: str = Field(default_factory=lambda: f"evt_{datetime.now(timezone.utc).timestamp()}")
 
     # References
     user_id: str
@@ -191,7 +191,7 @@ class TokensDeductedEvent(BaseModel):
     monthly_used: Optional[Decimal] = Field(None, description="Tokens used this month")
     percentage_used: Optional[float] = Field(None, description="% of monthly quota used")
 
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     class Config:
         json_encoders = {
@@ -210,7 +210,7 @@ class TokensInsufficientEvent(BaseModel):
     NATS Subject: wallet.tokens.insufficient
     """
     event_type: str = EventType.TOKENS_INSUFFICIENT
-    event_id: str = Field(default_factory=lambda: f"evt_{datetime.utcnow().timestamp()}")
+    event_id: str = Field(default_factory=lambda: f"evt_{datetime.now(timezone.utc).timestamp()}")
 
     user_id: str
     billing_record_id: str
@@ -221,7 +221,7 @@ class TokensInsufficientEvent(BaseModel):
 
     suggested_action: str = "upgrade_plan"  # or "purchase_tokens"
 
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     class Config:
         json_encoders = {

--- a/isA_common/tests/test_webhook_server.py
+++ b/isA_common/tests/test_webhook_server.py
@@ -6,7 +6,7 @@
 
 from flask import Flask, request, jsonify
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 app = Flask(__name__)
 
@@ -24,7 +24,7 @@ def handle_mqtt_webhook():
         headers = dict(request.headers)
 
         # 记录时间
-        received_at = datetime.utcnow().isoformat()
+        received_at = datetime.now(timezone.utc).isoformat()
 
         # 保存消息
         webhook_message = {

--- a/isA_common/tests/unit/test_client_aexit_cleanup.py
+++ b/isA_common/tests/unit/test_client_aexit_cleanup.py
@@ -1,0 +1,145 @@
+"""Unit tests for #122 — verify NATS and MQTT clients clean up on context exit."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestNATSClientAexit:
+    """AsyncNATSClient must clean up subscriptions and close on __aexit__."""
+
+    async def test_aexit_calls_close(self):
+        from isa_common import AsyncNATSClient
+
+        client = AsyncNATSClient(host="localhost", port=4222, lazy_connect=True)
+        client._connected = True
+        client._nc = AsyncMock()
+        client._nc.is_connected = True
+        client._nc.is_closed = False
+        client._nc.drain = AsyncMock()
+        client._nc.close = AsyncMock()
+        client._js = MagicMock()
+
+        await client.__aexit__(None, None, None)
+
+        assert client._connected is False
+
+    async def test_aexit_unsubscribes_active_subscriptions(self):
+        from isa_common import AsyncNATSClient
+
+        client = AsyncNATSClient(host="localhost", port=4222, lazy_connect=True)
+        client._connected = True
+        client._nc = AsyncMock()
+        client._nc.is_connected = True
+        client._nc.is_closed = False
+        client._nc.drain = AsyncMock()
+        client._nc.close = AsyncMock()
+        client._js = MagicMock()
+
+        # Add mock subscriptions
+        mock_sub = AsyncMock()
+        mock_sub.unsubscribe = AsyncMock()
+        client._subscriptions["test.subject"] = mock_sub
+
+        await client.__aexit__(None, None, None)
+
+        mock_sub.unsubscribe.assert_awaited_once()
+        assert len(client._subscriptions) == 0
+
+    async def test_aexit_handles_unsubscribe_error(self):
+        from isa_common import AsyncNATSClient
+
+        client = AsyncNATSClient(host="localhost", port=4222, lazy_connect=True)
+        client._connected = True
+        client._nc = AsyncMock()
+        client._nc.is_connected = True
+        client._nc.is_closed = False
+        client._nc.drain = AsyncMock()
+        client._nc.close = AsyncMock()
+        client._js = MagicMock()
+
+        mock_sub = AsyncMock()
+        mock_sub.unsubscribe = AsyncMock(side_effect=Exception("already unsubscribed"))
+        client._subscriptions["test.subject"] = mock_sub
+
+        # Should not raise
+        await client.__aexit__(None, None, None)
+        assert client._connected is False
+
+    async def test_aexit_cleans_up_on_exception(self):
+        from isa_common import AsyncNATSClient
+
+        client = AsyncNATSClient(host="localhost", port=4222, lazy_connect=True)
+        client._connected = True
+        client._nc = AsyncMock()
+        client._nc.is_connected = True
+        client._nc.is_closed = False
+        client._nc.drain = AsyncMock()
+        client._nc.close = AsyncMock()
+        client._js = MagicMock()
+
+        # Simulate context exit with an exception
+        await client.__aexit__(RuntimeError, RuntimeError("test"), None)
+        assert client._connected is False
+
+
+class TestMQTTClientAexit:
+    """AsyncMQTTClient must clean up sessions and subscriptions on __aexit__."""
+
+    async def test_aexit_calls_close(self):
+        from isa_common import AsyncMQTTClient
+
+        client = AsyncMQTTClient(host="localhost", port=1883, lazy_connect=True)
+        client._connected = True
+
+        await client.__aexit__(None, None, None)
+
+        assert client._connected is False
+
+    async def test_aexit_clears_sessions_and_subscriptions(self):
+        from isa_common import AsyncMQTTClient
+
+        client = AsyncMQTTClient(host="localhost", port=1883, lazy_connect=True)
+        client._connected = True
+
+        # Add some state
+        client._sessions["s1"] = {"client_id": "test"}
+        client._subscriptions["s1:topic/test"] = {"topic": "topic/test"}
+        client._devices["d1"] = {"device_id": "d1"}
+
+        await client.__aexit__(None, None, None)
+
+        assert len(client._sessions) == 0
+        assert len(client._subscriptions) == 0
+        assert len(client._devices) == 0
+        assert client._connected is False
+
+    async def test_aexit_cleans_up_on_exception(self):
+        from isa_common import AsyncMQTTClient
+
+        client = AsyncMQTTClient(host="localhost", port=1883, lazy_connect=True)
+        client._connected = True
+        client._sessions["s1"] = {"client_id": "test"}
+
+        await client.__aexit__(RuntimeError, RuntimeError("test"), None)
+
+        assert len(client._sessions) == 0
+        assert client._connected is False
+
+
+class TestBaseClientAexitDefault:
+    """Base class __aexit__ should be a no-op (backward compat)."""
+
+    async def test_base_aexit_is_noop(self):
+        from isa_common.async_base_client import AsyncBaseClient
+
+        # Base __aexit__ doesn't close — subclasses override
+        # Just verify it exists and doesn't raise
+        class DummyClient(AsyncBaseClient):
+            async def _connect(self): pass
+            async def _disconnect(self): pass
+            async def health_check(self): return {"healthy": True}
+
+        client = DummyClient(lazy_connect=True)
+        client._connected = True
+        await client.__aexit__(None, None, None)
+        # Base doesn't close — that's the documented behavior
+        assert client._connected is True

--- a/isA_common/tests/unit/test_datetime_utcnow_fix.py
+++ b/isA_common/tests/unit/test_datetime_utcnow_fix.py
@@ -1,0 +1,77 @@
+"""Unit tests for #120 — verify datetime.utcnow() is replaced with timezone-aware datetime."""
+import ast
+import pytest
+from datetime import timezone
+from pathlib import Path
+
+# Resolve paths relative to the isa_common package root
+_PKG_ROOT = Path(__file__).resolve().parents[2] / "isa_common"
+
+
+class TestNoDeprecatedDatetime:
+    """Ensure no file uses the deprecated datetime.utcnow()."""
+
+    FILES_TO_CHECK = [
+        _PKG_ROOT / "async_mqtt_client.py",
+        _PKG_ROOT / "events" / "base_event_models.py",
+        _PKG_ROOT / "events" / "billing_events.py",
+    ]
+
+    @pytest.mark.parametrize("filepath", FILES_TO_CHECK, ids=lambda p: p.name)
+    def test_no_utcnow_calls(self, filepath):
+        """Files must not contain datetime.utcnow() calls."""
+        source = filepath.read_text()
+        assert "datetime.utcnow()" not in source, (
+            f"{filepath.name} still contains deprecated datetime.utcnow()"
+        )
+
+    @pytest.mark.parametrize("filepath", FILES_TO_CHECK, ids=lambda p: p.name)
+    def test_no_utcnow_references(self, filepath):
+        """Files must not reference datetime.utcnow as a callable (e.g. default_factory)."""
+        source = filepath.read_text()
+        lines = source.splitlines()
+        for i, line in enumerate(lines, 1):
+            if "utcnow" in line:
+                pytest.fail(
+                    f"{filepath.name}:{i} still references utcnow: {line.strip()}"
+                )
+
+
+class TestEventModelsTimezoneAware:
+    """Verify event model defaults produce timezone-aware datetimes."""
+
+    def test_base_event_metadata_has_timezone(self):
+        from isa_common.events.base_event_models import EventMetadata
+
+        meta = EventMetadata()
+        assert meta.timestamp.tzinfo is not None, "EventMetadata.timestamp must be timezone-aware"
+
+    def test_usage_event_has_timezone(self):
+        from isa_common.events.billing_events import UsageEvent, UnitType
+        from decimal import Decimal
+
+        event = UsageEvent(
+            user_id="u1",
+            product_id="gpt-4",
+            usage_amount=Decimal("100"),
+            unit_type=UnitType.TOKEN,
+        )
+        assert event.timestamp.tzinfo is not None, "UsageEvent.timestamp must be timezone-aware"
+
+    def test_billing_calculated_event_has_timezone(self):
+        from isa_common.events.billing_events import BillingCalculatedEvent, UnitType
+        from decimal import Decimal
+
+        event = BillingCalculatedEvent(
+            user_id="u1",
+            billing_record_id="br1",
+            usage_event_id="ue1",
+            product_id="gpt-4",
+            actual_usage=Decimal("100"),
+            unit_type=UnitType.TOKEN,
+            token_equivalent=Decimal("100"),
+            cost_usd=Decimal("0.01"),
+            unit_price=Decimal("0.0001"),
+            token_conversion_rate=Decimal("1"),
+        )
+        assert event.timestamp.tzinfo is not None

--- a/isA_common/tests/unit/test_executor_shutdown.py
+++ b/isA_common/tests/unit/test_executor_shutdown.py
@@ -1,0 +1,97 @@
+"""Unit tests for #123 — verify ThreadPoolExecutor shutdown is graceful."""
+import ast
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_PKG_ROOT = Path(__file__).resolve().parents[2] / "isa_common"
+
+
+class TestNoWaitFalseShutdown:
+    """No client should use shutdown(wait=False)."""
+
+    FILES_TO_CHECK = [
+        _PKG_ROOT / "async_duckdb_client.py",
+        _PKG_ROOT / "async_chroma_client.py",
+        _PKG_ROOT / "async_local_storage_client.py",
+    ]
+
+    @pytest.mark.parametrize("filepath", FILES_TO_CHECK, ids=lambda p: p.name)
+    def test_no_shutdown_wait_false(self, filepath):
+        """Files must not use shutdown(wait=False) which orphans threads."""
+        source = filepath.read_text()
+        assert "shutdown(wait=False)" not in source, (
+            f"{filepath.name} still uses shutdown(wait=False)"
+        )
+
+    @pytest.mark.parametrize("filepath", FILES_TO_CHECK, ids=lambda p: p.name)
+    def test_uses_graceful_shutdown(self, filepath):
+        """Files should use shutdown(wait=True, cancel_futures=True)."""
+        source = filepath.read_text()
+        if "shutdown" in source:
+            assert "shutdown(wait=True" in source, (
+                f"{filepath.name} should use shutdown(wait=True, ...)"
+            )
+
+
+class TestDuckDBExecutorShutdown:
+    """DuckDB client executor shutdown is graceful."""
+
+    async def test_disconnect_shuts_down_executor(self):
+        from isa_common import AsyncDuckDBClient
+
+        client = AsyncDuckDBClient(lazy_connect=True)
+        client._conn = MagicMock()
+        client._executor = MagicMock()
+        client._connected = True
+
+        await client._disconnect()
+
+        client._executor.shutdown.assert_called_once_with(
+            wait=True, cancel_futures=True
+        )
+
+
+class TestChromaExecutorShutdown:
+    """ChromaDB client executor shutdown is graceful."""
+
+    async def test_disconnect_shuts_down_executor(self):
+        from isa_common import AsyncChromaClient
+
+        client = AsyncChromaClient(
+            persist_directory="/tmp/test_chroma",
+            lazy_connect=True,
+        )
+        client._client = MagicMock()
+        mock_executor = MagicMock()
+        client._executor = mock_executor
+        client._connected = True
+
+        await client._disconnect()
+
+        # _disconnect sets _executor = None after shutdown, so check the original mock
+        mock_executor.shutdown.assert_called_once_with(
+            wait=True, cancel_futures=True
+        )
+
+
+class TestLocalStorageExecutorShutdown:
+    """LocalStorage client executor shutdown is graceful."""
+
+    async def test_disconnect_shuts_down_executor(self):
+        from isa_common import AsyncLocalStorageClient
+
+        client = AsyncLocalStorageClient(
+            base_path="/tmp/test_storage",
+            lazy_connect=True,
+        )
+        mock_executor = MagicMock()
+        client._executor = mock_executor
+        client._connected = True
+
+        await client._disconnect()
+
+        # _disconnect sets _executor = None after shutdown, so check the original mock
+        mock_executor.shutdown.assert_called_once_with(
+            wait=True, cancel_futures=True
+        )


### PR DESCRIPTION
## Summary

- **#120**: Replace all `datetime.utcnow()` with `datetime.now(timezone.utc)` in `base_event_models.py`, `billing_events.py`, and `test_webhook_server.py` (13 occurrences). The MQTT client was already fixed in #125.
- **#122**: Add `__aexit__` overrides to `AsyncNATSClient` (unsubscribes active subscriptions, drains connection) and `AsyncMQTTClient` (clears subscriptions, sessions, devices) so resources are released on context exit.
- **#123**: Change `shutdown(wait=False)` to `shutdown(wait=True, cancel_futures=True)` in `AsyncChromaClient` and `AsyncLocalStorageClient`. DuckDB was already fixed in #125.

Fixes #120, Fixes #122, Fixes #123

**Parent Epic**: #92

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 26 new | Pass |
| L2 Component | 0 | N/A |
| L3 Integration | 0 | N/A |
| L4 API | 0 | N/A |
| L5 Smoke | 0 | N/A |

Full unit suite: **231 passed**, 0 failed.

## Test plan

- [x] New tests verify no `datetime.utcnow()` in source files
- [x] New tests verify event model timestamps are timezone-aware
- [x] New tests verify `__aexit__` calls `close()` and clears state for NATS/MQTT
- [x] New tests verify `__aexit__` handles errors gracefully
- [x] New tests verify `shutdown(wait=True, cancel_futures=True)` in all executor clients
- [x] All 231 existing unit tests pass (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)