### PR TITLE
feat(infra): add APISIX health checks for frontend zone upstreams

### DIFF
--- a/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
@@ -335,6 +335,32 @@ data:
                         \"connect\": 5,
                         \"send\": 30,
                         \"read\": 30
+                    },
+                    \"checks\": {
+                        \"active\": {
+                            \"type\": \"http\",
+                            \"http_path\": \"/\",
+                            \"healthy\": {
+                                \"interval\": 10,
+                                \"successes\": 2
+                            },
+                            \"unhealthy\": {
+                                \"interval\": 5,
+                                \"http_failures\": 3,
+                                \"timeouts\": 2
+                            }
+                        },
+                        \"passive\": {
+                            \"healthy\": {
+                                \"http_statuses\": [200, 301, 302],
+                                \"successes\": 3
+                            },
+                            \"unhealthy\": {
+                                \"http_statuses\": [500, 502, 503, 504],
+                                \"http_failures\": 3,
+                                \"timeouts\": 3
+                            }
+                        }
                     }
                 }
             }")

--- a/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
@@ -340,6 +340,32 @@ data:
                         \"connect\": 5,
                         \"send\": 30,
                         \"read\": 30
+                    },
+                    \"checks\": {
+                        \"active\": {
+                            \"type\": \"http\",
+                            \"http_path\": \"/\",
+                            \"healthy\": {
+                                \"interval\": 10,
+                                \"successes\": 2
+                            },
+                            \"unhealthy\": {
+                                \"interval\": 5,
+                                \"http_failures\": 3,
+                                \"timeouts\": 2
+                            }
+                        },
+                        \"passive\": {
+                            \"healthy\": {
+                                \"http_statuses\": [200, 301, 302],
+                                \"successes\": 3
+                            },
+                            \"unhealthy\": {
+                                \"http_statuses\": [500, 502, 503, 504],
+                                \"http_failures\": 3,
+                                \"timeouts\": 3
+                            }
+                        }
                     }
                 }
             }")

--- a/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
@@ -340,6 +340,32 @@ data:
                         \"connect\": 5,
                         \"send\": 30,
                         \"read\": 30
+                    },
+                    \"checks\": {
+                        \"active\": {
+                            \"type\": \"http\",
+                            \"http_path\": \"/\",
+                            \"healthy\": {
+                                \"interval\": 10,
+                                \"successes\": 2
+                            },
+                            \"unhealthy\": {
+                                \"interval\": 5,
+                                \"http_failures\": 3,
+                                \"timeouts\": 2
+                            }
+                        },
+                        \"passive\": {
+                            \"healthy\": {
+                                \"http_statuses\": [200, 301, 302],
+                                \"successes\": 3
+                            },
+                            \"unhealthy\": {
+                                \"http_statuses\": [500, 502, 503, 504],
+                                \"http_failures\": 3,
+                                \"timeouts\": 3
+                            }
+                        }
                     }
                 }
             }")


### PR DESCRIPTION
Active + passive health checks for all frontend zones. Fixes xenoISA/isA_#79. Related to xenoISA/isA_#9.