### PR TITLE
feat(core): expand billing events and harden isa_common imports

### DIFF
--- a/configs/local/grafana/dashboards/isa-platform-logs.json
+++ b/configs/local/grafana/dashboards/isa-platform-logs.json
@@ -41,7 +41,7 @@
             "uid": ""
           },
           "editorMode": "code",
-          "expr": "sum by (app) (count_over_time({app=~\"isa-.+\"} [$__auto]))",
+          "expr": "sum by (app) (count_over_time({app=~\"${service:regex}\"} [$__auto]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -82,7 +82,7 @@
             "uid": ""
           },
           "editorMode": "code",
-          "expr": "sum by (level) (count_over_time({app=~\"isa-.+\"} | json | level != \"\" [$__auto]))",
+          "expr": "sum by (level) (count_over_time({app=~\"${service:regex}\"} [$__auto]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -123,7 +123,7 @@
             "uid": ""
           },
           "editorMode": "code",
-          "expr": "sum by (app) (count_over_time({app=~\"isa-.+\"} | json | level = \"ERROR\" [$__auto]))",
+          "expr": "sum by (app) (count_over_time({app=~\"${service:regex}\", level=\"ERROR\"} [$__auto]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -164,7 +164,7 @@
             "uid": ""
           },
           "editorMode": "code",
-          "expr": "{app=~\"${service:pipe}\", level=~\"${level:pipe}\"}",
+          "expr": "{app=~\"${service:regex}\", level=~\"${level:regex}\"}",
           "queryType": "range",
           "refId": "A"
         }
@@ -209,22 +209,28 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "type": "loki",
+          "uid": ""
+        },
         "includeAll": true,
         "multi": true,
         "name": "level",
-        "options": [
-          {"selected": false, "text": "DEBUG", "value": "DEBUG"},
-          {"selected": false, "text": "INFO", "value": "INFO"},
-          {"selected": false, "text": "WARNING", "value": "WARNING"},
-          {"selected": false, "text": "ERROR", "value": "ERROR"},
-          {"selected": false, "text": "CRITICAL", "value": "CRITICAL"}
-        ],
-        "type": "custom"
+        "options": [],
+        "query": {
+          "label": "level",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "",
+          "type": 1
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-72h",
     "to": "now"
   },
   "timepicker": {},

--- a/deployments/kubernetes/local/manifests/grafana-dashboards.yaml
+++ b/deployments/kubernetes/local/manifests/grafana-dashboards.yaml
@@ -25,7 +25,7 @@ data:
           "gridPos": {"h": 4, "w": 24, "x": 0, "y": 0},
           "id": 1,
           "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": true, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": false},
-          "targets": [{"datasource": {"type": "loki", "uid": ""}, "editorMode": "code", "expr": "sum by (app) (count_over_time({app=~\"isa-.+\"} [$__auto]))", "queryType": "range", "refId": "A"}],
+          "targets": [{"datasource": {"type": "loki", "uid": ""}, "editorMode": "code", "expr": "sum by (app) (count_over_time({app=~\"${service:regex}\"} [$__auto]))", "queryType": "range", "refId": "A"}],
           "title": "Log Volume by Service",
           "type": "barchart"
         },
@@ -34,7 +34,7 @@ data:
           "gridPos": {"h": 4, "w": 12, "x": 0, "y": 4},
           "id": 2,
           "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": true, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": false},
-          "targets": [{"datasource": {"type": "loki", "uid": ""}, "editorMode": "code", "expr": "sum by (level) (count_over_time({app=~\"isa-.+\"} | json | level != \"\" [$__auto]))", "queryType": "range", "refId": "A"}],
+          "targets": [{"datasource": {"type": "loki", "uid": ""}, "editorMode": "code", "expr": "sum by (level) (count_over_time({app=~\"${service:regex}\"} [$__auto]))", "queryType": "range", "refId": "A"}],
           "title": "Log Volume by Level",
           "type": "barchart"
         },
@@ -43,7 +43,7 @@ data:
           "gridPos": {"h": 4, "w": 12, "x": 12, "y": 4},
           "id": 3,
           "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": true, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": false},
-          "targets": [{"datasource": {"type": "loki", "uid": ""}, "editorMode": "code", "expr": "sum by (app) (count_over_time({app=~\"isa-.+\"} | json | level = \"ERROR\" [$__auto]))", "queryType": "range", "refId": "A"}],
+          "targets": [{"datasource": {"type": "loki", "uid": ""}, "editorMode": "code", "expr": "sum by (app) (count_over_time({app=~\"${service:regex}\", level=\"ERROR\"} [$__auto]))", "queryType": "range", "refId": "A"}],
           "title": "Errors by Service",
           "type": "barchart"
         },
@@ -52,7 +52,7 @@ data:
           "gridPos": {"h": 16, "w": 24, "x": 0, "y": 8},
           "id": 4,
           "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": true, "showCommonLabels": false, "showLabels": true, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": true},
