### PR TITLE
fix(infra): harden NATS resource sizing, version pinning, and client log backoff

### DIFF
--- a/deployments/kubernetes/local/values/nats.yaml
+++ b/deployments/kubernetes/local/values/nats.yaml
@@ -28,13 +28,15 @@ config:
 
 # Container resources
 container:
+  image:
+    tag: "2.10.22-alpine"
   resources:
     requests:
-      cpu: 50m
-      memory: 64Mi
-    limits:
-      cpu: 250m
+      cpu: 100m
       memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
 
 # Service - use merge to set NodePort
 service:
@@ -64,6 +66,12 @@ podTemplate:
       labels:
         tier: infrastructure
         environment: local
+
+# Startup probe — allow 300s for JetStream recovery
+startupProbe:
+  enabled: true
+  periodSeconds: 10
+  failureThreshold: 30
 
 # Single replica for local
 replicaCount: 1

--- a/deployments/kubernetes/staging/values/nats.yaml
+++ b/deployments/kubernetes/staging/values/nats.yaml
@@ -28,6 +28,8 @@ config:
 
 # Container resources
 container:
+  image:
+    tag: "2.10.22-alpine"
   resources:
     requests:
       cpu: 100m
@@ -62,6 +64,12 @@ podTemplate:
       labels:
         tier: infrastructure
         environment: staging
+
+# Startup probe — allow 300s for JetStream recovery
+startupProbe:
+  enabled: true
+  periodSeconds: 10
+  failureThreshold: 30
 
 # Single replica for staging (cost optimization)
 replicaCount: 1

--- a/isA_common/isa_common/async_nats_client.py
+++ b/isA_common/isa_common/async_nats_client.py
@@ -190,10 +190,13 @@ class AsyncNATSClient(AsyncBaseClient):
 
         async def _on_error(error):
             self._consecutive_errors += 1
-            self._logger.warning(
-                f"NATS async error: {error} "
-                f"(consecutive_errors={self._consecutive_errors})"
-            )
+            # Log at exponential backoff: 1, 2, 4, 8, 16, 32, 64, 128, ...
+            n = self._consecutive_errors
+            if n == 1 or (n & (n - 1)) == 0:
+                self._logger.warning(
+                    f"NATS async error: {error} "
+                    f"(consecutive_errors={self._consecutive_errors})"
+                )
 
         connect_opts = {
             'servers': [server_url],


### PR DESCRIPTION
## Summary
- **Local NATS**: bump memory 256Mi→512Mi, CPU 250m→500m, pin to `2.10.22-alpine`, add 300s startup probe
- **Staging NATS**: pin to `2.10.22-alpine`, add 300s startup probe  
- **AsyncNATSClient**: log errors at exponential backoff (powers of 2) instead of every single error

## Problem
Local NATS pod had 153 restarts in 48 days (~3/day) due to OOM with 256Mi memory limit serving 20+ JetStream streams (23,000+ messages). Each restart triggers 2m34s JetStream recovery, during which all clients get `"empty response from server when expecting INFO message"` flooding logs with 140+ consecutive warnings.

## Compatibility
Verified safe with existing isA_Cloud skills:
- **cluster_operations**: ports, service names, pod names unchanged
- **backup_restore**: `get_pod nats` + port-forward unaffected by resource/probe changes
- **service_operation**: no NATS interaction

## Test plan
- [x] 7/7 NATS reconnect tests pass (`tests/nats/test_async_nats_reconnect.py`)
- [ ] `helm upgrade nats nats/nats -n isa-cloud-local -f deployments/kubernetes/local/values/nats.yaml`
- [ ] Verify pod stabilizes with 0 restarts over 1 hour
- [ ] Verify connected services stop logging "empty response" errors

Fixes #148, Fixes #149, Fixes #150
**Parent Epic**: #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)