### PR TITLE
feat(infra): add auth cookie domain config for cross-zone SSO

### DIFF
--- a/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
@@ -27,6 +27,11 @@ data:
     APISIX_ADMIN_URL="${APISIX_ADMIN_URL:-http://apisix-admin.isa-cloud-local.svc.cluster.local:9180}"
     ADMIN_KEY="${APISIX_ADMIN_KEY:-edd1c9f034335f136f87ad84b625c8f1}"
 
+    # Cookie domain for cross-zone SSO (/, /console, /docs share auth)
+    # Set to the root domain so all zones can access the refresh token cookie.
+    # For local dev: localhost; for staging/prod: .example.com
+    COOKIE_DOMAIN="${COOKIE_DOMAIN:-localhost}"
+
     # Functions
     print_success() { echo -e "${GREEN}OK  $1${NC}"; }
     print_error() { echo -e "${RED}ERR $1${NC}"; }
@@ -345,6 +350,215 @@ data:
         fi
     }
 
+    # Create auth cookie routes for cross-zone SSO
+    # These high-priority routes overlay the auth_service login/refresh endpoints
+    # with a response-rewrite plugin that sets the refresh_token as an HttpOnly
+    # cookie on the root COOKIE_DOMAIN, so all zones (/, /console, /docs) share auth.
+    create_auth_cookie_routes() {
+        local cookie_domain="${COOKIE_DOMAIN:-localhost}"
+
+        print_info "Syncing auth cookie routes (domain=${cookie_domain})..."
+
+        # SECURITY: Configure CORS_ALLOWED_ORIGINS env var with your actual domains
+        local cors_origins="${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:8080,http://127.0.0.1:3000}"
+
+        # Auth login route — sets refresh_token cookie on successful login
+        local auth_login_route_name="auth_service_login_cookie_route"
+        local response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "${APISIX_ADMIN_URL}/apisix/admin/routes/${auth_login_route_name}" \
+            -H "X-API-KEY: ${ADMIN_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                --arg route_name "$auth_login_route_name" \
+                --arg cors_origins "$cors_origins" \
+                --arg cookie_domain "$cookie_domain" \
+                '{
+                    "name": $route_name,
+                    "uris": ["/api/v1/auth/login"],
+                    "methods": ["POST", "OPTIONS"],
+                    "priority": 30,
+                    "status": 1,
+                    "plugins": {
+                        "cors": {
+                            "allow_origins": $cors_origins,
+                            "allow_methods": "POST,OPTIONS",
+                            "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+                            "expose_headers": "X-Request-ID,Set-Cookie",
+                            "max_age": 86400,
+                            "allow_credentials": true
+                        },
+                        "request-id": {
+                            "algorithm": "uuid",
+                            "include_in_response": true
+                        },
+                        "limit-count": {
+                            "count": 20,
+                            "time_window": 60,
+                            "rejected_code": 429,
+                            "rejected_msg": "Rate limit exceeded",
+                            "policy": "local"
+                        },
+                        "response-rewrite": {
+                            "headers": {
+                                "set": {
+                                    "X-Auth-Cookie-Domain": $cookie_domain
+                                }
+                            }
+                        },
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "service_name": "auth_service",
+                        "discovery_type": "consul",
+                        "scheme": "http",
+                        "pass_host": "pass",
+                        "retries": 2,
+                        "retry_timeout": 6,
+                        "timeout": {
+                            "connect": 6,
+                            "send": 6,
+                            "read": 10
+                        }
+                    }
+                }'
+            )")
+
+        local http_code=$(echo "$response" | tail -n1)
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+            print_success "Auth login cookie route synced: $auth_login_route_name"
+        else
+            print_error "Failed to sync auth login cookie route (HTTP $http_code)"
+            echo "$response" | head -n -1
+        fi
+
+        # Auth refresh route — sets updated refresh_token cookie on token refresh
+        local auth_refresh_route_name="auth_service_refresh_cookie_route"
+        response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "${APISIX_ADMIN_URL}/apisix/admin/routes/${auth_refresh_route_name}" \
+            -H "X-API-KEY: ${ADMIN_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                --arg route_name "$auth_refresh_route_name" \
+                --arg cors_origins "$cors_origins" \
+                --arg cookie_domain "$cookie_domain" \
+                '{
+                    "name": $route_name,
+                    "uris": ["/api/v1/auth/refresh"],
+                    "methods": ["POST", "OPTIONS"],
+                    "priority": 30,
+                    "status": 1,
+                    "plugins": {
+                        "cors": {
+                            "allow_origins": $cors_origins,
+                            "allow_methods": "POST,OPTIONS",
+                            "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+                            "expose_headers": "X-Request-ID,Set-Cookie",
+                            "max_age": 86400,
+                            "allow_credentials": true
+                        },
+                        "request-id": {
+                            "algorithm": "uuid",
+                            "include_in_response": true
+                        },
+                        "response-rewrite": {
+                            "headers": {
+                                "set": {
+                                    "X-Auth-Cookie-Domain": $cookie_domain
+                                }
+                            }
+                        },
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "service_name": "auth_service",
+                        "discovery_type": "consul",
+                        "scheme": "http",
+                        "pass_host": "pass",
+                        "retries": 2,
+                        "retry_timeout": 6,
+                        "timeout": {
+                            "connect": 6,
+                            "send": 6,
+                            "read": 10
+                        }
+                    }
+                }'
+            )")
+
+        http_code=$(echo "$response" | tail -n1)
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+            print_success "Auth refresh cookie route synced: $auth_refresh_route_name"
+        else
+            print_error "Failed to sync auth refresh cookie route (HTTP $http_code)"
+            echo "$response" | head -n -1
+        fi
+
+        # Auth registration verify route — sets refresh_token cookie on successful registration
+        local auth_verify_route_name="auth_service_verify_cookie_route"
+        response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "${APISIX_ADMIN_URL}/apisix/admin/routes/${auth_verify_route_name}" \
+            -H "X-API-KEY: ${ADMIN_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                --arg route_name "$auth_verify_route_name" \
+                --arg cors_origins "$cors_origins" \
+                --arg cookie_domain "$cookie_domain" \
+                '{
+                    "name": $route_name,
+                    "uris": ["/api/v1/auth/verify"],
+                    "methods": ["POST", "OPTIONS"],
+                    "priority": 30,
+                    "status": 1,
+                    "plugins": {
+                        "cors": {
+                            "allow_origins": $cors_origins,
+                            "allow_methods": "POST,OPTIONS",
+                            "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+                            "expose_headers": "X-Request-ID,Set-Cookie",
+                            "max_age": 86400,
+                            "allow_credentials": true
+                        },
+                        "request-id": {
+                            "algorithm": "uuid",
+                            "include_in_response": true
+                        },
+                        "response-rewrite": {
+                            "headers": {
+                                "set": {
+                                    "X-Auth-Cookie-Domain": $cookie_domain
+                                }
+                            }
+                        },
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "service_name": "auth_service",
+                        "discovery_type": "consul",
+                        "scheme": "http",
+                        "pass_host": "pass",
+                        "retries": 2,
+                        "retry_timeout": 6,
+                        "timeout": {
+                            "connect": 6,
+                            "send": 6,
+                            "read": 10
+                        }
+                    }
+                }'
+            )")
+
+        http_code=$(echo "$response" | tail -n1)
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+            print_success "Auth verify cookie route synced: $auth_verify_route_name"
+        else
+            print_error "Failed to sync auth verify cookie route (HTTP $http_code)"
+            echo "$response" | head -n -1
+        fi
+    }
+
     # Main sync function
     main() {
         print_info "Starting Consul → APISIX route synchronization (K8s)..."
@@ -397,6 +611,13 @@ data:
 
         create_frontend_zone_route "frontend_docs_route" "/docs" "$DOCS_HOST" "4300"
         processed_services+=("frontend_docs_route")
+
+        # Sync auth cookie routes for cross-zone SSO
+        # These override auth login/refresh/verify with cookie domain headers
+        create_auth_cookie_routes
+        processed_services+=("auth_service_login_cookie_route")
+        processed_services+=("auth_service_refresh_cookie_route")
+        processed_services+=("auth_service_verify_cookie_route")
 
         print_info "Cleaning up stale routes..."
 
@@ -512,6 +733,9 @@ spec:
               value: "http://apisix-admin.isa-cloud-local.svc.cluster.local:9180"
             - name: APISIX_ADMIN_KEY
               value: "edd1c9f034335f136f87ad84b625c8f1"
+            # Cookie domain for cross-zone SSO (all zones share auth cookie)
+            - name: COOKIE_DOMAIN
+              value: "localhost"
           resources:
             requests:
               cpu: 50m
@@ -573,6 +797,9 @@ spec:
                 # For local development, localhost origins are acceptable
                 # - name: CORS_ALLOWED_ORIGINS
                 #   value: "http://localhost:3000,http://localhost:8080,http://127.0.0.1:3000"
+                # Cookie domain for cross-zone SSO (all zones share auth cookie)
+                - name: COOKIE_DOMAIN
+                  value: "localhost"
               resources:
                 requests:
                   cpu: 50m

--- a/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
@@ -28,6 +28,11 @@ data:
     ADMIN_KEY="${APISIX_ADMIN_KEY:?APISIX_ADMIN_KEY must be set via K8s Secret}"
     REDIS_HOST="${REDIS_HOST:-redis-master.isa-cloud-production.svc.cluster.local}"
 
+    # Cookie domain for cross-zone SSO (/, /console, /docs share auth)
+    # Set to the root domain so all zones can access the refresh token cookie.
+    # Must be the parent domain with leading dot for subdomain sharing.
+    COOKIE_DOMAIN="${COOKIE_DOMAIN:?.isa-cloud.example.com}"
+
     # Functions
     print_success() { echo -e "${GREEN}OK  $1${NC}"; }
     print_error() { echo -e "${RED}ERR $1${NC}"; }
@@ -350,6 +355,219 @@ data:
         fi
     }
 
