### PR TITLE
feat(sdk): add AsyncFalkorClient for graph-backed discovery

### DIFF
--- a/isA_common/isa_common/__init__.py
+++ b/isA_common/isa_common/__init__.py
@@ -10,6 +10,7 @@ Native async clients connect directly to infrastructure services:
 - AsyncNeo4jClient (neo4j driver) - port 7687
 - AsyncNATSClient (nats-py) - port 4222
 - AsyncQdrantClient (qdrant-client) - port 6333
+- AsyncFalkorClient (falkordb) - port 6379 (Redis-module graph DB)
 - AsyncMQTTClient (aiomqtt) - port 1883
 - AsyncMinIOClient (aioboto3) - port 9000
 - AsyncDuckDBClient (duckdb) - embedded
@@ -43,6 +44,7 @@ from .async_minio_client import AsyncMinIOClient
 from .async_duckdb_client import AsyncDuckDBClient
 from .async_mqtt_client import AsyncMQTTClient
 from .async_qdrant_client import AsyncQdrantClient
+from .async_falkor_client import AsyncFalkorClient
 from .async_loki_client import AsyncLokiClient
 from .loki_handler import LokiHandler, setup_loki_logging
 
@@ -101,6 +103,7 @@ __all__ = [
     'AsyncDuckDBClient',
     'AsyncMQTTClient',
     'AsyncQdrantClient',
+    'AsyncFalkorClient',
     'AsyncLokiClient',
     'LokiHandler',
     'setup_loki_logging',
@@ -135,6 +138,7 @@ NATIVE_PORTS: Dict[str, int] = {
     'neo4j': 7687,
     'nats': 4222,
     'qdrant': 6333,
+    'falkordb': 6379,  # Redis-module graph DB; deployed on its own service in production
     'mqtt': 1883,
     'minio': 9000,
     'consul': 8500,

--- a/isA_common/isa_common/async_falkor_client.py
+++ b/isA_common/isa_common/async_falkor_client.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""
+Async FalkorDB Native Client
+
+High-performance async client for FalkorDB, the graph database that runs as a
+Redis module. Wraps the official `falkordb-py` async driver with the isa_common
+AsyncBaseClient conventions:
+
+- Lazy connection with async context manager
+- Connection pooling via redis BlockingConnectionPool
+- Tenacity-based retry with exponential backoff
+- OpenTelemetry tracing per query
+- Vector index helpers for the new MCP hierarchical-search backend
+  (see ADR-0001 in xenoISA/isA_MCP for graph schema)
+
+Always parameterize Cypher — never string-format user input into queries.
+"""
+
+import os
+import time
+from typing import Any, Dict, List, Literal, Optional, Sequence
+
+from .async_base_client import AsyncBaseClient
+
+
+class AsyncFalkorClient(AsyncBaseClient):
+    """
+    Async FalkorDB client using the native `falkordb.asyncio` driver.
+
+    Designed as the unified backend for hierarchical resource discovery in
+    isA_MCP (epic xenoISA/isA_MCP#525). Provides:
+
+    - Parameterized Cypher (read-only and write paths)
+    - Vector index management and queries (db.idx.vector.queryNodes)
+    - Bulk node creation via UNWIND
+    - Health check and graph listing
+    - OpenTelemetry instrumentation per operation
+    """
+
+    SERVICE_NAME = "FalkorDB"
+    DEFAULT_HOST = "localhost"
+    DEFAULT_PORT = 6379
+    ENV_PREFIX = "FALKOR"
+
+    DEFAULT_GRAPH = "mcp_discovery"
+
+    def __init__(
+        self,
+        graph: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        max_connections: int = 16,
+        socket_timeout: Optional[float] = 30.0,
+        ssl: bool = False,
+        retry_attempts: int = 3,
+        retry_min_wait: float = 0.5,
+        retry_max_wait: float = 5.0,
+        **kwargs,
+    ):
+        """
+        Initialize the FalkorDB client.
+
+        Args:
+            graph: Default graph name (env: FALKOR_GRAPH, default: 'mcp_discovery')
+            username: Optional auth username (env: FALKOR_USERNAME)
+            password: Optional auth password (env: FALKOR_PASSWORD)
+            max_connections: Pool size (default: 16)
+            socket_timeout: Per-command timeout in seconds (default: 30.0)
+            ssl: Use TLS (default: False)
+            retry_attempts: Max retry attempts on transient failures (default: 3)
+            retry_min_wait: Initial backoff seconds (default: 0.5)
+            retry_max_wait: Max backoff seconds (default: 5.0)
+            **kwargs: Base client args (host, port, user_id, organization_id, lazy_connect)
+        """
+        super().__init__(**kwargs)
+
+        self._graph_name = graph or os.getenv("FALKOR_GRAPH", self.DEFAULT_GRAPH)
+        self._username = username or os.getenv("FALKOR_USERNAME")
+        self._password = password or os.getenv("FALKOR_PASSWORD")
+        self._max_connections = max_connections
+        self._socket_timeout = socket_timeout
+        self._ssl = ssl
+
+        self._retry_attempts = retry_attempts
+        self._retry_min_wait = retry_min_wait
+        self._retry_max_wait = retry_max_wait
+
+        self._db = None
+        self._pool = None
+        self._tracer = None
+
+    async def _connect(self) -> None:
+        """Open a pooled connection to FalkorDB."""
+        from falkordb.asyncio import FalkorDB
+        from redis.asyncio import BlockingConnectionPool
+
+        pool_kwargs: Dict[str, Any] = {
+            "host": self._host,
+            "port": self._port,
+            "max_connections": self._max_connections,
+            "decode_responses": True,
+            "timeout": self._socket_timeout,
+        }
+        if self._username:
+            pool_kwargs["username"] = self._username
+        if self._password:
+            pool_kwargs["password"] = self._password
+        if self._ssl:
+            pool_kwargs["ssl"] = True
+
+        self._pool = BlockingConnectionPool(**pool_kwargs)
+        self._db = FalkorDB(connection_pool=self._pool)
+        self._logger.info(
+            f"Connected to FalkorDB at {self._host}:{self._port} (graph={self._graph_name})"
+        )
+
+    async def _disconnect(self) -> None:
+        """Close the connection pool."""
+        if self._pool:
+            try:
+                await self._pool.disconnect()
+            except Exception as e:
+                self._logger.warning(f"FalkorDB pool disconnect raised: {e}")
+        self._db = None
+        self._pool = None
+
+    def _get_tracer(self):
+        """Lazily acquire an OpenTelemetry tracer; tolerate missing OTel."""
+        if self._tracer is not None:
+            return self._tracer
+        try:
+            from opentelemetry import trace
+
+            self._tracer = trace.get_tracer("isa_common.falkor")
+        except ImportError:
+            self._tracer = False
+        return self._tracer
+
+    def _select_graph(self, graph: Optional[str]):
+        name = graph or self._graph_name
+        return self._db.select_graph(name)
+
+    @staticmethod
+    def _truncate(text: str, limit: int = 256) -> str:
+        if text is None:
+            return ""
+        return text if len(text) <= limit else f"{text[:limit]}..."
+
+    @staticmethod
+    def _result_to_dicts(result) -> List[Dict[str, Any]]:
+        """Convert a FalkorDB QueryResult into a list of dict rows."""
+        if result is None:
+            return []
+
+        rows = getattr(result, "result_set", None)
+        if not rows:
+            return []
+
+        header = getattr(result, "header", None) or []
+        columns: List[str] = []
+        for entry in header:
+            if isinstance(entry, (list, tuple)) and len(entry) >= 2:
+                columns.append(str(entry[1]))
+            else:
+                columns.append(str(entry))
+
+        if not columns:
+            columns = [f"col_{i}" for i in range(len(rows[0]))] if rows else []
+
+        out: List[Dict[str, Any]] = []
+        for row in rows:
+            normalized: List[Any] = []
+            for value in row:
+                if hasattr(value, "properties"):
+                    normalized.append(
+                        {
+                            "id": getattr(value, "id", None),
+                            "labels": list(getattr(value, "labels", []) or []),
+                            "properties": getattr(value, "properties", {}) or {},
+                        }
+                    )
+                else:
+                    normalized.append(value)
+            out.append(dict(zip(columns, normalized)))
+        return out
+
+    async def health_check(self) -> Optional[Dict[str, Any]]:
+        """Lightweight health probe using a Redis PING."""
+        try:
+            await self._ensure_connected()
+            pong = await self._db.connection.ping()
+            return {"healthy": bool(pong), "graph": self._graph_name}
+        except Exception as e:
+            return self.handle_error(e, "health check")
+
+    async def list_graphs(self) -> List[str]:
+        """Return the list of graphs in the FalkorDB instance."""
+        try:
+            await self._ensure_connected()
+            graphs = await self._db.list_graphs()
+            return list(graphs or [])
+        except Exception as e:
+            self.handle_error(e, "list graphs")
+            return []
+
+    async def query(
+        self,
+        cypher: str,
+        params: Optional[Dict[str, Any]] = None,
+        graph: Optional[str] = None,
+        timeout_ms: Optional[int] = None,
+        read_only: bool = False,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """
+        Execute a parameterized Cypher query.
+
+        Args:
+            cypher: Cypher statement. MUST use parameter placeholders ($name) for
+                any caller-supplied value. Never f-string user input into the query.
+            params: Parameter dict bound to the query.
+            graph: Override the default graph name.
+            timeout_ms: Per-query timeout in milliseconds.
+            read_only: If True, route via ro_query for read replica friendliness.
+
+        Returns:
+            List of row dicts keyed by RETURN clause aliases, or None on error.
+        """
+        try:
+            await self._ensure_connected()
+            g = self._select_graph(graph)
+
+            attempt = 0
+            last_error: Optional[Exception] = None
+            while attempt < self._retry_attempts:
+                attempt += 1
+                start = time.monotonic()
+                tracer = self._get_tracer()
+                span_cm = (
+                    tracer.start_as_current_span("falkor.query") if tracer else None
+                )
+                try:
+                    if span_cm:
+                        with span_cm as span:
+                            span.set_attribute("db.system", "falkordb")
+                            span.set_attribute("db.name", graph or self._graph_name)
+                            span.set_attribute(
+                                "db.operation", "ro_query" if read_only else "query"
+                            )
+                            span.set_attribute(
+                                "db.statement", self._truncate(cypher)
+                            )
+                            result = await self._run_query(
+                                g, cypher, params, timeout_ms, read_only
+                            )
+                            span.set_attribute(
+                                "db.rows", len(getattr(result, "result_set", []) or [])
+                            )
+                            return self._result_to_dicts(result)
+                    else:
+                        result = await self._run_query(
+                            g, cypher, params, timeout_ms, read_only
+                        )
+                        return self._result_to_dicts(result)
+                except Exception as e:
+                    last_error = e
+                    if not self._is_retriable(e) or attempt >= self._retry_attempts:
+                        raise
+                    backoff = min(
+                        self._retry_max_wait,
+                        self._retry_min_wait * (2 ** (attempt - 1)),
+                    )
+                    self._logger.warning(
+                        f"FalkorDB query failed (attempt {attempt}/{self._retry_attempts}): "
+                        f"{e}; retrying in {backoff:.2f}s"
+                    )
+                    import asyncio
+
+                    await asyncio.sleep(backoff)
+                finally:
+                    elapsed_ms = (time.monotonic() - start) * 1000
+                    self._logger.debug(
+                        f"FalkorDB query took {elapsed_ms:.1f}ms (attempt {attempt})"
+                    )
+
+            if last_error:
+                raise last_error
+            return []
+        except Exception as e:
+            return self.handle_error(e, "query")
+
+    async def _run_query(
+        self,
+        g,
+        cypher: str,
+        params: Optional[Dict[str, Any]],
+        timeout_ms: Optional[int],
+        read_only: bool,
+    ):
+        kwargs: Dict[str, Any] = {}
+        if params:
+            kwargs["params"] = params
+        if timeout_ms is not None:
+            kwargs["timeout"] = timeout_ms
+        if read_only:
+            return await g.ro_query(cypher, **kwargs)
+        return await g.query(cypher, **kwargs)
+
+    @staticmethod
+    def _is_retriable(error: Exception) -> bool:
+        """Decide whether to retry — only transient connection errors."""
+        message = str(error).lower()
+        retriable_hints = (
+            "connection",
+            "timeout",
+            "timed out",
+            "reset by peer",
+            "broken pipe",
+            "loading dataset",
+            "max number of clients",
+        )
+        return any(hint in message for hint in retriable_hints)
+
+    async def query_vector(
+        self,
+        label: str,
+        attribute: str,
+        vector: Sequence[float],
+        k: int = 10,
+        graph: Optional[str] = None,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """
+        Vector similarity search via db.idx.vector.queryNodes.
+
+        Args:
+            label: Node label that has a vector index on `attribute`.
+            attribute: Property name carrying the embedding.
+            vector: Query embedding (must match index dimension).
+            k: Top-K nearest neighbors.
+            graph: Override default graph.
+
+        Returns:
+            Rows of {node, score} where node is {id, labels, properties}.
+        """
+        cypher = (
+            "CALL db.idx.vector.queryNodes($label, $attribute, $k, vecf32($vector)) "
+            "YIELD node, score RETURN node, score"
+        )
+        return await self.query(
+            cypher,
+            params={
+                "label": label,
+                "attribute": attribute,
+                "k": int(k),
+                "vector": list(vector),
+            },
+            graph=graph,
+            read_only=True,
+        )
+
+    async def bulk_create_nodes(
+        self,
+        label: str,
+        rows: List[Dict[str, Any]],
+        merge_on: Optional[str] = None,
+        graph: Optional[str] = None,
+        batch_size: int = 500,
+    ) -> Optional[int]:
+        """
+        Insert or upsert nodes in batches via UNWIND.
+
+        Args:
+            label: Node label.
+            rows: List of property dicts. Each row becomes one node.
+            merge_on: If provided, MERGE on this property and SET the rest;
+                otherwise CREATE.
+            graph: Override default graph.
+            batch_size: Rows per Cypher call (default: 500).
+
+        Returns:
+            Total rows written, or None on error.
+        """
+        if not rows:
+            return 0
+
+        if not label.isidentifier():
+            raise ValueError(f"Invalid label: {label!r}")
+
+        if merge_on and not merge_on.isidentifier():
+            raise ValueError(f"Invalid merge_on property: {merge_on!r}")
+
+        try:
+            await self._ensure_connected()
+
+            if merge_on:
+                cypher = (
+                    f"UNWIND $rows AS row "
+                    f"MERGE (n:{label} {{ {merge_on}: row.{merge_on} }}) "
+                    f"SET n += row"
+                )
+            else:
+                cypher = f"UNWIND $rows AS row CREATE (n:{label}) SET n += row"
+
+            total = 0
+            for start in range(0, len(rows), batch_size):
+                batch = rows[start : start + batch_size]
+                result = await self.query(
+                    cypher, params={"rows": batch}, graph=graph
+                )
+                if result is None:
+                    return None
+                total += len(batch)
+            return total
+        except Exception as e:
+            return self.handle_error(e, "bulk create nodes")
+
+    async def create_index(
+        self,
+        label: str,
+        prop: str,
+        kind: Literal["range", "vector"] = "range",
+        dim: Optional[int] = None,
+        metric: Literal["cosine", "euclidean"] = "cosine",
+        graph: Optional[str] = None,
+    ) -> Optional[bool]:
+        """
+        Create a node index.
+
+        Args:
+            label: Node label.
+            prop: Property name to index.
+            kind: 'range' (B-tree-like) or 'vector'.
+            dim: Required for kind='vector' — embedding dimension.
+            metric: For kind='vector' — 'cosine' or 'euclidean'.
+            graph: Override default graph.
+
+        Returns:
+            True on success, None on error.
+        """
+        if not label.isidentifier():
+            raise ValueError(f"Invalid label: {label!r}")
+        if not prop.isidentifier():
+            raise ValueError(f"Invalid prop: {prop!r}")
+
+        try:
+            if kind == "vector":
+                if dim is None or dim <= 0:
+                    raise ValueError("Vector index requires dim > 0")
+                if metric not in ("cosine", "euclidean"):
+                    raise ValueError(f"Invalid metric: {metric!r}")
+                cypher = (
+                    f"CREATE VECTOR INDEX FOR (n:{label}) ON (n.{prop}) "
+                    f"OPTIONS {{dimension: {int(dim)}, similarityFunction: '{metric}'}}"
+                )
+            elif kind == "range":
+                cypher = f"CREATE INDEX FOR (n:{label}) ON (n.{prop})"
+            else:
+                raise ValueError(f"Unknown index kind: {kind!r}")
+
+            await self.query(cypher, graph=graph)
+            return True
+        except Exception as e:
+            return self.handle_error(e, "create index")
+
+    async def drop_graph(self, graph: Optional[str] = None) -> Optional[bool]:
+        """Drop a graph (DESTRUCTIVE). Use only in tests / migrations."""
+        try:
+            await self._ensure_connected()
+            g = self._select_graph(graph)
+            await g.delete()
+            return True
+        except Exception as e:
+            return self.handle_error(e, "drop graph")

--- a/isA_common/pyproject.toml
+++ b/isA_common/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "redis>=5.0.0",  # Async Redis (redis-py with asyncio)
     "nats-py>=2.6.0",  # Async NATS with JetStream
     "qdrant-client>=1.9.0",  # Async Qdrant vector database
+    "falkordb>=1.0.0",  # Async FalkorDB graph database (Redis module)
     "aiomqtt>=2.0.0",  # Async MQTT client
     "aiosqlite>=0.19.0",  # Async SQLite
     "duckdb>=0.10.0",  # DuckDB analytics database

--- a/isA_common/tests/falkor/test_async_falkor.py
+++ b/isA_common/tests/falkor/test_async_falkor.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Async FalkorDB Client - Integration Tests
+
+Requires a running FalkorDB instance. Skipped automatically when unreachable.
+Run locally:
+    docker run -p 6379:6379 -it --rm falkordb/falkordb:latest
+    HOST=localhost PORT=6379 pytest tests/falkor/test_async_falkor.py
+"""
+
+import os
+import socket
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from isa_common import AsyncFalkorClient
+
+
+HOST = os.environ.get("FALKOR_HOST", os.environ.get("HOST", "localhost"))
+PORT = int(os.environ.get("FALKOR_PORT", os.environ.get("PORT", "6379")))
+
+
+def _falkor_reachable() -> bool:
+    """Check that the host:port answers AND speaks FalkorDB (not plain Redis)."""
+    try:
+        with socket.create_connection((HOST, PORT), timeout=1.0):
+            pass
+    except OSError:
+        return False
+
+    try:
+        import asyncio
+
+        async def _probe() -> bool:
+            from falkordb.asyncio import FalkorDB
+
+            db = FalkorDB(
+                host=HOST,
+                port=PORT,
+                username=os.environ.get("FALKOR_USERNAME"),
+                password=os.environ.get("FALKOR_PASSWORD"),
+            )
+            try:
+                await db.list_graphs()
+                return True
+            finally:
+                close = getattr(db.connection, "aclose", None) or getattr(
+                    db.connection, "close", None
+                )
+                if close:
+                    res = close()
+                    if hasattr(res, "__await__"):
+                        await res
+
+        return asyncio.run(_probe())
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _falkor_reachable(),
+        reason=f"FalkorDB module not available at {HOST}:{PORT} (or auth required)",
+    ),
+]
+
+
+@pytest_asyncio.fixture
+async def client():
+    graph_name = f"test_{uuid.uuid4().hex[:8]}"
+    c = AsyncFalkorClient(host=HOST, port=PORT, graph=graph_name, lazy_connect=True)
+    yield c
+    try:
+        await c.drop_graph()
+    finally:
+        await c.close()
+
+
+class TestFalkorIntegration:
+    async def test_health_check(self, client):
+        result = await client.health_check()
+        assert result is not None
+        assert result["healthy"] is True
+
+    async def test_query_returns_value(self, client):
+        rows = await client.query("RETURN 1 AS v")
+        assert rows == [{"v": 1}]
+
+    async def test_create_node_and_read_back(self, client):
+        await client.query(
+            "CREATE (n:Skill {id: $id, name: $name})",
+            params={"id": "calendar-management", "name": "Calendar Management"},
+        )
+        rows = await client.query(
+            "MATCH (n:Skill {id: $id}) RETURN n.name AS name",
+            params={"id": "calendar-management"},
+        )
+        assert rows == [{"name": "Calendar Management"}]
+
+    async def test_bulk_create_with_merge_is_idempotent(self, client):
+        rows_in = [
+            {"id": "skill-a", "name": "Skill A"},
+            {"id": "skill-b", "name": "Skill B"},
+        ]
+        await client.bulk_create_nodes("Skill", rows_in, merge_on="id")
+        await client.bulk_create_nodes("Skill", rows_in, merge_on="id")
+
+        rows = await client.query("MATCH (n:Skill) RETURN count(n) AS c")
+        assert rows[0]["c"] == 2
+
+    async def test_vector_index_round_trip(self, client):
+        ok = await client.create_index(
+            "Doc", "embedding", kind="vector", dim=4, metric="cosine"
+        )
+        assert ok is True
+
+        await client.query(
+            "CREATE (:Doc {id: 'a', embedding: vecf32([1.0, 0.0, 0.0, 0.0])})"
+        )
+        await client.query(
+            "CREATE (:Doc {id: 'b', embedding: vecf32([0.0, 1.0, 0.0, 0.0])})"
+        )
+
+        results = await client.query_vector(
+            "Doc", "embedding", vector=[1.0, 0.0, 0.0, 0.0], k=2
+        )
+        assert results is not None
+        assert len(results) >= 1
+        top = results[0]
+        assert top["node"]["properties"]["id"] == "a"

--- a/isA_common/tests/unit/conftest.py
+++ b/isA_common/tests/unit/conftest.py
@@ -135,6 +135,44 @@ async def qdrant_client():
 
 
 # ============================================================================
+# FalkorDB
+# ============================================================================
+
+@pytest_asyncio.fixture
+async def falkor_client():
+    """AsyncFalkorClient with mocked falkordb async driver."""
+    from isa_common import AsyncFalkorClient
+
+    client = AsyncFalkorClient(
+        host="localhost", port=6379,
+        graph="test_graph",
+        user_id="test_user", organization_id="org1",
+        lazy_connect=True,
+    )
+
+    mock_graph = MagicMock()
+    mock_graph.query = AsyncMock()
+    mock_graph.ro_query = AsyncMock()
+    mock_graph.delete = AsyncMock()
+
+    mock_db = MagicMock()
+    mock_db.select_graph.return_value = mock_graph
+    mock_db.list_graphs = AsyncMock(return_value=["test_graph"])
+    mock_db.connection = MagicMock()
+    mock_db.connection.ping = AsyncMock(return_value=True)
+
+    mock_pool = MagicMock()
+    mock_pool.disconnect = AsyncMock()
+
+    client._db = mock_db
+    client._pool = mock_pool
+    client._graph = mock_graph
+    client._connected = True
+    yield client
+    client._connected = False
+
+
+# ============================================================================
 # DuckDB
 # ============================================================================
 

--- a/isA_common/tests/unit/test_falkor_unit.py
+++ b/isA_common/tests/unit/test_falkor_unit.py
@@ -1,0 +1,229 @@
+"""AsyncFalkorClient unit tests — mocked falkordb driver, no infrastructure required."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+class TestFalkorConnection:
+    async def test_starts_disconnected(self):
+        from isa_common import AsyncFalkorClient
+
+        client = AsyncFalkorClient(host="localhost", port=6379, lazy_connect=True)
+        assert client._connected is False
+
+    async def test_close_sets_disconnected(self, falkor_client):
+        await falkor_client.close()
+        assert falkor_client._connected is False
+
+    def test_default_graph_name_from_env(self, monkeypatch):
+        from isa_common import AsyncFalkorClient
+
+        monkeypatch.setenv("FALKOR_GRAPH", "custom_graph")
+        client = AsyncFalkorClient(host="localhost", port=6379, lazy_connect=True)
+        assert client._graph_name == "custom_graph"
+
+
+class TestFalkorHealthCheck:
+    async def test_health_check_success(self, falkor_client):
+        result = await falkor_client.health_check()
+
+        assert result is not None
+        assert result["healthy"] is True
+        assert result["graph"] == "test_graph"
+
+    async def test_health_check_error_returns_none(self, falkor_client):
+        falkor_client._db.connection.ping = AsyncMock(side_effect=Exception("connection refused"))
+
+        result = await falkor_client.health_check()
+
+        assert result is None
+
+
+class TestFalkorQuery:
+    async def test_query_passes_params(self, falkor_client):
+        mock_result = MagicMock()
+        mock_result.result_set = [["alice"]]
+        mock_result.header = [[1, "name"]]
+        falkor_client._graph.query = AsyncMock(return_value=mock_result)
+
+        rows = await falkor_client.query(
+            "MATCH (n:User {id: $id}) RETURN n.name AS name",
+            params={"id": 42},
+        )
+
+        assert rows == [{"name": "alice"}]
+        call_kwargs = falkor_client._graph.query.await_args.kwargs
+        assert call_kwargs["params"] == {"id": 42}
+
+    async def test_query_routes_read_only(self, falkor_client):
+        mock_result = MagicMock()
+        mock_result.result_set = []
+        mock_result.header = []
+        falkor_client._graph.ro_query = AsyncMock(return_value=mock_result)
+
+        await falkor_client.query("MATCH (n) RETURN n", read_only=True)
+
+        falkor_client._graph.ro_query.assert_awaited_once()
+        falkor_client._graph.query.assert_not_called()
+
+    async def test_query_normalizes_node_objects(self, falkor_client):
+        node = MagicMock()
+        node.id = 1
+        node.labels = ["User"]
+        node.properties = {"name": "alice"}
+        mock_result = MagicMock()
+        mock_result.result_set = [[node]]
+        mock_result.header = [[1, "n"]]
+        falkor_client._graph.query = AsyncMock(return_value=mock_result)
+
+        rows = await falkor_client.query("MATCH (n:User) RETURN n")
+
+        assert rows == [
+            {"n": {"id": 1, "labels": ["User"], "properties": {"name": "alice"}}}
+        ]
+
+    async def test_query_returns_none_on_unrecoverable_error(self, falkor_client):
+        falkor_client._graph.query = AsyncMock(side_effect=ValueError("syntax error"))
+
+        result = await falkor_client.query("INVALID")
+
+        assert result is None
+
+    async def test_query_retries_on_transient_then_succeeds(self, falkor_client):
+        mock_result = MagicMock()
+        mock_result.result_set = [[1]]
+        mock_result.header = [[1, "v"]]
+        falkor_client._retry_min_wait = 0.0
+        falkor_client._retry_max_wait = 0.0
+        falkor_client._graph.query = AsyncMock(
+            side_effect=[ConnectionError("connection reset by peer"), mock_result]
+        )
+
+        rows = await falkor_client.query("RETURN 1 AS v")
+
+        assert rows == [{"v": 1}]
+        assert falkor_client._graph.query.await_count == 2
+
+
+class TestFalkorVectorQuery:
+    async def test_query_vector_builds_cypher(self, falkor_client):
+        mock_result = MagicMock()
+        mock_result.result_set = []
+        mock_result.header = []
+        falkor_client._graph.ro_query = AsyncMock(return_value=mock_result)
+
+        await falkor_client.query_vector(
+            label="Skill", attribute="embedding", vector=[0.1, 0.2, 0.3], k=5
+        )
+
+        cypher = falkor_client._graph.ro_query.await_args.args[0]
+        params = falkor_client._graph.ro_query.await_args.kwargs["params"]
+        assert "db.idx.vector.queryNodes" in cypher
+        assert params == {
+            "label": "Skill",
+            "attribute": "embedding",
+            "k": 5,
+            "vector": [0.1, 0.2, 0.3],
+        }
+
+
+class TestFalkorBulkCreate:
+    async def test_bulk_create_uses_unwind(self, falkor_client):
+        mock_result = MagicMock()
+        mock_result.result_set = []
+        mock_result.header = []
+        falkor_client._graph.query = AsyncMock(return_value=mock_result)
+
+        rows = [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+        total = await falkor_client.bulk_create_nodes("Skill", rows)
+
+        assert total == 2
+        cypher = falkor_client._graph.query.await_args.args[0]
+        assert "UNWIND $rows" in cypher
+        assert "CREATE (n:Skill)" in cypher
+
+    async def test_bulk_create_with_merge(self, falkor_client):
+        mock_result = MagicMock()
+        mock_result.result_set = []
+        mock_result.header = []
+        falkor_client._graph.query = AsyncMock(return_value=mock_result)
+
+        rows = [{"id": "x", "name": "a"}]
+        await falkor_client.bulk_create_nodes("Skill", rows, merge_on="id")
+
+        cypher = falkor_client._graph.query.await_args.args[0]
+        assert "MERGE (n:Skill { id: row.id })" in cypher
+        assert "SET n += row" in cypher
+
+    async def test_bulk_create_rejects_invalid_label(self, falkor_client):
+        with pytest.raises(ValueError):
+            await falkor_client.bulk_create_nodes("Bad Label", [{"x": 1}])
+
+    async def test_bulk_create_rejects_invalid_merge_on(self, falkor_client):
+        with pytest.raises(ValueError):
+            await falkor_client.bulk_create_nodes("Skill", [{"x": 1}], merge_on="bad name")
+
+    async def test_bulk_create_empty_returns_zero(self, falkor_client):
+        result = await falkor_client.bulk_create_nodes("Skill", [])
+        assert result == 0
+
+    async def test_bulk_create_batches(self, falkor_client):
+        mock_result = MagicMock()
+        mock_result.result_set = []
+        mock_result.header = []
+        falkor_client._graph.query = AsyncMock(return_value=mock_result)
+
+        rows = [{"id": i} for i in range(7)]
+        total = await falkor_client.bulk_create_nodes("Skill", rows, batch_size=3)
+
+        assert total == 7
+        # 7 rows in batches of 3 -> ceil(7/3) = 3 calls
+        assert falkor_client._graph.query.await_count == 3
+
+
+class TestFalkorCreateIndex:
+    async def test_create_vector_index(self, falkor_client):
+        mock_result = MagicMock()
+        mock_result.result_set = []
+        mock_result.header = []
+        falkor_client._graph.query = AsyncMock(return_value=mock_result)
+
+        ok = await falkor_client.create_index(
+            "Skill", "embedding", kind="vector", dim=384, metric="cosine"
+        )
+
+        assert ok is True
+        cypher = falkor_client._graph.query.await_args.args[0]
+        assert "CREATE VECTOR INDEX FOR (n:Skill) ON (n.embedding)" in cypher
+        assert "dimension: 384" in cypher
+        assert "similarityFunction: 'cosine'" in cypher
+
+    async def test_create_range_index(self, falkor_client):
+        mock_result = MagicMock()
+        mock_result.result_set = []
+        mock_result.header = []
+        falkor_client._graph.query = AsyncMock(return_value=mock_result)
+
+        ok = await falkor_client.create_index("Skill", "id", kind="range")
+
+        assert ok is True
+        cypher = falkor_client._graph.query.await_args.args[0]
+        assert "CREATE INDEX FOR (n:Skill) ON (n.id)" in cypher
+
+    async def test_vector_index_requires_dim(self, falkor_client):
+        result = await falkor_client.create_index("Skill", "embedding", kind="vector")
+        assert result is None
+
+    async def test_invalid_label_raises(self, falkor_client):
+        with pytest.raises(ValueError):
+            await falkor_client.create_index("Bad Label", "embedding", kind="range")
+
+
+class TestFalkorListGraphs:
+    async def test_list_graphs(self, falkor_client):
+        result = await falkor_client.list_graphs()
+        assert result == ["test_graph"]
+
+    async def test_list_graphs_returns_empty_on_error(self, falkor_client):
+        falkor_client._db.list_graphs = AsyncMock(side_effect=Exception("nope"))
+        result = await falkor_client.list_graphs()
+        assert result == []


### PR DESCRIPTION
## Summary

- Adds `isa_common.AsyncFalkorClient` — async wrapper around `falkordb-py`, mirroring the conventions of `AsyncQdrantClient` and `AsyncNeo4jClient`
- Foundation for the MCP hierarchical-search backend swap (epic xenoISA/isA_MCP#525, schema in [ADR-0001](https://github.com/xenoISA/isA_MCP/blob/main/docs/adr/0001-falkordb-graph-schema-for-hierarchical-discovery.md))
- Per-query OpenTelemetry spans, retry with exponential backoff, parameterized Cypher only (identifier validation for DDL inputs)

## Surface

| Method | Purpose |
|---|---|
| `query(cypher, params, read_only)` | Parameterized Cypher with retry; routes to `ro_query` when `read_only=True` |
| `query_vector(label, attribute, vector, k)` | Wraps `db.idx.vector.queryNodes` |
| `bulk_create_nodes(label, rows, merge_on, batch_size)` | UNWIND-batched CREATE or MERGE upsert |
| `create_index(label, prop, kind, dim, metric)` | Range and vector indexes |
| `health_check`, `list_graphs`, `drop_graph` | Standard ops |

## Test plan

- [x] 23 unit tests pass (mocked driver) — `pytest tests/unit/test_falkor_unit.py`
- [x] 5 integration tests scaffolded; auto-skip when no real FalkorDB on `FALKOR_HOST:FALKOR_PORT`
- [ ] Run integration suite against the staging FalkorDB once xenoISA/isA_Cloud#202 (deployment) lands
- [ ] Wire isA_MCP `HierarchicalSearchService` to use this client (xenoISA/isA_MCP#527)

Fixes xenoISA/isA_Cloud#201
Parent epic: xenoISA/isA_MCP#525

🤖 Generated with [Claude Code](https://claude.com/claude-code)