-          "targets": [{"datasource": {"type": "loki", "uid": ""}, "editorMode": "code", "expr": "{app=~\"${service:pipe}\", level=~\"${level:pipe}\"}", "queryType": "range", "refId": "A"}],
+          "targets": [{"datasource": {"type": "loki", "uid": ""}, "editorMode": "code", "expr": "{app=~\"${service:regex}\", level=~\"${level:regex}\"}", "queryType": "range", "refId": "A"}],
           "title": "Logs",
           "type": "logs"
         }
@@ -75,21 +75,19 @@ data:
           },
           {
             "current": {"selected": true, "text": ["All"], "value": ["$__all"]},
-            "includeAll": true,
-            "multi": true,
-            "name": "level",
-            "options": [
-              {"selected": false, "text": "DEBUG", "value": "DEBUG"},
-              {"selected": false, "text": "INFO", "value": "INFO"},
-              {"selected": false, "text": "WARNING", "value": "WARNING"},
-              {"selected": false, "text": "ERROR", "value": "ERROR"},
-              {"selected": false, "text": "CRITICAL", "value": "CRITICAL"}
-            ],
-            "type": "custom"
+        "datasource": {"type": "loki", "uid": ""},
+        "includeAll": true,
+        "multi": true,
+        "name": "level",
+        "options": [],
+        "query": {"label": "level", "refId": "LokiVariableQueryEditor-VariableQuery", "stream": "", "type": 1},
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
           }
         ]
       },
-      "time": {"from": "now-1h", "to": "now"},
+      "time": {"from": "now-72h", "to": "now"},
       "timepicker": {},
       "timezone": "browser",
       "title": "isA Platform Logs",

--- a/isA_common/isa_common.egg-info/PKG-INFO
+++ b/isA_common/isa_common.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: isa-common
-Version: 0.3.1
+Version: 0.4.0
 Summary: Shared Python infrastructure library for isA platform
 Home-page: https://github.com/isa-platform/isA_Cloud
 Author: isA Platform
@@ -27,9 +27,25 @@ Requires-Dist: aioboto3>=12.0.0
 Requires-Dist: aiofiles>=23.0.0
 Requires-Dist: redis>=5.0.0
 Requires-Dist: nats-py>=2.6.0
-Requires-Dist: qdrant-client>=1.7.0
+Requires-Dist: qdrant-client>=1.9.0
 Requires-Dist: aiomqtt>=2.0.0
+Requires-Dist: aiosqlite>=0.19.0
 Requires-Dist: duckdb>=0.10.0
+Requires-Dist: aiohttp>=3.9.0
+Provides-Extra: metrics
+Requires-Dist: prometheus-client>=0.20.0; extra == "metrics"
+Requires-Dist: starlette>=0.27.0; extra == "metrics"
+Provides-Extra: tracing
+Requires-Dist: opentelemetry-sdk>=1.20.0; extra == "tracing"
+Requires-Dist: opentelemetry-exporter-otlp-proto-grpc>=1.20.0; extra == "tracing"
+Requires-Dist: opentelemetry-instrumentation-fastapi>=0.41b0; extra == "tracing"
+Provides-Extra: tracing-extras
+Requires-Dist: opentelemetry-instrumentation-aiohttp-client>=0.41b0; extra == "tracing-extras"
+Requires-Dist: opentelemetry-instrumentation-asyncpg>=0.41b0; extra == "tracing-extras"
+Requires-Dist: opentelemetry-instrumentation-redis>=0.41b0; extra == "tracing-extras"
+Requires-Dist: opentelemetry-instrumentation-httpx>=0.41b0; extra == "tracing-extras"
+Provides-Extra: observability
+Requires-Dist: isa-common[metrics,tracing]; extra == "observability"
 Provides-Extra: dev
 Requires-Dist: pytest>=7.0.0; extra == "dev"
 Requires-Dist: pytest-asyncio>=0.21.0; extra == "dev"
@@ -42,23 +58,39 @@ Dynamic: requires-python
 
 # isA Common
 
-Shared Python infrastructure library for the isA platform.
+Shared async Python client library for the isA platform.
 
 ## Overview
 
-`isa-common` provides Python client libraries and utilities for interacting with various infrastructure services in the isA Cloud platform, including:
+`isa-common` provides async Python clients for interacting with isA Cloud infrastructure services. All clients use `async with` context managers and share a common base class (`AsyncBaseClient`).
 