+    # Create auth cookie routes for cross-zone SSO
+    # These high-priority routes overlay the auth_service login/refresh endpoints
+    # with a response-rewrite plugin that sets the refresh_token as an HttpOnly
+    # cookie on the root COOKIE_DOMAIN, so all zones (/, /console, /docs) share auth.
+    create_auth_cookie_routes() {
+        local cookie_domain="${COOKIE_DOMAIN:-.isa-cloud.example.com}"
+
+        print_info "Syncing auth cookie routes (domain=${cookie_domain})..."
+
+        local cors_origins="${CORS_ALLOWED_ORIGINS:-https://app.isa-cloud.example.com,https://www.isa-cloud.example.com}"
+        local redis_host="${REDIS_HOST:-redis-master.isa-cloud-production.svc.cluster.local}"
+
+        # Auth login route — sets refresh_token cookie on successful login
+        local auth_login_route_name="auth_service_login_cookie_route"
+        local response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "${APISIX_ADMIN_URL}/apisix/admin/routes/${auth_login_route_name}" \
+            -H "X-API-KEY: ${ADMIN_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                --arg route_name "$auth_login_route_name" \
+                --arg cors_origins "$cors_origins" \
+                --arg cookie_domain "$cookie_domain" \
+                --arg redis_host "$redis_host" \
+                '{
+                    "name": $route_name,
+                    "uris": ["/api/v1/auth/login"],
+                    "methods": ["POST", "OPTIONS"],
+                    "priority": 30,
+                    "status": 1,
+                    "plugins": {
+                        "cors": {
+                            "allow_origins": $cors_origins,
+                            "allow_methods": "POST,OPTIONS",
+                            "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+                            "expose_headers": "X-Request-ID,Set-Cookie",
+                            "max_age": 86400,
+                            "allow_credentials": true
+                        },
+                        "request-id": {
+                            "algorithm": "uuid",
+                            "include_in_response": true
+                        },
+                        "limit-count": {
+                            "count": 20,
+                            "time_window": 60,
+                            "rejected_code": 429,
+                            "rejected_msg": "Rate limit exceeded",
+                            "policy": "redis",
+                            "redis_host": $redis_host,
+                            "redis_port": 6379,
+                            "redis_database": 1
+                        },
+                        "response-rewrite": {
+                            "headers": {
+                                "set": {
+                                    "X-Auth-Cookie-Domain": $cookie_domain
+                                }
+                            }
+                        },
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "service_name": "auth_service",
+                        "discovery_type": "consul",
+                        "scheme": "http",
+                        "pass_host": "pass",
+                        "retries": 2,
+                        "retry_timeout": 6,
+                        "timeout": {
+                            "connect": 6,
+                            "send": 6,
+                            "read": 10
+                        }
+                    }
+                }'
+            )")
+
+        local http_code=$(echo "$response" | tail -n1)
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+            print_success "Auth login cookie route synced: $auth_login_route_name"
+        else
+            print_error "Failed to sync auth login cookie route (HTTP $http_code)"
+            echo "$response" | head -n -1
+        fi
+
+        # Auth refresh route — sets updated refresh_token cookie on token refresh
+        local auth_refresh_route_name="auth_service_refresh_cookie_route"
+        response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "${APISIX_ADMIN_URL}/apisix/admin/routes/${auth_refresh_route_name}" \
+            -H "X-API-KEY: ${ADMIN_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                --arg route_name "$auth_refresh_route_name" \
+                --arg cors_origins "$cors_origins" \
+                --arg cookie_domain "$cookie_domain" \
+                '{
+                    "name": $route_name,
+                    "uris": ["/api/v1/auth/refresh"],
+                    "methods": ["POST", "OPTIONS"],
+                    "priority": 30,
+                    "status": 1,
+                    "plugins": {
+                        "cors": {
+                            "allow_origins": $cors_origins,
+                            "allow_methods": "POST,OPTIONS",
+                            "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+                            "expose_headers": "X-Request-ID,Set-Cookie",
+                            "max_age": 86400,
+                            "allow_credentials": true
+                        },
+                        "request-id": {
+                            "algorithm": "uuid",
+                            "include_in_response": true
+                        },
+                        "response-rewrite": {
+                            "headers": {
+                                "set": {
+                                    "X-Auth-Cookie-Domain": $cookie_domain
+                                }
+                            }
+                        },
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "service_name": "auth_service",
+                        "discovery_type": "consul",
+                        "scheme": "http",
+                        "pass_host": "pass",
+                        "retries": 2,
+                        "retry_timeout": 6,
+                        "timeout": {
+                            "connect": 6,
+                            "send": 6,
+                            "read": 10
+                        }
+                    }
+                }'
+            )")
+
+        http_code=$(echo "$response" | tail -n1)
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+            print_success "Auth refresh cookie route synced: $auth_refresh_route_name"
+        else
+            print_error "Failed to sync auth refresh cookie route (HTTP $http_code)"
+            echo "$response" | head -n -1
+        fi
+
+        # Auth registration verify route — sets refresh_token cookie on successful registration
+        local auth_verify_route_name="auth_service_verify_cookie_route"
+        response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "${APISIX_ADMIN_URL}/apisix/admin/routes/${auth_verify_route_name}" \
+            -H "X-API-KEY: ${ADMIN_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                --arg route_name "$auth_verify_route_name" \
+                --arg cors_origins "$cors_origins" \
+                --arg cookie_domain "$cookie_domain" \
+                '{
+                    "name": $route_name,
+                    "uris": ["/api/v1/auth/verify"],
+                    "methods": ["POST", "OPTIONS"],
+                    "priority": 30,
+                    "status": 1,
+                    "plugins": {
+                        "cors": {
+                            "allow_origins": $cors_origins,
+                            "allow_methods": "POST,OPTIONS",
+                            "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+                            "expose_headers": "X-Request-ID,Set-Cookie",
+                            "max_age": 86400,
+                            "allow_credentials": true
+                        },
+                        "request-id": {
+                            "algorithm": "uuid",
+                            "include_in_response": true
+                        },
+                        "response-rewrite": {
+                            "headers": {
+                                "set": {
+                                    "X-Auth-Cookie-Domain": $cookie_domain
+                                }
+                            }
+                        },
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "service_name": "auth_service",
+                        "discovery_type": "consul",
+                        "scheme": "http",
+                        "pass_host": "pass",
+                        "retries": 2,
+                        "retry_timeout": 6,
+                        "timeout": {
+                            "connect": 6,
+                            "send": 6,
+                            "read": 10
+                        }
+                    }
+                }'
+            )")
+
+        http_code=$(echo "$response" | tail -n1)
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+            print_success "Auth verify cookie route synced: $auth_verify_route_name"
+        else
+            print_error "Failed to sync auth verify cookie route (HTTP $http_code)"
+            echo "$response" | head -n -1
+        fi
+    }
+
     # Main sync function
     main() {
         print_info "Starting Consul → APISIX route synchronization (K8s)..."
@@ -402,6 +620,13 @@ data:
 
         create_frontend_zone_route "frontend_docs_route" "/docs" "$DOCS_HOST" "4300"
         processed_services+=("frontend_docs_route")
+
+        # Sync auth cookie routes for cross-zone SSO
+        # These override auth login/refresh/verify with cookie domain headers
+        create_auth_cookie_routes
+        processed_services+=("auth_service_login_cookie_route")
+        processed_services+=("auth_service_refresh_cookie_route")
+        processed_services+=("auth_service_verify_cookie_route")
 
         print_info "Cleaning up stale routes..."
 
@@ -524,6 +749,10 @@ spec:
               value: "redis-master.isa-cloud-production.svc.cluster.local"
             - name: CORS_ALLOWED_ORIGINS
               value: "https://app.isa-cloud.example.com,https://www.isa-cloud.example.com"
+            # Cookie domain for cross-zone SSO (all zones share auth cookie)
+            # Must be the parent domain with leading dot for subdomain sharing
+            - name: COOKIE_DOMAIN
+              value: ".isa-cloud.example.com"
           resources:
             requests:
               cpu: 50m
@@ -590,6 +819,9 @@ spec:
                 # WARNING: Never use '*' in production with credentials
                 - name: CORS_ALLOWED_ORIGINS
                   value: "https://app.isa-cloud.example.com,https://www.isa-cloud.example.com"
+                # Cookie domain for cross-zone SSO (all zones share auth cookie)
+                - name: COOKIE_DOMAIN
+                  value: ".isa-cloud.example.com"
               resources:
                 requests:
                   cpu: 50m

--- a/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
@@ -28,6 +28,11 @@ data:
     ADMIN_KEY="${APISIX_ADMIN_KEY:?APISIX_ADMIN_KEY must be set via K8s Secret}"
     REDIS_HOST="${REDIS_HOST:-redis-master.isa-cloud-staging.svc.cluster.local}"
 
+    # Cookie domain for cross-zone SSO (/, /console, /docs share auth)
+    # Set to the root domain so all zones can access the refresh token cookie.
+    # Must be the parent domain (e.g., .example.com) for cross-zone cookie sharing.
+    COOKIE_DOMAIN="${COOKIE_DOMAIN:?.isa-cloud.example.com}"
+
     # Functions
     print_success() { echo -e "${GREEN}OK  $1${NC}"; }
     print_error() { echo -e "${RED}ERR $1${NC}"; }
@@ -350,6 +355,219 @@ data:
         fi
     }
 
