### PR TITLE
fix(core): standardize mutation error returns across async clients

### DIFF
--- a/isA_common/isa_common/async_loki_client.py
+++ b/isA_common/isa_common/async_loki_client.py
@@ -156,8 +156,7 @@ class AsyncLokiClient(AsyncBaseClient):
 
             return True
         except Exception as e:
-            self.handle_error(e, "push_log")
-            return False
+            return self.handle_error(e, "push_log")
 
     async def push_batch(
         self,
@@ -208,8 +207,7 @@ class AsyncLokiClient(AsyncBaseClient):
                 return False
 
         except Exception as e:
-            self.handle_error(e, "push_batch")
-            return False
+            return self.handle_error(e, "push_batch")
 
     async def _flush_batch(self) -> bool:
         """Flush accumulated batch to Loki.

--- a/isA_common/isa_common/async_memory_client.py
+++ b/isA_common/isa_common/async_memory_client.py
@@ -163,8 +163,7 @@ class AsyncMemoryClient(AsyncBaseClient):
             return True
 
         except Exception as e:
-            self.handle_error(e, "set")
-            return False
+            return self.handle_error(e, "set")
 
     async def get(self, key: str) -> Optional[str]:
         """Get value by key."""
@@ -197,8 +196,7 @@ class AsyncMemoryClient(AsyncBaseClient):
             return existed
 
         except Exception as e:
-            self.handle_error(e, "delete")
-            return False
+            return self.handle_error(e, "delete")
 
     async def exists(self, key: str) -> bool:
         """Check if key exists."""
@@ -249,8 +247,7 @@ class AsyncMemoryClient(AsyncBaseClient):
                 return False
 
         except Exception as e:
-            self.handle_error(e, "expire")
-            return False
+            return self.handle_error(e, "expire")
 
     async def incr(self, key: str, amount: int = 1) -> Optional[int]:
         """Increment value by amount."""
@@ -293,8 +290,7 @@ class AsyncMemoryClient(AsyncBaseClient):
             return True
 
         except Exception as e:
-            self.handle_error(e, "mset")
-            return False
+            return self.handle_error(e, "mset")
 
     async def mget(self, keys: List[str]) -> List[Optional[str]]:
         """Get multiple values by keys."""
@@ -402,8 +398,7 @@ class AsyncMemoryClient(AsyncBaseClient):
             return True
 
         except Exception as e:
-            self.handle_error(e, "flush")
-            return False
+            return self.handle_error(e, "flush")
 
     async def flush_all(self) -> Optional[bool]:
         """Clear all keys (globally)."""
@@ -417,8 +412,7 @@ class AsyncMemoryClient(AsyncBaseClient):
             return True
 
         except Exception as e:
-            self.handle_error(e, "flush_all")
-            return False
+            return self.handle_error(e, "flush_all")
 
     # ============================================
     # Hash Operations
@@ -445,8 +439,7 @@ class AsyncMemoryClient(AsyncBaseClient):
             return True
 
         except Exception as e:
-            self.handle_error(e, "hset")
-            return False
+            return self.handle_error(e, "hset")
 
     async def hget(self, name: str, key: str) -> Optional[str]:
         """Get hash field."""
@@ -503,8 +496,7 @@ class AsyncMemoryClient(AsyncBaseClient):
                 return False
 
         except Exception as e:
-            self.handle_error(e, "hdel")
-            return False
+            return self.handle_error(e, "hdel")
 
     # ============================================
     # List Operations

--- a/isA_common/isa_common/async_minio_client.py
+++ b/isA_common/isa_common/async_minio_client.py
@@ -246,8 +246,7 @@ class AsyncMinIOClient(AsyncBaseClient):
                 return True
 
         except Exception as e:
-            self.handle_error(e, "delete bucket")
-            return False
+            return self.handle_error(e, "delete bucket")
 
     async def _empty_bucket(self, client, bucket_name: str):
         """Delete all objects in a bucket."""
@@ -461,8 +460,7 @@ class AsyncMinIOClient(AsyncBaseClient):
                     raise e
 
         except Exception as e:
-            self.handle_error(e, "upload large file")
-            return False
+            return self.handle_error(e, "upload large file")
 
     # ============================================
     # Object Download
@@ -552,12 +550,10 @@ class AsyncMinIOClient(AsyncBaseClient):
                 return True
 
             except Exception as e:
-                self.handle_error(e, "download to file")
-                return False
+                return self.handle_error(e, "download to file")
 
         except Exception as e:
-            self.handle_error(e, "download to file")
-            return False
+            return self.handle_error(e, "download to file")
 
     # ============================================
     # Object Management
@@ -608,8 +604,7 @@ class AsyncMinIOClient(AsyncBaseClient):
                 return True
 
         except Exception as e:
-            self.handle_error(e, "delete object")
-            return False
+            return self.handle_error(e, "delete object")
 
     async def delete_objects(self, bucket_name: str, object_keys: List[str]) -> bool:
         """Batch delete objects."""
@@ -625,8 +620,7 @@ class AsyncMinIOClient(AsyncBaseClient):
                 return True
 
         except Exception as e:
-            self.handle_error(e, "delete objects")
-            return False
+            return self.handle_error(e, "delete objects")
 
     async def copy_object(
         self,
@@ -649,8 +643,7 @@ class AsyncMinIOClient(AsyncBaseClient):
                 return True
 
         except Exception as e:
-            self.handle_error(e, "copy object")
-            return False
+            return self.handle_error(e, "copy object")
 
     async def get_object_metadata(self, bucket_name: str, object_key: str) -> Optional[Dict]:
         """Get object metadata without downloading content."""
@@ -754,8 +747,7 @@ class AsyncMinIOClient(AsyncBaseClient):
                 return True
 
         except Exception as e:
-            self.handle_error(e, "set bucket versioning")
-            return False
+            return self.handle_error(e, "set bucket versioning")
 
     async def set_bucket_tags(self, bucket_name: str, tags: Dict[str, str]) -> bool:
         """Set bucket tags."""
@@ -771,8 +763,7 @@ class AsyncMinIOClient(AsyncBaseClient):
                 return True
 
         except Exception as e:
-            self.handle_error(e, "set bucket tags")
-            return False
+            return self.handle_error(e, "set bucket tags")
 
     async def get_bucket_tags(self, bucket_name: str) -> Optional[Dict[str, str]]:
         """Get bucket tags."""
@@ -813,8 +804,7 @@ class AsyncMinIOClient(AsyncBaseClient):
                 return True
 
         except Exception as e:
-            self.handle_error(e, "set object tags")
-            return False
+            return self.handle_error(e, "set object tags")
 
     async def get_object_tags(self, bucket_name: str, object_key: str) -> Optional[Dict[str, str]]:
         """Get object tags."""

--- a/isA_common/isa_common/async_redis_client.py
+++ b/isA_common/isa_common/async_redis_client.py
@@ -126,8 +126,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return result is True or result == 'OK'
 
         except Exception as e:
-            self.handle_error(e, "set")
-            return False
+            return self.handle_error(e, "set")
 
     async def get(self, key: str) -> Optional[str]:
         """Get value by key."""
@@ -146,8 +145,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return result > 0
 
         except Exception as e:
-            self.handle_error(e, "delete")
-            return False
+            return self.handle_error(e, "delete")
 
     async def exists(self, key: str) -> bool:
         """Check if key exists."""
@@ -194,8 +192,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return True
 
         except Exception as e:
-            self.handle_error(e, "mset")
-            return False
+            return self.handle_error(e, "mset")
 
     async def mget(self, keys: List[str]) -> Dict[str, str]:
         """Batch get key-values."""
@@ -221,8 +218,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return await self._client.delete(*prefixed_keys)
 
         except Exception as e:
-            self.handle_error(e, "delete_multiple")
-            return 0
+            return self.handle_error(e, "delete_multiple")
 
     async def execute_batch(self, commands: List[Dict]) -> Optional[Dict]:
         """Execute batch commands using pipeline."""
@@ -295,8 +291,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return await self._client.expire(self._prefix_key(key), seconds)
 
         except Exception as e:
-            self.handle_error(e, "expire")
-            return False
+            return self.handle_error(e, "expire")
 
     async def ttl(self, key: str) -> Optional[int]:
         """Get time to live."""
@@ -318,8 +313,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return True
 
         except Exception as e:
-            self.handle_error(e, "rename")
-            return False
+            return self.handle_error(e, "rename")
 
     async def list_keys(self, pattern: str = "*", limit: int = 100) -> List[str]:
         """List keys matching pattern."""
@@ -413,8 +407,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return True
 
         except Exception as e:
-            self.handle_error(e, "hset")
-            return False
+            return self.handle_error(e, "hset")
 
     async def hget(self, key: str, field: str) -> Optional[str]:
         """Get hash field."""
@@ -441,8 +434,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return await self._client.hdel(self._prefix_key(key), *fields)
 
         except Exception as e:
-            self.handle_error(e, "hdelete")
-            return 0
+            return self.handle_error(e, "hdelete")
 
     async def hexists(self, key: str, field: str) -> bool:
         """Check if hash field exists."""
@@ -617,8 +609,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return result == 1
 
         except Exception as e:
-            self.handle_error(e, "release_lock")
-            return False
+            return self.handle_error(e, "release_lock")
 
     async def renew_lock(self, lock_key: str, lock_id: str, ttl_seconds: int = 10) -> bool:
         """Renew distributed lock TTL."""
@@ -638,8 +629,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return result == 1
 
         except Exception as e:
-            self.handle_error(e, "renew_lock")
-            return False
+            return self.handle_error(e, "renew_lock")
 
     # ============================================
     # Pub/Sub Operations
@@ -722,8 +712,7 @@ class AsyncRedisClient(AsyncBaseClient):
             return result > 0
 
         except Exception as e:
-            self.handle_error(e, "delete_session")
-            return False
+            return self.handle_error(e, "delete_session")
 
     # ============================================
     # Statistics

--- a/isA_common/tests/unit/test_loki_unit.py
+++ b/isA_common/tests/unit/test_loki_unit.py
@@ -166,7 +166,7 @@ class TestLokiPushBatch:
 
         result = await loki_client.push_batch([{"labels": {}, "message": "fail"}])
 
-        assert result is False
+        assert result is None
 
 
 class TestLokiQuery:

--- a/isA_common/tests/unit/test_redis_unit.py
+++ b/isA_common/tests/unit/test_redis_unit.py
@@ -122,12 +122,12 @@ class TestRedisMultiTenant:
 
 
 class TestRedisErrorHandling:
-    async def test_set_connection_error_returns_false(self, redis_client):
+    async def test_set_connection_error_returns_none(self, redis_client):
         redis_client._client.set = AsyncMock(side_effect=ConnectionError("refused"))
 
         result = await redis_client.set("key", "value")
 
-        assert result is False
+        assert result is None
 
     async def test_get_connection_error_returns_none(self, redis_client):
         redis_client._client.get = AsyncMock(side_effect=ConnectionError("refused"))


### PR DESCRIPTION
## Summary
- Standardize 30 mutation method error paths across 4 async clients to use `return self.handle_error(e, "op")` instead of `self.handle_error(); return False/0`
- Ensures all mutation errors consistently return `None` (from `handle_error()`) per the Error Return Convention documented in #133
- Updates 2 test assertions to expect `None` instead of `False` for mutation errors

### Clients updated
| Client | Methods Changed |
|--------|----------------|
| AsyncRedisClient | 11 (`set`, `delete`, `mset`, `delete_multiple`, `expire`, `rename`, `hset`, `hdelete`, `release_lock`, `renew_lock`, `delete_session`) |
| AsyncMinIOClient | 9 (`delete_bucket`, `upload_large_file`, `download_to_file` ×2, `delete_object`, `delete_objects`, `copy_object`, `set_bucket_versioning`, `set_bucket_tags`, `set_object_tags`) |
| AsyncMemoryClient | 8 (`set`, `delete`, `mset`, `expire`, `flush`, `flush_all`, `hset`, `hdel`) |
| AsyncLokiClient | 2 (`push_log`, `push_batch`) |

Boolean methods (`exists`, `bucket_exists`, `hexists`, `sismember`) and logic-flow returns intentionally unchanged.

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L1 Unit | 417 | Pass |
| L2 Component | N/A | N/A |
| L3 Integration | N/A | N/A |

Fixes #134
**Parent Epic**: #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)