-- **DuckDB Client** - Analytics database integration
-- **Loki Client** - Log aggregation and querying
-- **MinIO Client** - Object storage operations
-- **MQTT Client** - Message broker for IoT
-- **NATS Client** - Cloud-native messaging system
-- **Redis Client** - Caching and data structures
-- **Supabase Client** - Backend-as-a-Service integration
+### Infrastructure Clients (require running services)
+
+| Client | Service | Default Port | Protocol |
+|--------|---------|-------------|----------|
+| `AsyncRedisClient` | Redis | 6379 | gRPC proxy |
+| `AsyncPostgresClient` | PostgreSQL | 5432 | gRPC proxy |
+| `AsyncNeo4jClient` | Neo4j | 7687 | gRPC proxy |
+| `AsyncNATSClient` | NATS | 4222 | gRPC proxy |
+| `AsyncMQTTClient` | MQTT | 1883 | gRPC proxy |
+| `AsyncMinioClient` | MinIO | 9000 | gRPC proxy |
+| `AsyncQdrantClient` | Qdrant | 6333 | gRPC proxy |
+| `AsyncDuckDBClient` | DuckDB | embedded | native |
+
+### Local-Mode Clients (no external services needed)
+
+Drop-in alternatives for desktop/offline use. Same API surface, backed by local storage:
+
+| Local Client | Replaces | Backed By |
+|-------------|----------|-----------|
+| `AsyncSQLiteClient` | `AsyncPostgresClient` | SQLite file |
+| `AsyncLocalStorageClient` | `AsyncMinioClient` | Local filesystem |
+| `AsyncChromaClient` | `AsyncQdrantClient` | ChromaDB (embedded) |
+| `AsyncMemoryClient` | `AsyncRedisClient` | In-memory dict |
+
+**When to use local clients:** Use local-mode clients when running on desktop/ICP without cloud infrastructure, for development/testing without Docker, or when you need offline-capable storage.
 
 ## Installation
-
-Install from PyPI:
 
 ```bash
 pip install isa-common
@@ -66,96 +98,49 @@ pip install isa-common
 
 ## Quick Start
 
-### DuckDB Client Example
-
 ```python
-from isa_common.duckdb_client import DuckDBClient
+from isa_common import AsyncRedisClient
 
-client = DuckDBClient(host="localhost", port=50051)
-client.connect()
-
-# Execute query
-result = client.execute_query("SELECT * FROM my_table")
-print(result)
+async with AsyncRedisClient(host="localhost", port=6379, user_id="my-user") as client:
+    health = await client.health_check()
+    await client.set("key", "value")
+    value = await client.get("key")
 ```
 
-### NATS Client Example
+### Using Local-Mode Clients
 
 ```python
-from isa_common.nats_client import NATSClient
+from isa_common import AsyncSQLiteClient, AsyncLocalStorageClient
 
-client = NATSClient(host="localhost", port=50054)
-client.connect()
+# SQLite instead of PostgreSQL
+async with AsyncSQLiteClient(database="app.db", user_id="my-user") as db:
+    await db.query("SELECT * FROM users")
 
-# Publish message
-client.publish("my.subject", b"Hello World")
-
-# Subscribe to subject
-messages = client.subscribe("my.subject")
+# Local filesystem instead of MinIO
+async with AsyncLocalStorageClient(base_path="./storage", user_id="my-user") as storage:
+    await storage.put_object("my-bucket", "file.txt", b"contents")
 ```
-
-### MinIO Client Example
-
-```python
-from isa_common.minio_client import MinIOClient
-
-client = MinIOClient(host="localhost", port=50052)
-client.connect()
-
-# Upload file
-client.put_object("my-bucket", "file.txt", b"file contents")
-
-# Download file
-data = client.get_object("my-bucket", "file.txt")
-```
-
-## Features
-
-- **gRPC-based** communication with backend services
-- **Service Discovery** integration with Consul
-- **Automatic Reconnection** with configurable retry policies
-- **Type Safety** with Pydantic models
-- **Comprehensive Examples** included in the package
-
-## Requirements
-
-- Python 3.8+
-- grpcio >= 1.50.0
-- pydantic >= 2.0.0
-- tenacity >= 8.0.0
-
-## Documentation
-
-For detailed documentation and more examples, see:
-- [DuckDB Client Examples](examples/duck_client_examples.py)
-- [Loki Client Examples](examples/loki_client_examples.py)
-- [MinIO Client Examples](examples/minio_client_examples.py)
-- [MQTT Client Examples](examples/mqtt_client_examples.py)
-- [NATS Client Examples](examples/nats_client_examples.py)
-- [Redis Client Examples](examples/redis_client_examples.py)
-- [Supabase Client Examples](examples/supa_client_examples.py)
 
 ## Development
 
-Install development dependencies:
+Run tests (requires services or use local clients):
 
 ```bash
