### PR TITLE
test(core): add unit tests for 5 untested local-mode clients

### DIFF
--- a/isA_common/tests/unit/conftest.py
+++ b/isA_common/tests/unit/conftest.py
@@ -4,7 +4,7 @@ Unit test fixtures — all tests use mocked backends, no infrastructure required
 import logging
 import pytest
 import pytest_asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 
 # ============================================================================
@@ -192,3 +192,107 @@ async def loki_client():
     yield client
     client._batch = []
     client._connected = False
+
+
+# ============================================================================
+# SQLite
+# ============================================================================
+
+@pytest_asyncio.fixture
+async def sqlite_client(tmp_path):
+    """AsyncSQLiteClient with a real temp database (no external deps)."""
+    from isa_common import AsyncSQLiteClient
+
+    client = AsyncSQLiteClient(
+        database="test.db",
+        db_path=str(tmp_path),
+        user_id="test_user", organization_id="org1",
+        lazy_connect=True,
+    )
+    # Mock _conn so tests don't need aiosqlite
+    client._conn = AsyncMock()
+    client._connected = True
+    yield client
+    client._connected = False
+
+
+# ============================================================================
+# LocalStorage
+# ============================================================================
+
+@pytest_asyncio.fixture
+async def local_storage_client(tmp_path):
+    """AsyncLocalStorageClient with a real temp directory."""
+    from isa_common import AsyncLocalStorageClient
+
+    client = AsyncLocalStorageClient(
+        base_path=str(tmp_path),
+        user_id="test_user", organization_id="org1",
+        lazy_connect=True,
+    )
+    client._connected = True
+    yield client
+    client._connected = False
+
+
+# ============================================================================
+# ChromaDB
+# ============================================================================
+
+@pytest_asyncio.fixture
+async def chroma_client(tmp_path):
+    """AsyncChromaClient with mocked chromadb backend."""
+    from isa_common import AsyncChromaClient
+
+    client = AsyncChromaClient(
+        persist_directory=str(tmp_path),
+        user_id="test_user", organization_id="org1",
+        lazy_connect=True,
+    )
+    client._client = MagicMock()
+    client._connected = True
+    yield client
+    client._connected = False
+
+
+# ============================================================================
+# Memory (In-memory cache)
+# ============================================================================
+
+@pytest_asyncio.fixture
+async def memory_client():
+    """AsyncMemoryClient with instance-local store (no global bleed)."""
+    from isa_common import AsyncMemoryClient
+
+    client = AsyncMemoryClient(
+        use_global_store=False,
+        user_id="test_user", organization_id="org1",
+        lazy_connect=True,
+    )
+    client._connected = True
+    yield client
+    client._store.clear()
+    client._expiry.clear()
+    client._connected = False
+
+
+# ============================================================================
+# Consul
+# ============================================================================
+
+@pytest.fixture
+def consul_registry():
+    """ConsulRegistry with mocked consul backend."""
+    from isa_common.consul_client import ConsulRegistry
+
+    with patch("isa_common.consul_client.consul.Consul") as MockConsul:
+        mock_consul = MagicMock()
+        MockConsul.return_value = mock_consul
+        registry = ConsulRegistry(
+            service_name="test-service",
+            service_port=8080,
+            consul_host="localhost",
+            consul_port=8500,
+        )
+        registry.consul = mock_consul
+        yield registry

