### PR TITLE
feat(infra): add APISIX gateway route for isA_Mate service

### DIFF
--- a/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
@@ -598,6 +598,11 @@ data:
             fi
         done
 
+        # Sync Mate service route (static upstream, not Consul-discovered)
+        local MATE_HOST="${MATE_HOST:-isa-mate.isa-cloud-local.svc.cluster.local}"
+        create_frontend_zone_route "mate_service_route" "/mate" "$MATE_HOST" "18789"
+        processed_services+=("mate_service_route")
+
         # Sync frontend zone routes (static upstreams, not Consul-discovered)
         local FRONTEND_HOST="${FRONTEND_HOST:-isa-app.isa-cloud-local.svc.cluster.local}"
         local CONSOLE_HOST="${CONSOLE_HOST:-isa-console.isa-cloud-local.svc.cluster.local}"

--- a/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
@@ -607,6 +607,11 @@ data:
             fi
         done
 
+        # Sync Mate service route (static upstream, not Consul-discovered)
+        local MATE_HOST="${MATE_HOST:-isa-mate.isa-cloud-production.svc.cluster.local}"
+        create_frontend_zone_route "mate_service_route" "/mate" "$MATE_HOST" "18789"
+        processed_services+=("mate_service_route")
+
         # Sync frontend zone routes (static upstreams, not Consul-discovered)
         local FRONTEND_HOST="${FRONTEND_HOST:-isa-app.isa-cloud-production.svc.cluster.local}"
         local CONSOLE_HOST="${CONSOLE_HOST:-isa-console.isa-cloud-production.svc.cluster.local}"

--- a/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
@@ -607,6 +607,11 @@ data:
             fi
         done
 
+        # Sync Mate service route (static upstream, not Consul-discovered)
+        local MATE_HOST="${MATE_HOST:-isa-mate.isa-cloud-staging.svc.cluster.local}"
+        create_frontend_zone_route "mate_service_route" "/mate" "$MATE_HOST" "18789"
+        processed_services+=("mate_service_route")
+
         # Sync frontend zone routes (static upstreams, not Consul-discovered)
         local FRONTEND_HOST="${FRONTEND_HOST:-isa-app.isa-cloud-staging.svc.cluster.local}"
         local CONSOLE_HOST="${CONSOLE_HOST:-isa-console.isa-cloud-staging.svc.cluster.local}"


### PR DESCRIPTION
Route /mate/* to isA_Mate (:18789). Applied to local, staging, production manifests. Related to xenoISA/isA_#33.