### PR TITLE
feat(chart): add topology spread and affinity support

### DIFF
--- a/deployments/charts/isa-service/templates/deployment.yaml
+++ b/deployments/charts/isa-service/templates/deployment.yaml
@@ -84,6 +84,14 @@ spec:
             port: {{ .Values.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.volumes }}
       volumes:
       {{- toYaml .Values.volumes | nindent 6 }}

--- a/deployments/charts/isa-service/values.yaml
+++ b/deployments/charts/isa-service/values.yaml
@@ -97,6 +97,18 @@ service:
 consul:
   enabled: true
 
+# Topology spread constraints (spread pods across nodes/zones)
+topologySpreadConstraints: []
+# - maxSkew: 1
+#   topologyKey: kubernetes.io/hostname
+#   whenUnsatisfiable: DoNotSchedule
+#   labelSelector:
+#     matchLabels:
+#       app: my-service
+
+# Affinity rules (pod anti-affinity, node affinity, etc.)
+affinity: {}
+
 # Optional volumes
 volumes: []
 # - name: models


### PR DESCRIPTION
## Summary
- Add `topologySpreadConstraints` and `affinity` fields to the isa-service Helm chart deployment template
- Add commented default values showing usage patterns
- Required by xenoISA/isA_Model#553 to spread model-service replicas across nodes

## Test plan
- [ ] `helm template` dry-run with topology values to verify rendered YAML
- [ ] Deploy to staging with soft spread constraint and verify pod scheduling

🤖 Generated with [Claude Code](https://claude.com/claude-code)