-pip install isa-common[dev]
+# Run individual service tests
+python tests/redis/test_async_redis.py
+python tests/duck/test_async_duckdb.py
+
+# Run all tests via Makefile
+make test
 ```
 
-Run tests:
+## Contract Coverage
 
-```bash
-pytest
-```
+See [tests/contract_coverage.md](tests/contract_coverage.md) for the mapping between CDD contract IDs (BR/EC/ER) and test functions.
 
 ## License
 
 Copyright © 2024 isA Platform
-
-## Support
-
-For issues and questions, please visit: https://github.com/isa-platform/isA_Cloud
 
 
 

--- a/isA_common/isa_common.egg-info/SOURCES.txt
+++ b/isA_common/isa_common.egg-info/SOURCES.txt
@@ -7,6 +7,7 @@ isa_common/async_chroma_client.py
 isa_common/async_client_config.py
 isa_common/async_duckdb_client.py
 isa_common/async_local_storage_client.py
+isa_common/async_loki_client.py
 isa_common/async_memory_client.py
 isa_common/async_minio_client.py
 isa_common/async_mqtt_client.py
@@ -17,6 +18,11 @@ isa_common/async_qdrant_client.py
 isa_common/async_redis_client.py
 isa_common/async_sqlite_client.py
 isa_common/consul_client.py
+isa_common/loki_handler.py
+isa_common/metrics.py
+isa_common/nats_client.py
+isa_common/observability.py
+isa_common/tracing.py
 isa_common.egg-info/PKG-INFO
 isa_common.egg-info/SOURCES.txt
 isa_common.egg-info/dependency_links.txt

--- a/isA_common/isa_common.egg-info/requires.txt
+++ b/isA_common/isa_common.egg-info/requires.txt
@@ -9,9 +9,11 @@ aioboto3>=12.0.0
 aiofiles>=23.0.0
 redis>=5.0.0
 nats-py>=2.6.0
-qdrant-client>=1.7.0
+qdrant-client>=1.9.0
 aiomqtt>=2.0.0
+aiosqlite>=0.19.0
 duckdb>=0.10.0
+aiohttp>=3.9.0
 
 [dev]
 pytest>=7.0.0
@@ -19,3 +21,21 @@ pytest-asyncio>=0.21.0
 black>=23.0.0
 flake8>=6.0.0
 mypy>=1.0.0
+
+[metrics]
+prometheus-client>=0.20.0
+starlette>=0.27.0
+
+[observability]
+isa-common[metrics,tracing]
+
+[tracing]
+opentelemetry-sdk>=1.20.0
+opentelemetry-exporter-otlp-proto-grpc>=1.20.0
+opentelemetry-instrumentation-fastapi>=0.41b0
+
+[tracing-extras]
+opentelemetry-instrumentation-aiohttp-client>=0.41b0
+opentelemetry-instrumentation-asyncpg>=0.41b0
+opentelemetry-instrumentation-redis>=0.41b0
+opentelemetry-instrumentation-httpx>=0.41b0

--- a/isA_common/isa_common/__init__.py
+++ b/isA_common/isa_common/__init__.py
@@ -56,10 +56,27 @@ from .observability import setup_observability
 # =============================================================================
 # Local-Mode Alternative Clients (ICP/Desktop — no infrastructure required)
 # =============================================================================
-from .async_sqlite_client import AsyncSQLiteClient
-from .async_local_storage_client import AsyncLocalStorageClient
-from .async_chroma_client import AsyncChromaClient
-from .async_memory_client import AsyncMemoryClient
+# Keep isa_common importable in lean producer runtimes even when local-mode
+# optional dependencies are not installed.
+try:
+    from .async_sqlite_client import AsyncSQLiteClient
+except ModuleNotFoundError:
+    AsyncSQLiteClient = None  # type: ignore[assignment]
+
+try:
+    from .async_local_storage_client import AsyncLocalStorageClient
+except ModuleNotFoundError:
+    AsyncLocalStorageClient = None  # type: ignore[assignment]
+
+try:
+    from .async_chroma_client import AsyncChromaClient
+except ModuleNotFoundError:
+    AsyncChromaClient = None  # type: ignore[assignment]
+
+try:
+    from .async_memory_client import AsyncMemoryClient
+except ModuleNotFoundError:
+    AsyncMemoryClient = None  # type: ignore[assignment]
 
 # Service Discovery
 from .consul_client import ConsulRegistry, AsyncConsulRegistry, consul_lifespan

--- a/isA_common/isa_common/async_nats_client.py
+++ b/isA_common/isa_common/async_nats_client.py
@@ -15,6 +15,7 @@ providing full support for all NATS operations including:
 import os
 import time
 import asyncio
+import re
 from typing import List, Dict, Optional, AsyncIterator, Any
 
 import nats
@@ -89,6 +90,12 @@ class AsyncNATSClient(AsyncBaseClient):
         if subject.startswith(prefix):
             return subject
         return f"{prefix}{subject}"
+
+    @staticmethod
+    def _sanitize_consumer_name(name: str) -> str:
+        """Normalize durable consumer names to JetStream-safe characters."""
+        sanitized = re.sub(r"[^A-Za-z0-9_-]+", "-", name).strip("-")
+        return sanitized or "consumer"
 
     def _connection_healthy(self) -> bool:
         """Check if the underlying NATS connection can be used safely."""
@@ -555,6 +562,8 @@ class AsyncNATSClient(AsyncBaseClient):
                 'last': DeliverPolicy.LAST,
             }
             deliver = deliver_policy_map.get(delivery_policy.lower(), DeliverPolicy.ALL)
+
+            consumer_name = self._sanitize_consumer_name(consumer_name)
 
             config = ConsumerConfig(
                 durable_name=consumer_name,

--- a/isA_common/isa_common/events/__init__.py
+++ b/isA_common/isa_common/events/__init__.py
@@ -12,7 +12,11 @@ from .base_event_subscriber import BaseEventSubscriber, EventHandler, Idempotenc
 # Billing-specific event implementations
 from .billing_events import (
     EventType,
+    BillingAccountType,
+    BillingSurface,
+    CostComponentType,
     UnitType,
+    CostComponent,
     UsageEvent,
     BillingCalculatedEvent,
     TokensDeductedEvent,
@@ -42,9 +46,13 @@ __all__ = [
 
     # Billing event types
     'EventType',
+    'BillingAccountType',
+    'BillingSurface',
+    'CostComponentType',
     'UnitType',
 
     # Billing event models
+    'CostComponent',
     'UsageEvent',
     'BillingCalculatedEvent',
     'TokensDeductedEvent',

--- a/isA_common/isa_common/events/base_event_subscriber.py
+++ b/isA_common/isa_common/events/base_event_subscriber.py
@@ -630,6 +630,7 @@ class BaseEventSubscriber:
 
             # Map event types to classes
             event_classes = {
+                "billing.usage.recorded": UsageEvent,
                 "usage.recorded": UsageEvent,
                 "billing.calculated": BillingCalculatedEvent,
                 "wallet.tokens.deducted": TokensDeductedEvent,

--- a/isA_common/isa_common/events/billing_event_publisher.py
+++ b/isA_common/isa_common/events/billing_event_publisher.py
@@ -10,12 +10,13 @@ import json
 import logging
 import asyncio
 import warnings
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from decimal import Decimal
 from datetime import datetime
 
 from ..nats_client import NATSClient
 from .billing_events import (
+    EventType,
     UsageEvent,
     BillingCalculatedEvent,
     TokensDeductedEvent,
@@ -128,7 +129,23 @@ class BillingEventPublisher:
         subscription_id: Optional[str] = None,
         session_id: Optional[str] = None,
         request_id: Optional[str] = None,
-        usage_details: Optional[Dict[str, Any]] = None
+        usage_details: Optional[Dict[str, Any]] = None,
+        *,
+        actor_user_id: Optional[str] = None,
+        billing_account_type: Optional[str] = None,
+        billing_account_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        service_type: Optional[str] = None,
+        operation_type: Optional[str] = None,
+        source_service: Optional[str] = None,
+        resource_name: Optional[str] = None,
+        meter_type: Optional[str] = None,
+        schema_version: str = "1.0",
+        billing_surface: str = "abstract_service",
+        cost_components: Optional[List[Dict[str, Any]]] = None,
+        credits_used: Optional[Decimal] = None,
+        cost_usd: Optional[Decimal] = None,
+        credit_consumption_handled: bool = False,
     ) -> bool:
         """
         Publish a usage event.
@@ -162,16 +179,47 @@ class BillingEventPublisher:
             )
         """
         try:
+            details = dict(usage_details or {})
+            resolved_actor_user_id = actor_user_id or user_id
+            resolved_billing_account_type = billing_account_type or (
+                "organization" if (organization_id or self.default_org_id) else "user"
+            )
+            resolved_billing_account_id = billing_account_id or (
+                (organization_id or self.default_org_id)
+                if resolved_billing_account_type == "organization"
+                else resolved_actor_user_id
+            )
+
             event = UsageEvent(
                 user_id=user_id,
+                actor_user_id=resolved_actor_user_id,
+                billing_account_type=resolved_billing_account_type,
+                billing_account_id=resolved_billing_account_id,
                 product_id=product_id,
                 usage_amount=usage_amount,
                 unit_type=unit_type,
                 organization_id=organization_id or self.default_org_id,
+                agent_id=agent_id,
                 subscription_id=subscription_id,
+                service_type=service_type or details.get("service_type"),
+                operation_type=operation_type
+                or details.get("operation_type")
+                or details.get("operation"),
+                source_service=source_service or details.get("source_service"),
+                resource_name=resource_name
+                or details.get("resource_name")
+                or details.get("tool_name")
+                or details.get("model"),
+                meter_type=meter_type or details.get("meter_type"),
                 session_id=session_id,
                 request_id=request_id,
-                usage_details=usage_details or {}
+                usage_details=details,
+                schema_version=schema_version,
+                billing_surface=billing_surface,
+                cost_components=cost_components or [],
+                credits_used=credits_used,
+                cost_usd=cost_usd,
+                credit_consumption_handled=credit_consumption_handled,
             )
 
             subject = get_nats_subject(event)
@@ -180,11 +228,18 @@ class BillingEventPublisher:
             result = await self.nats_client.publish(
                 subject=subject,
                 data=data,
-                headers={"event_type": "usage.recorded"}
+                headers={"event_type": EventType.USAGE_RECORDED.value}
             )
 
             if result and result.get('success'):
-                logger.info(f"Published usage event: {product_id} for user {user_id}")
+                logger.info(
+                    "Published billing usage event: product=%s user=%s payer=%s:%s subject=%s",
+                    product_id,
+                    user_id,
+                    resolved_billing_account_type,
+                    resolved_billing_account_id,
+                    subject,
+                )
                 return True
             else:
                 logger.error(f"Failed to publish usage event: {result}")

--- a/isA_common/isa_common/events/billing_events.py
+++ b/isA_common/isa_common/events/billing_events.py
@@ -1,21 +1,22 @@
 """
-Billing Event Models for Event-Driven Architecture
+Billing event models for event-driven billing.
 
-All services use NATS to communicate via events instead of direct HTTP calls.
-This provides loose coupling, better scalability, and fault tolerance.
+Usage events are transported over NATS. Control-plane operations such as
+pricing, reservations, and reporting remain API-driven.
 """
 
+import re
 from enum import Enum
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Iterable, List
 from datetime import datetime, timezone
 from decimal import Decimal
 from pydantic import BaseModel, Field
 
 
 class EventType(str, Enum):
-    """Event types for billing system"""
-    # Usage events (published by isA_Model, isA_Agent, etc.)
-    USAGE_RECORDED = "usage.recorded"
+    """Event types for the billing system."""
+    USAGE_RECORDED = "billing.usage.recorded"
+    LEGACY_USAGE_RECORDED = "usage.recorded"
 
     # Billing events (published by billing_service)
     COST_CALCULATED = "billing.calculated"
@@ -30,14 +31,75 @@ class EventType(str, Enum):
 
 
 class UnitType(str, Enum):
-    """Unit types for different services"""
-    TOKEN = "token"           # LLM tokens (GPT-4, GPT-3.5, embeddings)
-    IMAGE = "image"           # Image generation (DALL-E, Stable Diffusion)
-    MINUTE = "minute"         # Audio processing (STT, TTS)
-    CHARACTER = "character"   # TTS character count
-    REQUEST = "request"       # API calls (agent tools, searches)
-    BYTE = "byte"            # Storage (Minio, S3)
-    SECOND = "second"        # Video processing
+    """Unit types for different services."""
+    TOKEN = "token"
+    IMAGE = "image"
+    MINUTE = "minute"
+    HOUR = "hour"
+    CHARACTER = "character"
+    REQUEST = "request"
+    URL = "url"
+    BYTE = "byte"
+    GB = "gb"
+    GB_MONTH = "gb_month"
+    EXECUTION = "execution"
+    OPERATION = "operation"
+    UNIT = "unit"
+    SECOND = "second"
+
+
+class BillingAccountType(str, Enum):
+    """Canonical payer types."""
+    USER = "user"
+    ORGANIZATION = "organization"
+
+
+class BillingSurface(str, Enum):
+    """Customer-facing abstraction for a billing event."""
+    ABSTRACT_SERVICE = "abstract_service"
+    ADD_ON = "add_on"
+
+
+class CostComponentType(str, Enum):
+    """Underlying component classes bundled into an abstract service."""
+    RUNTIME = "runtime"
+    TOKEN_COMPUTE = "token_compute"
+    STORAGE = "storage"
+    NETWORK = "network"
+    EXTERNAL_API = "external_api"
+
+
+class CostComponent(BaseModel):
+    """Underlying resource or external API component for a usage event."""
+    component_id: str = Field(..., description="Stable component identifier")
+    component_type: CostComponentType = Field(
+        ..., description="Underlying resource or API class"
+    )
+    bundled: bool = Field(
+        default=True,
+        description="Whether the component is bundled into the abstract service price",
+    )
+    customer_visible: bool = Field(
+        default=False,
+        description="Whether the component is intentionally exposed to customers",
+    )
+    provider: Optional[str] = Field(
+        default=None,
+        description="Provider or implementation behind the component",
+    )
+    meter_type: Optional[str] = Field(
+        default=None,
+        description="Internal meter for the component when known",
+    )
+    unit_type: Optional[UnitType] = Field(
+        default=None,
+        description="Native unit used by the component when known",
+    )
+    usage_amount: Optional[Decimal] = Field(
+        default=None,
+        description="Underlying usage amount when the producer provides it",
+    )
+    notes: Optional[str] = None
 
 
 # ====================
@@ -48,22 +110,38 @@ class UsageEvent(BaseModel):
     """
     Published when any service uses a billable resource.
 
-    Publishers: isA_Model, isA_Agent, storage_service, etc.
-    Subscribers: billing_service, product_service (for metrics)
+    Publishers: `isA_Model`, `isA_Agent`, `isA_MCP`, `isA_OS`, `isA_Data`,
+    `storage_service`, and other usage producers.
 
-    NATS Subject: usage.recorded.{product_id}
-    Example: usage.recorded.gpt-4, usage.recorded.dall-e-3
+    Subscribers: `billing_service`, `product_service` metrics consumers, and
+    analytics consumers.
+
+    Canonical NATS subject family: `billing.usage.recorded.>`
     """
-    event_type: str = EventType.USAGE_RECORDED
+    event_type: str = Field(default=EventType.USAGE_RECORDED.value)
     event_id: str = Field(default_factory=lambda: f"evt_{datetime.now(timezone.utc).timestamp()}")
+    schema_version: str = Field(default="1.0", description="Billing usage event schema version")
 
-    # User context
+    # Payer and actor context
     user_id: str = Field(..., description="User who triggered the usage")
+    actor_user_id: Optional[str] = Field(None, description="Human actor responsible for the action")
+    billing_account_type: Optional[BillingAccountType] = Field(
+        None, description="Canonical payer type"
+    )
+    billing_account_id: Optional[str] = Field(
+        None, description="Canonical payer identifier"
+    )
     organization_id: Optional[str] = Field(None, description="Organization context")
+    agent_id: Optional[str] = Field(None, description="Agent that executed the work")
     subscription_id: Optional[str] = Field(None, description="Active subscription")
 
-    # Usage details
+    # Billable identity
     product_id: str = Field(..., description="Product being used (gpt-4, dall-e-3, etc)")
+    service_type: Optional[str] = Field(None, description="Canonical service category")
+    operation_type: Optional[str] = Field(None, description="Canonical operation type")
+    source_service: Optional[str] = Field(None, description="Originating service name")
+    resource_name: Optional[str] = Field(None, description="Resource name within the source service")
+    meter_type: Optional[str] = Field(None, description="Billing meter type")
     usage_amount: Decimal = Field(..., description="Amount used in native units")
     unit_type: UnitType = Field(..., description="Unit type (token, image, etc)")
 
@@ -73,6 +151,20 @@ class UsageEvent(BaseModel):
 
     # Metadata
     usage_details: Dict[str, Any] = Field(default_factory=dict, description="Additional context")
+    billing_surface: BillingSurface = Field(
+        default=BillingSurface.ABSTRACT_SERVICE,
+        description="Customer-facing abstraction for the invoiceable event",
+    )
+    cost_components: List[CostComponent] = Field(
+        default_factory=list,
+        description="Bundled underlying resource or external API components",
+    )
+    credits_used: Optional[Decimal] = Field(None, description="Credits already computed upstream")
+    cost_usd: Optional[Decimal] = Field(None, description="USD cost already computed upstream")
+    credit_consumption_handled: bool = Field(
+        False,
+        description="Whether the producer already consumed or reconciled payer credits",
+    )
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     class Config:
@@ -262,18 +354,53 @@ def create_usage_event(
     )
 
 
+_INVALID_SUBJECT_TOKEN = re.compile(r"[^A-Za-z0-9_-]+")
+
+
+def _sanitize_subject_token(value: Optional[str], fallback: str) -> str:
+    """Return a NATS-safe subject token."""
+    if not value:
+        return fallback
+    token = _INVALID_SUBJECT_TOKEN.sub("-", value.strip().lower()).strip("-")
+    return token or fallback
+
+
+def _usage_subject_tokens(event: UsageEvent) -> Iterable[str]:
+    """Build canonical subject tokens for a usage event."""
+    primary = (
+        event.source_service
+        or event.service_type
+        or event.product_id
+    )
+    yield _sanitize_subject_token(primary, "unknown")
+
+    secondary = event.resource_name
+    if not secondary:
+        details = event.usage_details or {}
+        secondary = (
+            details.get("resource_name")
+            or details.get("tool_name")
+            or details.get("model")
+            or details.get("operation_type")
+            or details.get("operation")
+        )
+
+    if secondary:
+        yield _sanitize_subject_token(str(secondary), "resource")
+
+
 def get_nats_subject(event: BaseModel) -> str:
     """
     Get the NATS subject for an event.
 
     Returns:
-        - usage.recorded.{product_id} for UsageEvent
+        - billing.usage.recorded.<source>[.<resource>] for UsageEvent
         - billing.calculated for BillingCalculatedEvent
         - wallet.tokens.deducted for TokensDeductedEvent
         - etc.
     """
     if isinstance(event, UsageEvent):
-        return f"usage.recorded.{event.product_id}"
+        return ".".join(("billing", "usage", "recorded", *_usage_subject_tokens(event)))
     elif isinstance(event, BillingCalculatedEvent):
         return "billing.calculated"
     elif isinstance(event, TokensDeductedEvent):

--- a/isA_common/isa_common/metrics.py
+++ b/isA_common/isa_common/metrics.py
@@ -364,7 +364,7 @@ def setup_metrics(
     version: str = "unknown",
     registry: Optional[object] = None,
     excluded_paths: Optional[set] = None,
-) -> None:
+) -> bool:
     """
     One-liner to add Prometheus metrics to any FastAPI/Starlette app.
 
@@ -380,10 +380,14 @@ def setup_metrics(
         registry: Custom CollectorRegistry (default: prometheus default)
         excluded_paths: Paths to exclude from metrics (default: /health, /metrics, etc.)
 
+    Returns:
+        ``True`` when middleware and the ``/metrics`` route were installed,
+        otherwise ``False`` when Prometheus support is unavailable.
+
     Example:
         from isa_common.metrics import setup_metrics
         app = FastAPI()
-        setup_metrics(app, service_name="isA_user", version="1.0.0")
+        enabled = setup_metrics(app, service_name="isA_user", version="1.0.0")
     """
     global _service_name, _registry
 
@@ -395,7 +399,7 @@ def setup_metrics(
 
     if not _PROMETHEUS_AVAILABLE:
         logger.warning(f"Metrics disabled for {service_name} — install prometheus_client")
-        return
+        return False
 
     # Initialize standard metrics
     _init_common_metrics()
@@ -415,6 +419,7 @@ def setup_metrics(
     app.routes.append(Route("/metrics", _create_metrics_endpoint()))
 
     logger.info(f"Prometheus metrics initialized for {service_name}")
+    return True
 
 
 def metrics_text() -> bytes:

--- a/isA_common/isa_common/observability.py
+++ b/isA_common/isa_common/observability.py
@@ -79,13 +79,12 @@ def setup_observability(
     if enable_metrics:
         try:
             from .metrics import setup_metrics
-            setup_metrics(
+            result["metrics"] = setup_metrics(
                 app,
                 service_name=service_name,
                 version=version,
                 registry=metrics_registry,
             )
-            result["metrics"] = True
         except Exception as e:
             logger.warning(f"Failed to setup metrics: {e}")
 

--- a/isA_common/setup.py
+++ b/isA_common/setup.py
@@ -33,6 +33,7 @@ setup(
         "grpcio>=1.50.0",
         "grpcio-tools>=1.50.0",
         "pydantic>=2.0.0",
+        "prometheus-client>=0.20.0",
         "tenacity>=8.0.0",
         "python-consul2>=0.1.5",
         "asyncpg>=0.29.0",  # PostgreSQL async client

--- a/isA_common/tests/unit/test_metrics_unit.py
+++ b/isA_common/tests/unit/test_metrics_unit.py
@@ -324,7 +324,8 @@ class TestSetupMetrics:
 
         old_svc, old_reg = m._service_name, m._registry
         try:
-            m.setup_metrics(app, service_name="isA_test", registry=registry)
+            result = m.setup_metrics(app, service_name="isA_test", registry=registry)
+            assert result is True
             assert m._service_name == "isA_test"
             assert m._registry is registry
         finally:
@@ -373,7 +374,8 @@ class TestSetupMetrics:
         try:
             app = MagicMock()
             app.routes = []
-            m.setup_metrics(app, service_name="isA_test")
+            result = m.setup_metrics(app, service_name="isA_test")
+            assert result is False
             # Should not add middleware or routes
             app.add_middleware.assert_not_called()
             assert len(app.routes) == 0

--- a/isA_common/tests/unit/test_observability_unit.py
+++ b/isA_common/tests/unit/test_observability_unit.py
@@ -172,3 +172,31 @@ class TestReturnValue:
             tempo_port=4318,
         )
         assert isinstance(result, dict)
+
+    def test_metrics_result_tracks_setup_metrics_return_value(self):
+        """Metrics should stay disabled when setup_metrics returns False."""
+        from isa_common.observability import setup_observability
+
+        app = MagicMock()
+        with patch("isa_common.metrics.setup_metrics", return_value=False):
+            result = setup_observability(
+                app,
+                service_name="test",
+                enable_logging=False,
+                enable_tracing=False,
+            )
+        assert result == {"metrics": False, "logging": False, "tracing": False}
+
+    def test_metrics_result_enabled_when_setup_metrics_succeeds(self):
+        """Metrics should reflect a successful setup_metrics call."""
+        from isa_common.observability import setup_observability
+
+        app = MagicMock()
+        with patch("isa_common.metrics.setup_metrics", return_value=True):
+            result = setup_observability(
+                app,
+                service_name="test",
+                enable_logging=False,
+                enable_tracing=False,
+            )
+        assert result == {"metrics": True, "logging": False, "tracing": False}


### PR DESCRIPTION
## Summary
- Extend billing event models with account types, billing surfaces, cost components, and richer UnitType enum for multi-service metering
- Make local-mode client imports optional so isa_common works in lean producer runtimes without sqlite/chroma deps
- Return bool from `setup_metrics()` so callers can branch on Prometheus availability
- Fix Grafana log dashboard queries to use template variable regex instead of hardcoded patterns

## Test plan
- [ ] Run `pytest isA_common/tests/unit/` — metrics and observability tests pass
- [ ] Import `isa_common` in a minimal venv without optional deps — no ImportError
- [ ] Verify Grafana dashboard service/level dropdowns filter correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)