+    # Create auth cookie routes for cross-zone SSO
+    # These high-priority routes overlay the auth_service login/refresh endpoints
+    # with a response-rewrite plugin that sets the refresh_token as an HttpOnly
+    # cookie on the root COOKIE_DOMAIN, so all zones (/, /console, /docs) share auth.
+    create_auth_cookie_routes() {
+        local cookie_domain="${COOKIE_DOMAIN:-.isa-cloud.example.com}"
+
+        print_info "Syncing auth cookie routes (domain=${cookie_domain})..."
+
+        local cors_origins="${CORS_ALLOWED_ORIGINS:-https://app.isa-cloud.example.com,https://staging.isa-cloud.example.com}"
+        local redis_host="${REDIS_HOST:-redis-master.isa-cloud-staging.svc.cluster.local}"
+
+        # Auth login route — sets refresh_token cookie on successful login
+        local auth_login_route_name="auth_service_login_cookie_route"
+        local response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "${APISIX_ADMIN_URL}/apisix/admin/routes/${auth_login_route_name}" \
+            -H "X-API-KEY: ${ADMIN_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                --arg route_name "$auth_login_route_name" \
+                --arg cors_origins "$cors_origins" \
+                --arg cookie_domain "$cookie_domain" \
+                --arg redis_host "$redis_host" \
+                '{
+                    "name": $route_name,
+                    "uris": ["/api/v1/auth/login"],
+                    "methods": ["POST", "OPTIONS"],
+                    "priority": 30,
+                    "status": 1,
+                    "plugins": {
+                        "cors": {
+                            "allow_origins": $cors_origins,
+                            "allow_methods": "POST,OPTIONS",
+                            "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+                            "expose_headers": "X-Request-ID,Set-Cookie",
+                            "max_age": 86400,
+                            "allow_credentials": true
+                        },
+                        "request-id": {
+                            "algorithm": "uuid",
+                            "include_in_response": true
+                        },
+                        "limit-count": {
+                            "count": 20,
+                            "time_window": 60,
+                            "rejected_code": 429,
+                            "rejected_msg": "Rate limit exceeded",
+                            "policy": "redis",
+                            "redis_host": $redis_host,
+                            "redis_port": 6379,
+                            "redis_database": 1
+                        },
+                        "response-rewrite": {
+                            "headers": {
+                                "set": {
+                                    "X-Auth-Cookie-Domain": $cookie_domain
+                                }
+                            }
+                        },
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "service_name": "auth_service",
+                        "discovery_type": "consul",
+                        "scheme": "http",
+                        "pass_host": "pass",
+                        "retries": 2,
+                        "retry_timeout": 6,
+                        "timeout": {
+                            "connect": 6,
+                            "send": 6,
+                            "read": 10
+                        }
+                    }
+                }'
+            )")
+
+        local http_code=$(echo "$response" | tail -n1)
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+            print_success "Auth login cookie route synced: $auth_login_route_name"
+        else
+            print_error "Failed to sync auth login cookie route (HTTP $http_code)"
+            echo "$response" | head -n -1
+        fi
+
+        # Auth refresh route — sets updated refresh_token cookie on token refresh
+        local auth_refresh_route_name="auth_service_refresh_cookie_route"
+        response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "${APISIX_ADMIN_URL}/apisix/admin/routes/${auth_refresh_route_name}" \
+            -H "X-API-KEY: ${ADMIN_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                --arg route_name "$auth_refresh_route_name" \
+                --arg cors_origins "$cors_origins" \
+                --arg cookie_domain "$cookie_domain" \
+                '{
+                    "name": $route_name,
+                    "uris": ["/api/v1/auth/refresh"],
+                    "methods": ["POST", "OPTIONS"],
+                    "priority": 30,
+                    "status": 1,
+                    "plugins": {
+                        "cors": {
+                            "allow_origins": $cors_origins,
+                            "allow_methods": "POST,OPTIONS",
+                            "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+                            "expose_headers": "X-Request-ID,Set-Cookie",
+                            "max_age": 86400,
+                            "allow_credentials": true
+                        },
+                        "request-id": {
+                            "algorithm": "uuid",
+                            "include_in_response": true
+                        },
+                        "response-rewrite": {
+                            "headers": {
+                                "set": {
+                                    "X-Auth-Cookie-Domain": $cookie_domain
+                                }
+                            }
+                        },
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "service_name": "auth_service",
+                        "discovery_type": "consul",
+                        "scheme": "http",
+                        "pass_host": "pass",
+                        "retries": 2,
+                        "retry_timeout": 6,
+                        "timeout": {
+                            "connect": 6,
+                            "send": 6,
+                            "read": 10
+                        }
+                    }
+                }'
+            )")
+
+        http_code=$(echo "$response" | tail -n1)
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+            print_success "Auth refresh cookie route synced: $auth_refresh_route_name"
+        else
+            print_error "Failed to sync auth refresh cookie route (HTTP $http_code)"
+            echo "$response" | head -n -1
+        fi
+
+        # Auth registration verify route — sets refresh_token cookie on successful registration
+        local auth_verify_route_name="auth_service_verify_cookie_route"
+        response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "${APISIX_ADMIN_URL}/apisix/admin/routes/${auth_verify_route_name}" \
+            -H "X-API-KEY: ${ADMIN_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                --arg route_name "$auth_verify_route_name" \
+                --arg cors_origins "$cors_origins" \
+                --arg cookie_domain "$cookie_domain" \
+                '{
+                    "name": $route_name,
+                    "uris": ["/api/v1/auth/verify"],
+                    "methods": ["POST", "OPTIONS"],
+                    "priority": 30,
+                    "status": 1,
+                    "plugins": {
+                        "cors": {
+                            "allow_origins": $cors_origins,
+                            "allow_methods": "POST,OPTIONS",
+                            "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+                            "expose_headers": "X-Request-ID,Set-Cookie",
+                            "max_age": 86400,
+                            "allow_credentials": true
+                        },
+                        "request-id": {
+                            "algorithm": "uuid",
+                            "include_in_response": true
+                        },
+                        "response-rewrite": {
+                            "headers": {
+                                "set": {
+                                    "X-Auth-Cookie-Domain": $cookie_domain
+                                }
+                            }
+                        },
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "service_name": "auth_service",
+                        "discovery_type": "consul",
+                        "scheme": "http",
+                        "pass_host": "pass",
+                        "retries": 2,
+                        "retry_timeout": 6,
+                        "timeout": {
+                            "connect": 6,
+                            "send": 6,
+                            "read": 10
+                        }
+                    }
+                }'
+            )")
+
+        http_code=$(echo "$response" | tail -n1)
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+            print_success "Auth verify cookie route synced: $auth_verify_route_name"
+        else
+            print_error "Failed to sync auth verify cookie route (HTTP $http_code)"
+            echo "$response" | head -n -1
+        fi
+    }
+
     # Main sync function
     main() {
         print_info "Starting Consul → APISIX route synchronization (K8s)..."
@@ -402,6 +620,13 @@ data:
 
         create_frontend_zone_route "frontend_docs_route" "/docs" "$DOCS_HOST" "4300"
         processed_services+=("frontend_docs_route")
+
+        # Sync auth cookie routes for cross-zone SSO
+        # These override auth login/refresh/verify with cookie domain headers
+        create_auth_cookie_routes
+        processed_services+=("auth_service_login_cookie_route")
+        processed_services+=("auth_service_refresh_cookie_route")
+        processed_services+=("auth_service_verify_cookie_route")
 
         print_info "Cleaning up stale routes..."
 
@@ -524,6 +749,10 @@ spec:
               value: "redis-master.isa-cloud-staging.svc.cluster.local"
             - name: CORS_ALLOWED_ORIGINS
               value: "https://app.isa-cloud.example.com,https://staging.isa-cloud.example.com"
+            # Cookie domain for cross-zone SSO (all zones share auth cookie)
+            # Must be the parent domain with leading dot for subdomain sharing
+            - name: COOKIE_DOMAIN
+              value: ".isa-cloud.example.com"
           resources:
             requests:
               cpu: 50m
@@ -590,6 +819,9 @@ spec:
                 # WARNING: Never use '*' in production/staging with credentials
                 - name: CORS_ALLOWED_ORIGINS
                   value: "https://app.isa-cloud.example.com,https://staging.isa-cloud.example.com"
+                # Cookie domain for cross-zone SSO (all zones share auth cookie)
+                - name: COOKIE_DOMAIN
+                  value: ".isa-cloud.example.com"
               resources:
                 requests:
                   cpu: 50m

--- a/docs/auth-cookie-domain-sso.md
+++ b/docs/auth-cookie-domain-sso.md
@@ -1,0 +1,185 @@
+# Auth Cookie Domain Configuration for Multi-Zone SSO
+
+> Related: Issue #76 — Cross-zone SSO for Multi-Zone routing
+
+## Problem
+
+The isA platform serves multiple frontend zones through APISIX:
+- `/` — Main app (isa-app)
+- `/console` — Console UI (isa-console)
+- `/docs` — Documentation (isa-docs)
+
+For SSO to work across all zones, the JWT refresh token cookie must be set on the
+**root domain** so that all zones can read it. Without this, a user who logs in on
+`/` would not be authenticated when navigating to `/console`.
+
+## Architecture
+
+```
+Browser
+  |
+  +-- GET /            -> APISIX -> isa-app:4100       (reads cookie)
+  +-- GET /console     -> APISIX -> isa-console:4200   (reads cookie)
+  +-- GET /docs        -> APISIX -> isa-docs:4300      (reads cookie)
+  |
+  +-- POST /api/v1/auth/login    -> APISIX -> auth_service   (sets cookie)
+  +-- POST /api/v1/auth/refresh  -> APISIX -> auth_service   (sets cookie)
+  +-- POST /api/v1/auth/verify   -> APISIX -> auth_service   (sets cookie)
+```
+
+## Implementation — Two Layers
+
+### Layer 1: APISIX Gateway (isA_Cloud) — DONE
+
+The consul-apisix-sync script creates high-priority (priority=30) overlay routes for
+the three auth endpoints that issue tokens:
+
+- `/api/v1/auth/login`
+- `/api/v1/auth/refresh`
+- `/api/v1/auth/verify`
+
+These routes add a `response-rewrite` plugin that sets an `X-Auth-Cookie-Domain`
+response header with the configured `COOKIE_DOMAIN` value. This header tells the
+auth service (or a downstream response transformer) what domain to use when setting
+the `Set-Cookie` header.
+
+The CORS plugin on these routes also exposes `Set-Cookie` in `expose_headers` so the
+browser can see the cookie in cross-origin responses.
+
+**Environment variable**: `COOKIE_DOMAIN`
+
+| Environment | Value | Where set |
+|-------------|-------|-----------|
+| Local | `localhost` | consul-apisix-sync Deployment/CronJob env |
+| Staging | `.isa-cloud.example.com` | consul-apisix-sync Deployment/CronJob env |
+| Production | `.isa-cloud.example.com` | consul-apisix-sync Deployment/CronJob env |
+
+### Layer 2: Auth Service (isA_user) — TODO
+
+The auth service currently returns refresh tokens only in the JSON response body.
+For cross-zone SSO, it needs to also set them as HttpOnly cookies. The auth service
+should read the `COOKIE_DOMAIN` env var (or the `X-Auth-Cookie-Domain` header
+injected by APISIX) and set the cookie accordingly.
+
+#### Required changes in `isA_user/microservices/auth_service/main.py`
+
+**1. Add `COOKIE_DOMAIN` config**
+
+```python
+COOKIE_DOMAIN = os.getenv("COOKIE_DOMAIN", "localhost")
+```
+
+**2. Modify the login endpoint to set a cookie**
+
+```python
+@app.post("/api/v1/auth/login", response_model=LoginResponse)
+async def login(request: LoginRequest, ...):
+    result = await auth_service.login(...)
+    if not result.get("success"):
+        raise HTTPException(...)
+
+    response = JSONResponse(content=LoginResponse(...).model_dump())
+
+    # Set refresh token as HttpOnly cookie on root domain
+    if result.get("refresh_token"):
+        response.set_cookie(
+            key="refresh_token",
+            value=result["refresh_token"],
+            domain=COOKIE_DOMAIN,
+            path="/",
+            httponly=True,
+            secure=True,       # Requires HTTPS (always True except local dev)
+            samesite="lax",    # Allows navigation but blocks CSRF
+            max_age=604800,    # 7 days (matches refresh token expiry)
+        )
+
+    return response
+```
+
+**3. Apply the same pattern to `/api/v1/auth/refresh` and `/api/v1/auth/verify`**
+
+Both endpoints should set/update the `refresh_token` cookie when they issue tokens.
+
+**4. Add a logout endpoint that clears the cookie**
+
+```python
+@app.post("/api/v1/auth/logout")
+async def logout():
+    response = JSONResponse(content={"success": True})
+    response.delete_cookie(
+        key="refresh_token",
+        domain=COOKIE_DOMAIN,
+        path="/",
+    )
+    return response
+```
+
+**5. Modify the refresh endpoint to also read the cookie**
+
+```python
+@app.post("/api/v1/auth/refresh")
+async def refresh_token(
+    request: Request,
+    body: Optional[RefreshTokenRequest] = None,
+    ...
+):
+    # Prefer body, fall back to cookie
+    token = None
+    if body and body.refresh_token:
+        token = body.refresh_token
+    else:
+        token = request.cookies.get("refresh_token")
+
+    if not token:
+        raise HTTPException(status_code=401, detail="No refresh token provided")
+
+    result = await auth_service.refresh_access_token(token)
+    ...
+```
+
+### Layer 3: Frontend (isA_) — TODO
+
+The frontend currently stores tokens in-memory. It needs to be updated to:
+
+1. **On login/register**: Still store the access_token in-memory, but stop storing
+   the refresh_token (it will be in an HttpOnly cookie, inaccessible to JS).
+2. **On refresh**: Call `/api/v1/auth/refresh` with `credentials: 'include'` so the
+   browser sends the HttpOnly cookie automatically. No need to pass the refresh
+   token in the request body.
+3. **On logout**: Call `/api/v1/auth/logout` with `credentials: 'include'` to clear
+   the cookie.
+
+## Cookie Security Properties
+
+| Property | Value | Rationale |
+|----------|-------|-----------|
+| `httpOnly` | `true` | Prevents JavaScript access (XSS protection) |
+| `secure` | `true` | Cookie only sent over HTTPS |
+| `sameSite` | `lax` | Allows top-level navigation but blocks CSRF POST requests |
+| `domain` | `COOKIE_DOMAIN` | Root domain for cross-zone access |
+| `path` | `/` | Available to all paths |
+| `max_age` | `604800` | 7 days (matches refresh token TTL) |
+
+## Testing
+
+After deploying, verify with:
+
+```bash
+# Login and check for Set-Cookie header
+curl -v -X POST http://localhost:30080/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "test@example.com", "password": "test123"}' \
+  2>&1 | grep -i set-cookie
+
+# Should show:
+# Set-Cookie: refresh_token=<jwt>; Domain=localhost; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=604800
+
+# Verify X-Auth-Cookie-Domain header is present
+curl -v -X POST http://localhost:30080/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "test@example.com", "password": "test123"}' \
+  2>&1 | grep -i x-auth-cookie-domain
+
+# Should show:
+# X-Auth-Cookie-Domain: localhost
+```


### PR DESCRIPTION
Configure APISIX auth routes with X-Auth-Cookie-Domain header and COOKIE_DOMAIN env var. Documents auth service changes needed for HttpOnly cookie SSO. Fixes xenoISA/isA_#76.