### PR TITLE
feat(infra): add mcp-worker ArgoCD app manifests

### DIFF
--- a/deployments/argocd/apps/production/core-services.yaml
+++ b/deployments/argocd/apps/production/core-services.yaml
@@ -49,6 +49,47 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  name: mcp-worker-service-production
+  namespace: argocd
+  labels:
+    app: mcp-worker-service
+    environment: production
+    tier: core
+    critical: "true"
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: isa-deployments
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: isa-alerts
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/xenoISA/isA_Cloud.git
+    targetRevision: production
+    path: deployments/charts/isa-service
+    helm:
+      valueFiles:
+        - ../../../isA_MCP/deployment/helm/values.yaml
+        - ../../../isA_MCP/deployment/helm/values-mcp-worker-production.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: isa-cloud-production
+  syncPolicy:
+    # NO automated sync for production - manual approval required
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
   name: model-service-production
   namespace: argocd
   labels:

--- a/deployments/argocd/apps/staging/kustomization.yaml
+++ b/deployments/argocd/apps/staging/kustomization.yaml
@@ -10,6 +10,7 @@ kind: Kustomization
 resources:
   # Core services
   - mcp-service.yaml
+  - mcp-worker-service.yaml
   - model-service.yaml
   - agent-service.yaml
   - data-service.yaml

--- a/deployments/argocd/apps/staging/mcp-worker-service.yaml
+++ b/deployments/argocd/apps/staging/mcp-worker-service.yaml
@@ -1,0 +1,45 @@
+# =============================================================================
+# MCP Worker Service - Staging
+# =============================================================================
+# Deploys mcp-worker alongside mcp-service for NATS-based tool execution.
+# Worker consumes from TOOL_EXECUTION JetStream stream.
+# =============================================================================
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mcp-worker-service-staging
+  namespace: argocd
+  labels:
+    app: mcp-worker-service
+    environment: staging
+    tier: core
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/xenoISA/isA_Cloud.git
+    targetRevision: main
+    path: deployments/charts/isa-service
+    helm:
+      valueFiles:
+        - ../../../isA_MCP/deployment/helm/values.yaml
+        - ../../../isA_MCP/deployment/helm/values-mcp-worker-staging.yaml
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: isa-cloud-staging
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m


### PR DESCRIPTION
## Summary
- Add ArgoCD Application manifests for `mcp-worker-service` in staging (auto-sync) and production (manual sync)
- Worker deploys alongside mcp-service for NATS-based tool execution offloading

Related to xenoISA/isA_MCP#367
**Parent Epic**: xenoISA/isA_MCP#356

## Changes
| File | Change |
|------|--------|
| `deployments/argocd/apps/staging/mcp-worker-service.yaml` | New staging Application |
| `deployments/argocd/apps/staging/kustomization.yaml` | Add worker to resource list |
| `deployments/argocd/apps/production/core-services.yaml` | Add worker Application (no auto-sync) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)