### PR TITLE
fix(core): fix MQTT health_check and MinIO bucket_exists error handling

### DIFF
--- a/isA_common/isa_common/async_minio_client.py
+++ b/isA_common/isa_common/async_minio_client.py
@@ -297,8 +297,10 @@ class AsyncMinIOClient(AsyncBaseClient):
             error_code = e.response.get('Error', {}).get('Code', '')
             if error_code in ('404', 'NoSuchBucket'):
                 return False
+            self.handle_error(e, "bucket_exists")
             return False
-        except Exception:
+        except Exception as e:
+            self.handle_error(e, "bucket_exists")
             return False
 
     async def get_bucket_info(self, bucket_name: str) -> Optional[Dict]:

--- a/isA_common/isa_common/async_mqtt_client.py
+++ b/isA_common/isa_common/async_mqtt_client.py
@@ -127,12 +127,7 @@ class AsyncMQTTClient(AsyncBaseClient):
                 }
 
         except Exception as e:
-            return {
-                'healthy': False,
-                'broker_status': 'disconnected',
-                'active_connections': 0,
-                'message': str(e)
-            }
+            return self.handle_error(e, "health check")
 
     # ============================================
     # Connection Management

--- a/isA_common/tests/unit/test_mqtt_unit.py
+++ b/isA_common/tests/unit/test_mqtt_unit.py
@@ -28,17 +28,15 @@ class TestMQTTHealthCheck:
         assert result is not None
         assert result.get("healthy") is True
 
-    async def test_health_check_error_returns_unhealthy(self, mqtt_client):
-        # MQTT health_check returns a dict with healthy=False on error (not None)
+    async def test_health_check_error_returns_none(self, mqtt_client):
+        # MQTT health_check now returns None on error (consistent with all other clients)
         mock_mqtt = AsyncMock()
         mock_mqtt.__aenter__ = AsyncMock(side_effect=Exception("connection refused"))
 
         with patch("isa_common.async_mqtt_client.aiomqtt.Client", return_value=mock_mqtt):
             result = await mqtt_client.health_check()
 
-        assert result is not None
-        assert result.get("healthy") is False
-        assert result.get("broker_status") == "disconnected"
+        assert result is None
 
 
 class TestMQTTSessionManagement:


### PR DESCRIPTION
## Summary
- MQTT `health_check()` now returns `None` on error via `handle_error()` instead of a dict — matches all other clients
- MinIO `bucket_exists()` now calls `handle_error()` for non-404 errors instead of silently swallowing them

Fixes #132
**Parent Issue**: #124 | **Parent Epic**: #92

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 1 updated | Pass |
| Full suite | 417 | Pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)