--- a/isA_common/tests/unit/test_chroma_unit.py
+++ b/isA_common/tests/unit/test_chroma_unit.py
@@ -1,0 +1,264 @@
+"""Unit tests for AsyncChromaClient — #119."""
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ============================================================================
+# L1 — Pure helper functions
+# ============================================================================
+
+
+class TestFlattenPayload:
+    """_flatten_payload converts nested dicts for ChromaDB metadata."""
+
+    def _make_client(self, tmp_path):
+        from isa_common import AsyncChromaClient
+        return AsyncChromaClient(
+            persist_directory=str(tmp_path), lazy_connect=True
+        )
+
+    def test_primitives_pass_through(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._flatten_payload({"name": "test", "count": 42, "active": True})
+        assert result == {"name": "test", "count": 42, "active": True}
+
+    def test_dict_serialized_as_json(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._flatten_payload({"nested": {"a": 1}})
+        assert result["nested"] == '{"a": 1}'
+
+    def test_list_serialized_as_json(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._flatten_payload({"tags": ["a", "b"]})
+        assert result["tags"] == '["a", "b"]'
+
+    def test_none_becomes_empty_string(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._flatten_payload({"field": None})
+        assert result["field"] == ""
+
+
+class TestUnflattenPayload:
+    """_unflatten_payload parses JSON strings back to dicts/lists."""
+
+    def _make_client(self, tmp_path):
+        from isa_common import AsyncChromaClient
+        return AsyncChromaClient(
+            persist_directory=str(tmp_path), lazy_connect=True
+        )
+
+    def test_json_dict_parsed(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._unflatten_payload({"nested": '{"a": 1}'})
+        assert result["nested"] == {"a": 1}
+
+    def test_json_list_parsed(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._unflatten_payload({"tags": '["a", "b"]'})
+        assert result["tags"] == ["a", "b"]
+
+    def test_plain_string_preserved(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._unflatten_payload({"name": "hello"})
+        assert result["name"] == "hello"
+
+    def test_non_string_preserved(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._unflatten_payload({"count": 42})
+        assert result["count"] == 42
+
+    def test_roundtrip(self, tmp_path):
+        client = self._make_client(tmp_path)
+        original = {"name": "test", "tags": ["a", "b"], "meta": {"k": "v"}, "count": 5}
+        flat = client._flatten_payload(original)
+        restored = client._unflatten_payload(flat)
+        assert restored == original
+
+
+class TestBuildWhereClause:
+    """_build_where_clause converts Qdrant-style filters to ChromaDB."""
+
+    def _make_client(self, tmp_path):
+        from isa_common import AsyncChromaClient
+        return AsyncChromaClient(
+            persist_directory=str(tmp_path), lazy_connect=True
+        )
+
+    def test_single_must_keyword(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._build_where_clause({
+            "must": [{"field": "type", "match": {"keyword": "tool"}}]
+        })
+        assert result == {"type": {"$eq": "tool"}}
+
+    def test_multiple_must_uses_and(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._build_where_clause({
+            "must": [
+                {"field": "type", "match": {"keyword": "tool"}},
+                {"field": "active", "match": {"boolean": True}},
+            ]
+        })
+        assert "$and" in result
+
+    def test_range_condition(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._build_where_clause({
+            "must": [{"field": "score", "range": {"gte": 0.5, "lt": 1.0}}]
+        })
+        assert result == {"score": {"$gte": 0.5, "$lt": 1.0}}
+
+    def test_empty_must_returns_none(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._build_where_clause({"must": []})
+        assert result is None
+
+    def test_no_must_key_returns_none(self, tmp_path):
+        client = self._make_client(tmp_path)
+        result = client._build_where_clause({})
+        assert result is None
+
+
+class TestParseSearchResults:
+    """_parse_search_results converts ChromaDB results to Qdrant format."""
+
+    def _make_client(self, tmp_path):
+        from isa_common import AsyncChromaClient
+        return AsyncChromaClient(
+            persist_directory=str(tmp_path), lazy_connect=True
+        )
+
+    def test_basic_parse(self, tmp_path):
+        client = self._make_client(tmp_path)
+        results = {
+            "ids": [["id1", "id2"]],
+            "distances": [[0.1, 0.3]],
+            "metadatas": [[{"name": "a"}, {"name": "b"}]],
+        }
+        parsed = client._parse_search_results(results, None, True, False)
+        assert len(parsed) == 2
+        assert parsed[0]["id"] == "id1"
+        assert parsed[0]["score"] == pytest.approx(0.9)
+        assert parsed[0]["payload"] == {"name": "a"}
+
+    def test_score_threshold_filters(self, tmp_path):
+        client = self._make_client(tmp_path)
+        results = {
+            "ids": [["id1", "id2"]],
+            "distances": [[0.1, 0.9]],
+            "metadatas": [[{"name": "a"}, {"name": "b"}]],
+        }
+        parsed = client._parse_search_results(results, 0.5, True, False)
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == "id1"
+
+    def test_empty_results(self, tmp_path):
+        client = self._make_client(tmp_path)
+        results = {"ids": [[]], "distances": [[]], "metadatas": [[]]}
+        parsed = client._parse_search_results(results, None, True, False)
+        assert parsed == []
+
+
+# ============================================================================
+# L2 — Component tests (mocked chromadb backend)
+# ============================================================================
+
+
+class TestChromaClientDisconnect:
+    """_disconnect cleans up client and executor."""
+
+    async def test_disconnect_shuts_down_executor(self, chroma_client):
+        mock_executor = MagicMock()
+        chroma_client._executor = mock_executor
+        await chroma_client._disconnect()
+        mock_executor.shutdown.assert_called_once_with(
+            wait=True, cancel_futures=True
+        )
+        assert chroma_client._client is None
+        assert chroma_client._executor is None
+
+
+class TestChromaClientCollections:
+    """Collection management operations."""
+
+    async def test_create_collection(self, chroma_client):
+        chroma_client._client.get_or_create_collection = MagicMock()
+
+        result = await chroma_client.create_collection("test_col", vector_size=128)
+        assert result is True
+
+    async def test_list_collections(self, chroma_client):
+        mock_col1 = MagicMock()
+        mock_col1.name = "col1"
+        mock_col2 = MagicMock()
+        mock_col2.name = "col2"
+        chroma_client._client.list_collections = MagicMock(
+            return_value=[mock_col1, mock_col2]
+        )
+
+        result = await chroma_client.list_collections()
+        assert result == ["col1", "col2"]
+
+    async def test_delete_collection(self, chroma_client):
+        chroma_client._client.delete_collection = MagicMock()
+
+        result = await chroma_client.delete_collection("test_col")
+        assert result is True
+        chroma_client._client.delete_collection.assert_called_with("test_col")
+
+    async def test_get_collection_info(self, chroma_client):
+        mock_col = MagicMock()
+        mock_col.count.return_value = 42
+        mock_col.metadata = {"hnsw:space": "cosine"}
+        chroma_client._client.get_collection = MagicMock(return_value=mock_col)
+
+        info = await chroma_client.get_collection_info("test_col")
+        assert info["points_count"] == 42
+        assert info["status"] == "ready"
+
+
+class TestChromaClientPointOps:
+    """Point upsert/delete/count operations."""
+
+    async def test_upsert_points(self, chroma_client):
+        mock_col = MagicMock()
+        mock_col.upsert = MagicMock()
+        chroma_client._client.get_or_create_collection = MagicMock(return_value=mock_col)
+
+        points = [
+            {"id": 1, "vector": [0.1] * 4, "payload": {"name": "a"}},
+            {"id": 2, "vector": [0.2] * 4, "payload": {"name": "b"}},
+        ]
+        result = await chroma_client.upsert_points("col", points)
+        assert result == "success"
+        mock_col.upsert.assert_called_once()
+
+    async def test_delete_points(self, chroma_client):
+        mock_col = MagicMock()
+        mock_col.delete = MagicMock()
+        chroma_client._client.get_collection = MagicMock(return_value=mock_col)
+
+        result = await chroma_client.delete_points("col", [1, 2])
+        assert result == "success"
+        mock_col.delete.assert_called_once_with(ids=["1", "2"])
+
+    async def test_count_points(self, chroma_client):
+        mock_col = MagicMock()
+        mock_col.count.return_value = 10
+        chroma_client._client.get_collection = MagicMock(return_value=mock_col)
+
+        count = await chroma_client.count_points("col")
+        assert count == 10
+
+
+class TestChromaIndexOps:
+    """Index management is a no-op for ChromaDB."""
+
+    async def test_create_field_index_noop(self, chroma_client):
+        result = await chroma_client.create_field_index("col", "field")
+        assert result == "success"
+
+    async def test_delete_field_index_noop(self, chroma_client):
+        result = await chroma_client.delete_field_index("col", "field")
+        assert result == "success"

--- a/isA_common/tests/unit/test_consul_unit.py
+++ b/isA_common/tests/unit/test_consul_unit.py
@@ -1,0 +1,361 @@
+"""Unit tests for ConsulRegistry — #119."""
+import json
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+
+# ============================================================================
+# L1 — Pure helper functions
+# ============================================================================
+
+
+class TestIsLoopback:
+    """_is_loopback detects loopback addresses."""
+
+    def test_ipv4_loopback(self):
+        from isa_common.consul_client import _is_loopback
+        assert _is_loopback("127.0.0.1") is True
+
+    def test_ipv6_loopback(self):
+        from isa_common.consul_client import _is_loopback
+        assert _is_loopback("::1") is True
+
+    def test_localhost_string(self):
+        from isa_common.consul_client import _is_loopback
+        assert _is_loopback("localhost") is True
+        assert _is_loopback("LOCALHOST") is True
+
+    def test_non_loopback(self):
+        from isa_common.consul_client import _is_loopback
+        assert _is_loopback("10.0.0.1") is False
+        assert _is_loopback("192.168.1.1") is False
+
+    def test_127_x_variants(self):
+        from isa_common.consul_client import _is_loopback
+        assert _is_loopback("127.0.0.2") is True
+        assert _is_loopback("127.255.255.255") is True
+
+
+# ============================================================================
+# L2 — ConsulRegistry initialization
+# ============================================================================
+
+
+class TestConsulRegistryInit:
+    """ConsulRegistry init and service ID."""
+
+    def test_init_with_service(self, consul_registry):
+        assert consul_registry.service_name == "test-service"
+        assert consul_registry.service_port == 8080
+        assert consul_registry.service_id is not None
+        assert "test-service" in consul_registry.service_id
+
+    def test_init_discovery_only(self):
+        with patch("isa_common.consul_client.consul.Consul"):
+            from isa_common.consul_client import ConsulRegistry
+            registry = ConsulRegistry()
+            assert registry.service_name is None
+            assert registry.service_id is None
+
+
+# ============================================================================
+# L2 — Registration / deregistration
+# ============================================================================
+
+
+class TestConsulRegistryRegister:
+    """register() and deregister() operations."""
+
+    def test_register_success(self, consul_registry):
+        consul_registry.consul.agent.service.register = MagicMock()
+        consul_registry.consul.agent.check.ttl_pass = MagicMock()
+        consul_registry.consul.agent.services.return_value = {}
+
+        result = consul_registry.register()
+        assert result is True
+        consul_registry.consul.agent.service.register.assert_called_once()
+
+    def test_register_failure(self, consul_registry):
+        consul_registry.consul.agent.service.register = MagicMock(
+            side_effect=Exception("connection refused")
+        )
+        consul_registry.consul.agent.services.return_value = {}
+
+        result = consul_registry.register()
+        assert result is False
+
+    def test_deregister_success(self, consul_registry):
+        consul_registry.consul.agent.service.deregister = MagicMock()
+
+        result = consul_registry.deregister()
+        assert result is True
+        consul_registry.consul.agent.service.deregister.assert_called_once_with(
+            consul_registry.service_id
+        )
+
+    def test_deregister_failure(self, consul_registry):
+        consul_registry.consul.agent.service.deregister = MagicMock(
+            side_effect=Exception("not found")
+        )
+
+        result = consul_registry.deregister()
+        assert result is False
+
+
+class TestConsulRegistryCleanupStale:
+    """cleanup_stale_registrations removes old entries."""
+
+    def test_cleanup_removes_stale(self, consul_registry):
+        consul_registry.consul.agent.services.return_value = {
+            consul_registry.service_id: {
+                "Service": "test-service",
+                "Port": 8080,
+                "Address": consul_registry.service_host,
+            },
+            "test-service-old-host-8080": {
+                "Service": "test-service",
+                "Port": 8080,
+                "Address": "old-host",
+            },
+        }
+        consul_registry.consul.agent.service.deregister = MagicMock()
+
+        count = consul_registry.cleanup_stale_registrations()
+        assert count == 1
+        consul_registry.consul.agent.service.deregister.assert_called_once_with(
+            "test-service-old-host-8080"
+        )
+
+    def test_cleanup_no_stale(self, consul_registry):
+        consul_registry.consul.agent.services.return_value = {
+            consul_registry.service_id: {
+                "Service": "test-service",
+                "Port": 8080,
+                "Address": consul_registry.service_host,
+            },
+        }
+
+        count = consul_registry.cleanup_stale_registrations()
+        assert count == 0
+
+    def test_cleanup_handles_error(self, consul_registry):
+        consul_registry.consul.agent.services.side_effect = Exception("timeout")
+        count = consul_registry.cleanup_stale_registrations()
+        assert count == 0
+
+
+# ============================================================================
+# L2 — Configuration management
+# ============================================================================
+
+
+class TestConsulRegistryConfig:
+    """KV store get/set/get_all operations."""
+
+    def test_get_config_string(self, consul_registry):
+        consul_registry.consul.kv.get.return_value = (
+            1, {"Value": b"hello"}
+        )
+        result = consul_registry.get_config("key1")
+        assert result == "hello"
+
+    def test_get_config_json(self, consul_registry):
+        consul_registry.consul.kv.get.return_value = (
+            1, {"Value": json.dumps({"a": 1}).encode()}
+        )
+        result = consul_registry.get_config("key1")
+        assert result == {"a": 1}
+
+    def test_get_config_missing(self, consul_registry):
+        consul_registry.consul.kv.get.return_value = (0, None)
+        result = consul_registry.get_config("missing", default="fallback")
+        assert result == "fallback"
+
+    def test_get_config_error(self, consul_registry):
+        consul_registry.consul.kv.get.side_effect = Exception("timeout")
+        result = consul_registry.get_config("key1", default="safe")
+        assert result == "safe"
+
+    def test_set_config_string(self, consul_registry):
+        consul_registry.consul.kv.put.return_value = True
+        result = consul_registry.set_config("key1", "value1")
+        assert result is True
+        consul_registry.consul.kv.put.assert_called_once_with(
+            "test-service/key1", "value1"
+        )
+
+    def test_set_config_dict(self, consul_registry):
+        consul_registry.consul.kv.put.return_value = True
+        result = consul_registry.set_config("key1", {"a": 1})
+        assert result is True
+        call_args = consul_registry.consul.kv.put.call_args
+        assert json.loads(call_args[0][1]) == {"a": 1}
+
+    def test_set_config_error(self, consul_registry):
+        consul_registry.consul.kv.put.side_effect = Exception("timeout")
+        result = consul_registry.set_config("key1", "val")
+        assert result is False
+
+    def test_get_all_config(self, consul_registry):
+        consul_registry.consul.kv.get.return_value = (1, [
+            {"Key": "test-service/db_host", "Value": b"localhost"},
+            {"Key": "test-service/db_port", "Value": b"5432"},
+        ])
+        result = consul_registry.get_all_config()
+        assert result == {"db_host": "localhost", "db_port": 5432}
+
+    def test_get_all_config_empty(self, consul_registry):
+        consul_registry.consul.kv.get.return_value = (0, None)
+        result = consul_registry.get_all_config()
+        assert result == {}
+
+
+# ============================================================================
+# L2 — Service discovery
+# ============================================================================
+
+
+class TestConsulRegistryDiscovery:
+    """Service discovery operations."""
+
+    def test_discover_service(self, consul_registry):
+        consul_registry.consul.health.service.return_value = (1, [
+            {
+                "Service": {
+                    "ID": "svc-1",
+                    "Address": "10.0.0.1",
+                    "Port": 8080,
+                    "Tags": ["v1"],
+                    "Meta": {},
+                }
+            },
+            {
+                "Service": {
+                    "ID": "svc-2",
+                    "Address": "10.0.0.2",
+                    "Port": 8080,
+                    "Tags": ["v1"],
+                    "Meta": {},
+                }
+            },
+        ])
+
+        instances = consul_registry.discover_service("my-service")
+        assert len(instances) == 2
+        assert instances[0]["address"] == "10.0.0.1"
+
+    def test_discover_service_empty(self, consul_registry):
+        consul_registry.consul.health.service.return_value = (1, [])
+        instances = consul_registry.discover_service("missing-service")
+        assert instances == []
+
+    def test_discover_service_error(self, consul_registry):
+        consul_registry.consul.health.service.side_effect = Exception("timeout")
+        instances = consul_registry.discover_service("my-service")
+        assert instances == []
+
+
+class TestConsulRegistryEndpoint:
+    """get_service_endpoint and get_service_address."""
+
+    def test_get_service_endpoint_single(self, consul_registry):
+        consul_registry.consul.health.service.return_value = (1, [
+            {
+                "Service": {
+                    "ID": "svc-1",
+                    "Address": "10.0.0.1",
+                    "Port": 8080,
+                    "Tags": [],
+                    "Meta": {},
+                }
+            },
+        ])
+        result = consul_registry.get_service_endpoint("my-service")
+        assert result == "http://10.0.0.1:8080"
+
+    def test_get_service_endpoint_none(self, consul_registry):
+        consul_registry.consul.health.service.return_value = (1, [])
+        result = consul_registry.get_service_endpoint("missing")
+        assert result is None
+
+    def test_get_service_address_with_fallback(self, consul_registry):
+        consul_registry.consul.health.service.return_value = (1, [])
+        result = consul_registry.get_service_address(
+            "missing", fallback_url="http://localhost:9090", max_retries=1
+        )
+        assert result == "http://localhost:9090"
+
+    def test_get_service_address_no_fallback_raises(self, consul_registry):
+        consul_registry.consul.health.service.return_value = (1, [])
+        with pytest.raises(ValueError, match="not found"):
+            consul_registry.get_service_address("missing", max_retries=1)
+
+    def test_get_service_address_success(self, consul_registry):
+        consul_registry.consul.health.service.return_value = (1, [
+            {
+                "Service": {
+                    "ID": "svc-1",
+                    "Address": "10.0.0.1",
+                    "Port": 8080,
+                    "Tags": [],
+                    "Meta": {},
+                }
+            },
+        ])
+        result = consul_registry.get_service_address("my-service")
+        assert result == "http://10.0.0.1:8080"
+
+
+class TestConsulRegistryConvenience:
+    """Convenience get_*_service_url methods."""
+
+    def test_get_auth_service_url_not_found(self, consul_registry):
+        consul_registry.consul.health.service.return_value = (1, [])
+        with pytest.raises(ValueError, match="auth_service"):
+            consul_registry.get_auth_service_url()
+
+    def test_get_auth_service_url_found(self, consul_registry):
+        consul_registry.consul.health.service.return_value = (1, [
+            {
+                "Service": {
+                    "ID": "auth-1",
+                    "Address": "10.0.0.1",
+                    "Port": 8001,
+                    "Tags": [],
+                    "Meta": {},
+                }
+            },
+        ])
+        result = consul_registry.get_auth_service_url()
+        assert result == "http://10.0.0.1:8001"
+
+
+class TestConsulRegistryRoundRobin:
+    """Round-robin load balancing."""
+
+    def test_round_robin_cycles(self, consul_registry):
+        instances = [
+            {"id": "a", "address": "10.0.0.1", "port": 8080, "tags": [], "meta": {}},
+            {"id": "b", "address": "10.0.0.2", "port": 8080, "tags": [], "meta": {}},
+        ]
+        first = consul_registry._get_round_robin_instance("svc", instances)
+        second = consul_registry._get_round_robin_instance("svc", instances)
+        third = consul_registry._get_round_robin_instance("svc", instances)
+        assert first["id"] == "a"
+        assert second["id"] == "b"
+        assert third["id"] == "a"  # Wraps around
+
+
+class TestConsulRegistryMaintenance:
+    """start_maintenance / stop_maintenance."""
+
+    def test_stop_maintenance_cancels_task(self, consul_registry):
+        mock_task = MagicMock()
+        consul_registry._health_check_task = mock_task
+        consul_registry.stop_maintenance()
+        mock_task.cancel.assert_called_once()
+        assert consul_registry._health_check_task is None
+
+    def test_stop_maintenance_noop_when_no_task(self, consul_registry):
+        consul_registry._health_check_task = None
+        consul_registry.stop_maintenance()  # Should not raise

--- a/isA_common/tests/unit/test_local_storage_unit.py
+++ b/isA_common/tests/unit/test_local_storage_unit.py
@@ -1,0 +1,245 @@
+"""Unit tests for AsyncLocalStorageClient — #119."""
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ============================================================================
+# L1 — Path helpers (pure logic, no I/O)
+# ============================================================================
+
+
+class TestGetUserPath:
+    """_get_user_path returns tenant-isolated path."""
+
+    def test_with_user_id(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        client = AsyncLocalStorageClient(
+            base_path=str(tmp_path), user_id="test_user", lazy_connect=True
+        )
+        assert client._get_user_path() == tmp_path / "user-test-user"
+
+    def test_without_user_id(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        client = AsyncLocalStorageClient(
+            base_path=str(tmp_path), lazy_connect=True
+        )
+        # Default user_id is "default", but _get_user_path adds "user-" prefix
+        assert client._get_user_path() == tmp_path / "user-default"
+
+    def test_sanitizes_user_id(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        client = AsyncLocalStorageClient(
+            base_path=str(tmp_path), user_id="auth0|USER_123", lazy_connect=True
+        )
+        path = client._get_user_path()
+        assert "auth0-user-123" in str(path)
+        assert "--" not in path.name
+        assert "|" not in path.name
+
+
+class TestGetBucketPath:
+    """_get_bucket_path sanitizes and returns bucket directory."""
+
+    def test_basic_bucket(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        client = AsyncLocalStorageClient(
+            base_path=str(tmp_path), user_id="u1", lazy_connect=True
+        )
+        path = client._get_bucket_path("my_bucket")
+        assert path.name == "my-bucket"
+
+    def test_sanitizes_double_hyphens(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        client = AsyncLocalStorageClient(
+            base_path=str(tmp_path), user_id="u1", lazy_connect=True
+        )
+        path = client._get_bucket_path("my__bucket")
+        assert "--" not in path.name
+
+
+class TestGetObjectPath:
+    """_get_object_path validates against path traversal."""
+
+    def test_valid_object_key(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        client = AsyncLocalStorageClient(
+            base_path=str(tmp_path), user_id="u1", lazy_connect=True
+        )
+        path = client._get_object_path("bucket", "dir/file.txt")
+        assert "dir/file.txt" in str(path) or "dir" in str(path)
+
+    def test_path_traversal_blocked(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        client = AsyncLocalStorageClient(
+            base_path=str(tmp_path), user_id="u1", lazy_connect=True
+        )
+        with pytest.raises(ValueError, match="path traversal"):
+            client._get_object_path("bucket", "../../etc/passwd")
+
+    def test_path_traversal_dotdot_in_middle(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        client = AsyncLocalStorageClient(
+            base_path=str(tmp_path), user_id="u1", lazy_connect=True
+        )
+        with pytest.raises(ValueError, match="path traversal"):
+            client._get_object_path("bucket", "a/../../etc/passwd")
+
+
+class TestGetMetadataPath:
+    """_get_metadata_path returns sidecar .meta.json path."""
+
+    def test_metadata_path(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        client = AsyncLocalStorageClient(
+            base_path=str(tmp_path), user_id="u1", lazy_connect=True
+        )
+        obj_path = tmp_path / "file.txt"
+        meta_path = client._get_metadata_path(obj_path)
+        assert meta_path == tmp_path / "file.txt.meta.json"
+
+
+# ============================================================================
+# L2 — Component tests (real filesystem via tmp_path)
+# ============================================================================
+
+
+class TestLocalStorageConnect:
+    """_connect creates base directory."""
+
+    async def test_connect_creates_directory(self, tmp_path):
+        from isa_common import AsyncLocalStorageClient
+        base = tmp_path / "new_storage"
+        client = AsyncLocalStorageClient(
+            base_path=str(base), lazy_connect=True
+        )
+        client._connected = True
+        await client._connect()
+        assert base.exists()
+
+
+class TestLocalStorageDisconnect:
+    """_disconnect shuts down executor."""
+
+    async def test_disconnect_shuts_down_executor(self, local_storage_client):
+        mock_executor = MagicMock()
+        local_storage_client._executor = mock_executor
+        await local_storage_client._disconnect()
+        mock_executor.shutdown.assert_called_once_with(
+            wait=True, cancel_futures=True
+        )
+        assert local_storage_client._executor is None
+
+
+class TestLocalStorageBucketOps:
+    """Bucket create/exists/delete/list operations."""
+
+    async def test_create_bucket(self, local_storage_client):
+        result = await local_storage_client.create_bucket("test-bucket")
+        assert result is True
+        bucket_path = local_storage_client._get_bucket_path("test-bucket")
+        assert bucket_path.exists()
+
+    async def test_bucket_exists_true(self, local_storage_client):
+        await local_storage_client.create_bucket("exists-bucket")
+        result = await local_storage_client.bucket_exists("exists-bucket")
+        assert result is True
+
+    async def test_bucket_exists_false(self, local_storage_client):
+        result = await local_storage_client.bucket_exists("nonexistent")
+        assert result is False
+
+    async def test_list_buckets_empty(self, local_storage_client):
+        result = await local_storage_client.list_buckets()
+        assert result == []
+
+    async def test_list_buckets(self, local_storage_client):
+        await local_storage_client.create_bucket("b1")
+        await local_storage_client.create_bucket("b2")
+        result = await local_storage_client.list_buckets()
+        assert sorted(result) == ["b1", "b2"]
+
+    async def test_delete_empty_bucket(self, local_storage_client):
+        await local_storage_client.create_bucket("del-bucket")
+        result = await local_storage_client.delete_bucket("del-bucket")
+        assert result is True
+
+    async def test_delete_nonexistent_bucket(self, local_storage_client):
+        result = await local_storage_client.delete_bucket("no-such-bucket")
+        assert result is True
+
+
+class TestLocalStorageObjectOps:
+    """Object put/get/delete/exists operations."""
+
+    async def test_put_and_get_object(self, local_storage_client):
+        data = b"Hello, World!"
+        etag = await local_storage_client.put_object(
+            "test-bucket", "hello.txt", data, content_type="text/plain"
+        )
+        assert etag is not None
+
+        retrieved = await local_storage_client.get_object("test-bucket", "hello.txt")
+        assert retrieved == data
+
+    async def test_get_nonexistent_object(self, local_storage_client):
+        await local_storage_client.create_bucket("empty-bucket")
+        result = await local_storage_client.get_object("empty-bucket", "nope.txt")
+        assert result is None
+
+    async def test_object_exists(self, local_storage_client):
+        await local_storage_client.put_object("bucket", "file.txt", b"data")
+        assert await local_storage_client.object_exists("bucket", "file.txt") is True
+        assert await local_storage_client.object_exists("bucket", "nope.txt") is False
+
+    async def test_delete_object(self, local_storage_client):
+        await local_storage_client.put_object("bucket", "file.txt", b"data")
+        result = await local_storage_client.delete_object("bucket", "file.txt")
+        assert result is True
+        assert await local_storage_client.object_exists("bucket", "file.txt") is False
+
+    async def test_get_object_info(self, local_storage_client):
+        await local_storage_client.put_object(
+            "bucket", "file.txt", b"data",
+            content_type="text/plain", metadata={"author": "test"}
+        )
+        info = await local_storage_client.get_object_info("bucket", "file.txt")
+        assert info is not None
+        assert info["key"] == "file.txt"
+        assert info["size"] == 4
+        assert info["content_type"] == "text/plain"
+
+    async def test_copy_object(self, local_storage_client):
+        await local_storage_client.put_object("src", "file.txt", b"data")
+        etag = await local_storage_client.copy_object("src", "file.txt", "dst", "copy.txt")
+        assert etag is not None
+        copied = await local_storage_client.get_object("dst", "copy.txt")
+        assert copied == b"data"
+
+    async def test_move_object(self, local_storage_client):
+        await local_storage_client.put_object("src", "file.txt", b"data")
+        etag = await local_storage_client.move_object("src", "file.txt", "dst", "moved.txt")
+        assert etag is not None
+        assert await local_storage_client.object_exists("src", "file.txt") is False
+        assert await local_storage_client.get_object("dst", "moved.txt") == b"data"
+
+
+class TestLocalStoragePresignedUrl:
+    """get_presigned_url returns file:// URL."""
+
+    async def test_presigned_url_for_existing_object(self, local_storage_client):
+        await local_storage_client.put_object("bucket", "f.txt", b"x")
+        url = await local_storage_client.get_presigned_url("bucket", "f.txt")
+        assert url.startswith("file://")
+
+    async def test_presigned_url_for_nonexistent_get(self, local_storage_client):
+        await local_storage_client.create_bucket("bucket")
+        url = await local_storage_client.get_presigned_url("bucket", "nope.txt")
+        assert url is None
+
+    async def test_presigned_url_put_method(self, local_storage_client):
+        await local_storage_client.create_bucket("bucket")
+        url = await local_storage_client.get_presigned_url(
+            "bucket", "new.txt", method="PUT"
+        )
+        assert url.startswith("file://")

--- a/isA_common/tests/unit/test_memory_unit.py
+++ b/isA_common/tests/unit/test_memory_unit.py
@@ -1,0 +1,316 @@
+"""Unit tests for AsyncMemoryClient — #119."""
+import time
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ============================================================================
+# L1 — Pure logic helpers
+# ============================================================================
+
+
+class TestIsExpired:
+    """_is_expired checks TTL expiration."""
+
+    def test_not_expired(self):
+        from isa_common import AsyncMemoryClient
+        client = AsyncMemoryClient(use_global_store=False, lazy_connect=True)
+        client._expiry["key1"] = time.time() + 3600
+        assert client._is_expired("key1") is False
+
+    def test_expired(self):
+        from isa_common import AsyncMemoryClient
+        client = AsyncMemoryClient(use_global_store=False, lazy_connect=True)
+        client._expiry["key1"] = time.time() - 1
+        assert client._is_expired("key1") is True
+
+    def test_no_expiry(self):
+        from isa_common import AsyncMemoryClient
+        client = AsyncMemoryClient(use_global_store=False, lazy_connect=True)
+        client._expiry["key1"] = 0
+        assert client._is_expired("key1") is False
+
+    def test_missing_key(self):
+        from isa_common import AsyncMemoryClient
+        client = AsyncMemoryClient(use_global_store=False, lazy_connect=True)
+        assert client._is_expired("nonexistent") is False
+
+
+# ============================================================================
+# L2 — Component tests (string operations)
+# ============================================================================
+
+
+class TestMemoryClientSetGet:
+    """set/get/delete/exists operations."""
+
+    async def test_set_and_get(self, memory_client):
+        await memory_client.set("key1", "value1")
+        result = await memory_client.get("key1")
+        assert result == "value1"
+
+    async def test_get_missing_key(self, memory_client):
+        result = await memory_client.get("nonexistent")
+        assert result is None
+
+    async def test_delete_existing(self, memory_client):
+        await memory_client.set("key1", "value1")
+        result = await memory_client.delete("key1")
+        assert result is True
+        assert await memory_client.get("key1") is None
+
+    async def test_delete_missing(self, memory_client):
+        result = await memory_client.delete("nonexistent")
+        assert result is False
+
+    async def test_exists_true(self, memory_client):
+        await memory_client.set("key1", "value1")
+        assert await memory_client.exists("key1") is True
+
+    async def test_exists_false(self, memory_client):
+        assert await memory_client.exists("nope") is False
+
+
+class TestMemoryClientTTL:
+    """TTL-based expiration."""
+
+    async def test_set_with_ttl(self, memory_client):
+        await memory_client.set("key1", "value1", ttl_seconds=3600)
+        result = await memory_client.get("key1")
+        assert result == "value1"
+
+    async def test_expired_key_returns_none(self, memory_client):
+        await memory_client.set("key1", "value1", ttl_seconds=1)
+        # Manually expire it
+        prefix = memory_client._prefix_key("key1")
+        memory_client._expiry[prefix] = time.time() - 1
+        result = await memory_client.get("key1")
+        assert result is None
+
+    async def test_ttl_returns_remaining(self, memory_client):
+        await memory_client.set("key1", "value1", ttl_seconds=3600)
+        remaining = await memory_client.ttl("key1")
+        assert 3590 < remaining <= 3600
+
+    async def test_ttl_no_expiry(self, memory_client):
+        await memory_client.set("key1", "value1")
+        result = await memory_client.ttl("key1")
+        assert result == -1
+
+    async def test_expire_sets_ttl(self, memory_client):
+        await memory_client.set("key1", "value1")
+        result = await memory_client.expire("key1", 60)
+        assert result is True
+        remaining = await memory_client.ttl("key1")
+        assert 50 < remaining <= 60
+
+    async def test_expire_nonexistent_key(self, memory_client):
+        result = await memory_client.expire("nope", 60)
+        assert result is False
+
+
+class TestMemoryClientIncr:
+    """Increment/decrement operations."""
+
+    async def test_incr_new_key(self, memory_client):
+        result = await memory_client.incr("counter")
+        assert result == 1
+
+    async def test_incr_existing(self, memory_client):
+        await memory_client.set("counter", "5")
+        result = await memory_client.incr("counter")
+        assert result == 6
+
+    async def test_incr_by_amount(self, memory_client):
+        await memory_client.set("counter", "10")
+        result = await memory_client.incr("counter", 5)
+        assert result == 15
+
+    async def test_decr(self, memory_client):
+        await memory_client.set("counter", "10")
+        result = await memory_client.decr("counter")
+        assert result == 9
+
+
+class TestMemoryClientMultiKey:
+    """Multi-key operations (mset, mget, delete_many)."""
+
+    async def test_mset_and_mget(self, memory_client):
+        await memory_client.mset({"k1": "v1", "k2": "v2", "k3": "v3"})
+        result = await memory_client.mget(["k1", "k2", "k3"])
+        assert result == ["v1", "v2", "v3"]
+
+    async def test_mget_with_missing(self, memory_client):
+        await memory_client.set("k1", "v1")
+        result = await memory_client.mget(["k1", "missing"])
+        assert result == ["v1", None]
+
+    async def test_delete_many(self, memory_client):
+        await memory_client.mset({"k1": "v1", "k2": "v2"})
+        count = await memory_client.delete_many(["k1", "k2", "k3"])
+        assert count == 2
+
+
+class TestMemoryClientKeys:
+    """Key pattern matching and scanning."""
+
+    async def test_keys_pattern(self, memory_client):
+        await memory_client.mset({"user:1": "a", "user:2": "b", "session:1": "c"})
+        result = await memory_client.keys("user:*")
+        assert sorted(result) == ["user:1", "user:2"]
+
+    async def test_keys_all(self, memory_client):
+        await memory_client.mset({"k1": "v1", "k2": "v2"})
+        result = await memory_client.keys("*")
+        assert len(result) == 2
+
+    async def test_scan_pagination(self, memory_client):
+        await memory_client.mset({f"k{i}": f"v{i}" for i in range(5)})
+        cursor, batch = await memory_client.scan(cursor=0, pattern="*", count=3)
+        assert len(batch) == 3
+        assert cursor > 0  # More results available
+
+
+class TestMemoryClientFlush:
+    """Flush operations."""
+
+    async def test_flush_clears_tenant_keys(self, memory_client):
+        await memory_client.mset({"k1": "v1", "k2": "v2"})
+        result = await memory_client.flush()
+        assert result is True
+        assert await memory_client.keys("*") == []
+
+    async def test_flush_all(self, memory_client):
+        await memory_client.mset({"k1": "v1"})
+        result = await memory_client.flush_all()
+        assert result is True
+        assert len(memory_client._store) == 0
+
+
+# ============================================================================
+# L2 — Hash operations
+# ============================================================================
+
+
+class TestMemoryClientHash:
+    """Hash (dict-like) operations."""
+
+    async def test_hset_and_hget(self, memory_client):
+        await memory_client.hset("myhash", "field1", "value1")
+        result = await memory_client.hget("myhash", "field1")
+        assert result == "value1"
+
+    async def test_hget_missing_field(self, memory_client):
+        await memory_client.hset("myhash", "field1", "value1")
+        result = await memory_client.hget("myhash", "missing")
+        assert result is None
+
+    async def test_hget_missing_hash(self, memory_client):
+        result = await memory_client.hget("nohash", "field")
+        assert result is None
+
+    async def test_hgetall(self, memory_client):
+        await memory_client.hset("myhash", "f1", "v1")
+        await memory_client.hset("myhash", "f2", "v2")
+        result = await memory_client.hgetall("myhash")
+        assert result == {"f1": "v1", "f2": "v2"}
+
+    async def test_hgetall_empty(self, memory_client):
+        result = await memory_client.hgetall("nohash")
+        assert result == {}
+
+    async def test_hdel(self, memory_client):
+        await memory_client.hset("myhash", "f1", "v1")
+        result = await memory_client.hdel("myhash", "f1")
+        assert result is True
+        assert await memory_client.hget("myhash", "f1") is None
+
+    async def test_hdel_missing(self, memory_client):
+        result = await memory_client.hdel("myhash", "nope")
+        assert result is False
+
+
+# ============================================================================
+# L2 — List operations
+# ============================================================================
+
+
+class TestMemoryClientList:
+    """List (lpush, rpush, lrange, llen) operations."""
+
+    async def test_rpush_and_lrange(self, memory_client):
+        await memory_client.rpush("mylist", "a", "b", "c")
+        result = await memory_client.lrange("mylist", 0, -1)
+        assert result == ["a", "b", "c"]
+
+    async def test_lpush(self, memory_client):
+        await memory_client.rpush("mylist", "b")
+        await memory_client.lpush("mylist", "a")
+        result = await memory_client.lrange("mylist", 0, -1)
+        assert result == ["a", "b"]
+
+    async def test_llen(self, memory_client):
+        await memory_client.rpush("mylist", "a", "b", "c")
+        result = await memory_client.llen("mylist")
+        assert result == 3
+
+    async def test_llen_empty(self, memory_client):
+        result = await memory_client.llen("empty")
+        assert result == 0
+
+    async def test_lrange_slice(self, memory_client):
+        await memory_client.rpush("mylist", "a", "b", "c", "d")
+        result = await memory_client.lrange("mylist", 1, 2)
+        assert result == ["b", "c"]
+
+
+# ============================================================================
+# L2 — Health check and stats
+# ============================================================================
+
+
+class TestMemoryClientHealthCheck:
+    """health_check returns status."""
+
+    async def test_health_check(self, memory_client):
+        result = await memory_client.health_check()
+        assert result["healthy"] is True
+        assert result["key_count"] == 0
+
+
+class TestMemoryClientStats:
+    """get_stats returns statistics."""
+
+    async def test_get_stats(self, memory_client):
+        await memory_client.mset({"k1": "v1", "k2": "v2"})
+        stats = await memory_client.get_stats()
+        assert stats["total_keys"] == 2
+        assert stats["storage_type"] == "in-memory"
+
+
+class TestMemoryClientDisconnect:
+    """_disconnect cancels cleanup task."""
+
+    async def test_disconnect_cancels_cleanup(self, memory_client):
+        import asyncio
+
+        # Create a real task that sleeps forever
+        async def forever():
+            await asyncio.sleep(3600)
+
+        task = asyncio.create_task(forever())
+        memory_client._cleanup_task = task
+        await memory_client._disconnect()
+        assert task.cancelled()
+        assert memory_client._cleanup_task is None
+
+
+class TestMemoryClientGlobalVsInstance:
+    """Global vs instance store isolation."""
+
+    def test_instance_store_isolation(self):
+        from isa_common import AsyncMemoryClient
+        c1 = AsyncMemoryClient(use_global_store=False, lazy_connect=True)
+        c2 = AsyncMemoryClient(use_global_store=False, lazy_connect=True)
+        c1._store["key"] = "val"
+        assert "key" not in c2._store

--- a/isA_common/tests/unit/test_sqlite_unit.py
+++ b/isA_common/tests/unit/test_sqlite_unit.py
@@ -1,0 +1,241 @@
+"""Unit tests for AsyncSQLiteClient — #119."""
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ============================================================================
+# L1 — Pure helper functions (no I/O)
+# ============================================================================
+
+
+class TestConvertPgPlaceholders:
+    """_convert_pg_placeholders converts $N to ?."""
+
+    def test_single_placeholder(self):
+        from isa_common.async_sqlite_client import _convert_pg_placeholders
+        assert _convert_pg_placeholders("SELECT * FROM t WHERE id = $1") == \
+            "SELECT * FROM t WHERE id = ?"
+
+    def test_multiple_placeholders(self):
+        from isa_common.async_sqlite_client import _convert_pg_placeholders
+        result = _convert_pg_placeholders(
+            "INSERT INTO t (a, b, c) VALUES ($1, $2, $3)"
+        )
+        assert result == "INSERT INTO t (a, b, c) VALUES (?, ?, ?)"
+
+    def test_no_placeholders(self):
+        from isa_common.async_sqlite_client import _convert_pg_placeholders
+        sql = "SELECT * FROM t"
+        assert _convert_pg_placeholders(sql) == sql
+
+
+class TestConvertPgSyntax:
+    """_convert_pg_syntax handles ILIKE → LIKE."""
+
+    def test_ilike_to_like(self):
+        from isa_common.async_sqlite_client import _convert_pg_syntax
+        assert "LIKE" in _convert_pg_syntax("SELECT * FROM t WHERE name ILIKE '%foo%'")
+        assert "ILIKE" not in _convert_pg_syntax("SELECT * FROM t WHERE name ILIKE '%foo%'")
+
+    def test_preserves_regular_like(self):
+        from isa_common.async_sqlite_client import _convert_pg_syntax
+        sql = "SELECT * FROM t WHERE name LIKE '%foo%'"
+        assert _convert_pg_syntax(sql) == sql
+
+
+class TestSerializeValue:
+    """_serialize_value converts dicts/lists to JSON strings."""
+
+    def test_dict(self):
+        from isa_common.async_sqlite_client import _serialize_value
+        result = _serialize_value({"key": "value"})
+        assert result == '{"key": "value"}'
+
+    def test_list(self):
+        from isa_common.async_sqlite_client import _serialize_value
+        result = _serialize_value([1, 2, 3])
+        assert result == "[1, 2, 3]"
+
+    def test_scalar_passthrough(self):
+        from isa_common.async_sqlite_client import _serialize_value
+        assert _serialize_value(42) == 42
+        assert _serialize_value("hello") == "hello"
+        assert _serialize_value(None) is None
+
+
+class TestDeserializeRow:
+    """_deserialize_row converts SQLite rows to dicts with JSON parsing."""
+
+    def test_basic_row(self):
+        from isa_common.async_sqlite_client import _deserialize_row
+        row = ("alice", 30)
+        description = [("name",), ("age",)]
+        result = _deserialize_row(row, description)
+        assert result == {"name": "alice", "age": 30}
+
+    def test_json_string_value(self):
+        from isa_common.async_sqlite_client import _deserialize_row
+        row = ('{"key": "value"}',)
+        description = [("data",)]
+        result = _deserialize_row(row, description)
+        assert result == {"data": {"key": "value"}}
+
+    def test_json_array_value(self):
+        from isa_common.async_sqlite_client import _deserialize_row
+        row = ('[1, 2, 3]',)
+        description = [("tags",)]
+        result = _deserialize_row(row, description)
+        assert result == {"tags": [1, 2, 3]}
+
+    def test_non_json_string(self):
+        from isa_common.async_sqlite_client import _deserialize_row
+        row = ("hello world",)
+        description = [("name",)]
+        result = _deserialize_row(row, description)
+        assert result == {"name": "hello world"}
+
+
+# ============================================================================
+# L2 — Component tests (mocked aiosqlite)
+# ============================================================================
+
+
+class TestSQLiteClientInit:
+    """AsyncSQLiteClient initialization."""
+
+    def test_default_init(self, tmp_path):
+        from isa_common import AsyncSQLiteClient
+        client = AsyncSQLiteClient(
+            database="test.db", db_path=str(tmp_path), lazy_connect=True
+        )
+        assert client._database == "test.db"
+        assert client._db_file == tmp_path / "test.db"
+
+    def test_default_database_name(self, tmp_path):
+        from isa_common import AsyncSQLiteClient
+        client = AsyncSQLiteClient(db_path=str(tmp_path), lazy_connect=True)
+        assert client._database == "isa_mcp.db"
+
+
+class TestSQLiteClientDisconnect:
+    """_disconnect closes connection."""
+
+    async def test_disconnect_closes_conn(self, sqlite_client):
+        mock_conn = AsyncMock()
+        sqlite_client._conn = mock_conn
+        await sqlite_client._disconnect()
+        mock_conn.close.assert_awaited_once()
+        assert sqlite_client._conn is None
+
+    async def test_disconnect_noop_when_no_conn(self, sqlite_client):
+        sqlite_client._conn = None
+        await sqlite_client._disconnect()  # Should not raise
+
+
+class TestSQLiteClientQuery:
+    """query() executes SELECT and returns rows."""
+
+    async def test_query_returns_rows(self, sqlite_client):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall = AsyncMock(return_value=[("alice", 30)])
+        mock_cursor.description = [("name",), ("age",)]
+        mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+        mock_cursor.__aexit__ = AsyncMock(return_value=None)
+        sqlite_client._conn.execute = MagicMock(return_value=mock_cursor)
+
+        result = await sqlite_client.query("SELECT * FROM users WHERE id = $1", [1])
+        assert result == [{"name": "alice", "age": 30}]
+
+    async def test_query_empty_result(self, sqlite_client):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall = AsyncMock(return_value=[])
+        mock_cursor.description = [("name",)]
+        mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+        mock_cursor.__aexit__ = AsyncMock(return_value=None)
+        sqlite_client._conn.execute = MagicMock(return_value=mock_cursor)
+
+        result = await sqlite_client.query("SELECT * FROM users")
+        assert result == []
+
+    async def test_query_with_schema(self, sqlite_client):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall = AsyncMock(return_value=[])
+        mock_cursor.description = [("id",)]
+        mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+        mock_cursor.__aexit__ = AsyncMock(return_value=None)
+        sqlite_client._conn.execute = MagicMock(return_value=mock_cursor)
+
+        await sqlite_client.query("SELECT * FROM myschema.users", schema="myschema")
+        # Verify the SQL was converted: myschema.users -> myschema_users
+        call_args = sqlite_client._conn.execute.call_args
+        assert "myschema_" in call_args[0][0]
+
+
+class TestSQLiteClientExecute:
+    """execute() runs INSERT/UPDATE/DELETE."""
+
+    async def test_execute_returns_rowcount(self, sqlite_client):
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 3
+        mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+        mock_cursor.__aexit__ = AsyncMock(return_value=None)
+        sqlite_client._conn.execute = MagicMock(return_value=mock_cursor)
+        sqlite_client._conn.commit = AsyncMock()
+
+        result = await sqlite_client.execute(
+            "DELETE FROM users WHERE active = $1", [False]
+        )
+        assert result == 3
+
+
+class TestSQLiteClientInsertInto:
+    """insert_into() batch inserts rows."""
+
+    async def test_insert_empty_rows(self, sqlite_client):
+        result = await sqlite_client.insert_into("users", [])
+        assert result == 0
+
+    async def test_insert_rows(self, sqlite_client):
+        sqlite_client._conn.execute = AsyncMock()
+        sqlite_client._conn.commit = AsyncMock()
+
+        rows = [{"name": "alice"}, {"name": "bob"}]
+        result = await sqlite_client.insert_into("users", rows)
+        assert result == 2
+
+
+class TestSQLiteClientHealthCheck:
+    """health_check() returns status dict."""
+
+    async def test_health_check_healthy(self, sqlite_client):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone = AsyncMock(return_value=("3.40.0",))
+        mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+        mock_cursor.__aexit__ = AsyncMock(return_value=None)
+        sqlite_client._conn.execute = MagicMock(return_value=mock_cursor)
+        # Mock _db_file existence
+        sqlite_client._db_file = MagicMock()
+        sqlite_client._db_file.exists.return_value = True
+        sqlite_client._db_file.stat.return_value = MagicMock(st_size=4096)
+
+        result = await sqlite_client.health_check()
+        assert result["healthy"] is True
+        assert result["version"] == "3.40.0"
+
+
+class TestSQLiteClientExecuteScript:
+    """execute_script() runs multi-statement SQL."""
+
+    async def test_execute_script_converts_types(self, sqlite_client):
+        sqlite_client._conn.executescript = AsyncMock()
+
+        script = "CREATE TABLE t (id SERIAL, data JSONB, ts TIMESTAMPTZ)"
+        result = await sqlite_client.execute_script(script)
+        assert result is True
+
+        called_sql = sqlite_client._conn.executescript.call_args[0][0]
+        assert "INTEGER" in called_sql
+        assert "TEXT" in called_sql
+        assert "SERIAL" not in called_sql
+        assert "JSONB" not in called_sql


### PR DESCRIPTION
## Summary
- Add 159 L1/L2 unit tests for 5 previously untested local-mode clients: AsyncSQLiteClient, AsyncLocalStorageClient, AsyncChromaClient, AsyncMemoryClient, and ConsulRegistry
- Add test fixtures for all 5 clients to `tests/unit/conftest.py`
- Covers helper functions, CRUD operations, lifecycle management, error paths, and path traversal protection

Fixes #119

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 38 (pure helpers) | Pass |
| L2 Component | 121 (mocked deps) | Pass |
| L3 Integration | N/A | — |
| L4 API | N/A | — |
| L5 Smoke | N/A | — |

**Full suite: 390 passed, 0 failed**

## Files Changed
- `tests/unit/conftest.py` — 5 new fixtures (sqlite, local_storage, chroma, memory, consul)
- `tests/unit/test_sqlite_unit.py` — PG→SQLite helpers, query/execute, health check
- `tests/unit/test_local_storage_unit.py` — path helpers, bucket/object CRUD, presigned URLs
- `tests/unit/test_chroma_unit.py` — flatten/unflatten, where clause, search parsing, collection mgmt
- `tests/unit/test_memory_unit.py` — string/hash/list ops, TTL, flush, global vs instance store
- `tests/unit/test_consul_unit.py` — registration, KV config, discovery, round-robin, stale cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)