### PR TITLE
feat(infra): add FalkorDB deployment (Helm + backup + runbook)

### DIFF
--- a/deployments/kubernetes/dev/values/falkordb.yaml
+++ b/deployments/kubernetes/dev/values/falkordb.yaml
@@ -1,0 +1,58 @@
+# FalkorDB Helm Values - DEV (kind cluster, single node)
+# Chart: bitnami/redis with FalkorDB module
+# Install: helm install falkordb bitnami/redis -n isa-cloud-dev -f dev/values/falkordb.yaml
+
+global:
+  security:
+    allowInsecureImages: true
+
+architecture: standalone
+
+image:
+  registry: docker.io
+  repository: falkordb/falkordb
+  tag: "v4.8.7"
+  pullPolicy: IfNotPresent
+
+# Dev mode: no auth for easy local poking; production and staging always enable it
+auth:
+  enabled: false
+
+master:
+  extraFlags:
+    - "--loadmodule"
+    - "/var/lib/falkordb/bin/falkordb.so"
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  persistence:
+    enabled: true
+    size: 5Gi
+
+  service:
+    type: ClusterIP
+    ports:
+      redis: 6379
+
+  configuration: |
+    appendonly yes
+    appendfsync everysec
+    maxmemory 768mb
+    maxmemory-policy noeviction
+
+  podLabels:
+    tier: infrastructure
+    environment: dev
+    app: falkordb
+
+replica:
+  replicaCount: 0
+
+metrics:
+  enabled: true

--- a/deployments/kubernetes/production/values/falkordb.yaml
+++ b/deployments/kubernetes/production/values/falkordb.yaml
@@ -1,0 +1,97 @@
+# FalkorDB Helm Values - PRODUCTION
+# Chart: bitnami/redis with FalkorDB module
+# Install: helm install falkordb bitnami/redis -n isa-cloud-production -f production/values/falkordb.yaml
+#
+# Production sizing assumes ~50k :Tool nodes and 4 384-dim vector indexes
+# (Skill, Tool, Prompt, Resource per ADR-0001 in xenoISA/isA_MCP).
+
+global:
+  security:
+    allowInsecureImages: true
+
+architecture: replication
+
+image:
+  registry: docker.io
+  repository: falkordb/falkordb
+  tag: "v4.8.7"
+  pullPolicy: IfNotPresent
+
+auth:
+  enabled: true
+  existingSecret: "falkordb-secret"
+  existingSecretPasswordKey: "falkordb-password"
+
+master:
+  extraFlags:
+    - "--loadmodule"
+    - "/var/lib/falkordb/bin/falkordb.so"
+
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 4Gi
+    limits:
+      cpu: 4000m
+      memory: 8Gi
+
+  persistence:
+    enabled: true
+    size: 50Gi
+
+  service:
+    type: ClusterIP
+    ports:
+      redis: 6379
+
+  configuration: |
+    appendonly yes
+    appendfsync everysec
+    save 900 1
+    save 300 10
+    save 60 10000
+    maxmemory 6gb
+    maxmemory-policy noeviction
+
+  podLabels:
+    tier: infrastructure
+    environment: production
+    app: falkordb
+
+# Read replica for query fan-out and HA
+replica:
+  replicaCount: 1
+  extraFlags:
+    - "--loadmodule"
+    - "/var/lib/falkordb/bin/falkordb.so"
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      cpu: 2000m
+      memory: 6Gi
+
+  persistence:
+    enabled: true
+    size: 50Gi
+
+  podLabels:
+    tier: infrastructure
+    environment: production
+    app: falkordb
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    namespace: monitoring
+    additionalLabels:
+      app: falkordb
+      environment: production
+
+# Pod Disruption Budget for graceful upgrades
+pdb:
+  create: true
+  minAvailable: 1

--- a/deployments/kubernetes/staging/README.md
+++ b/deployments/kubernetes/staging/README.md
@@ -23,6 +23,7 @@ Required secrets:
 - `postgresql-secret` - PostgreSQL credentials
 - `redis-secret` - Redis password
 - `neo4j-secret` - Neo4j credentials
+- `falkordb-secret` - FalkorDB password (key: `falkordb-password`)
 - `minio-secret` - MinIO access keys
 
 ### Storage Classes
@@ -75,6 +76,7 @@ The deploy script follows this order:
 | NATS | Helm | 1 | Event messaging |
 | EMQX | Helm | 1 | MQTT broker |
 | Qdrant | Helm | 1 | Vector database |
+| FalkorDB | Helm | 1 | Graph database (Redis module) for MCP hierarchical search |
 | Consul | Helm | 1 | Service discovery |
 | APISIX | Helm | 1 | API Gateway |
 
@@ -118,6 +120,9 @@ kubectl port-forward -n isa-cloud-staging svc/neo4j 7474:7474 7687:7687
 
 # Qdrant Dashboard
 kubectl port-forward -n isa-cloud-staging svc/qdrant 6333:6333
+
+# FalkorDB (use redis-cli on port 6379)
+kubectl port-forward -n isa-cloud-staging svc/falkordb-master 6379:6379
 ```
 
 ## Troubleshooting
@@ -191,13 +196,15 @@ helm rollback <release-name> -n isa-cloud-staging
 ```
 staging/
 ├── manifests/
-│   ├── etcd.yaml                 # etcd StatefulSet
-│   └── consul-apisix-sync.yaml   # Route sync CronJob
+│   ├── etcd.yaml                       # etcd StatefulSet
+│   ├── consul-apisix-sync.yaml         # Route sync CronJob
+│   └── falkordb-backup-cronjob.yaml    # FalkorDB daily backup to MinIO
 ├── values/
 │   ├── apisix.yaml               # APISIX Helm values
 │   ├── consul.yaml               # Consul Helm values
 │   ├── emqx.yaml                 # EMQX Helm values
 │   ├── etcd.yaml                 # etcd Helm values (alternative)
+│   ├── falkordb.yaml             # FalkorDB Helm values (Bitnami Redis + module)
 │   ├── minio.yaml                # MinIO Helm values
 │   ├── nats.yaml                 # NATS Helm values
 │   ├── neo4j.yaml                # Neo4j Helm values

--- a/deployments/kubernetes/staging/manifests/falkordb-backup-cronjob.yaml
+++ b/deployments/kubernetes/staging/manifests/falkordb-backup-cronjob.yaml
@@ -1,0 +1,97 @@
+# FalkorDB Daily Backup CronJob - STAGING
+# Runs `BGSAVE` against the master pod, then uploads the resulting RDB to MinIO.
+# Restore procedure: docs/runbooks/falkordb-recovery.md
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: falkordb-backup
+  namespace: isa-cloud-staging
+  labels:
+    app: falkordb
+    component: backup
+    tier: infrastructure
+    environment: staging
+spec:
+  # Daily at 03:15 UTC; offset from other backups to spread load
+  schedule: "15 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: falkordb
+            component: backup
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: backup
+              image: bitnami/redis:7.4
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: REDIS_HOST
+                  value: "falkordb-master.isa-cloud-staging.svc.cluster.local"
+                - name: REDIS_PORT
+                  value: "6379"
+                - name: REDISCLI_AUTH
+                  valueFrom:
+                    secretKeyRef:
+                      name: falkordb-secret
+                      key: falkordb-password
+                - name: MINIO_ENDPOINT
+                  value: "http://minio.isa-cloud-staging.svc.cluster.local:9000"
+                - name: MINIO_BUCKET
+                  value: "falkordb-backups"
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-secret
+                      key: root-user
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-secret
+                      key: root-password
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  TS=$(date -u +%Y%m%d-%H%M%S)
+                  KEY="falkordb-${TS}.rdb"
+
+                  echo "[1/4] Triggering BGSAVE on $REDIS_HOST..."
+                  redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" BGSAVE
+
+                  echo "[2/4] Waiting for BGSAVE to finish..."
+                  while true; do
+                    OUT=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" LASTSAVE)
+                    sleep 5
+                    NEW=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" LASTSAVE)
+                    if [ "$OUT" != "$NEW" ]; then
+                      break
+                    fi
+                  done
+
+                  echo "[3/4] Copying RDB out of master pod..."
+                  POD=$(echo $REDIS_HOST | cut -d. -f1)-0
+                  # The Bitnami Redis chart writes dump.rdb under /data
+                  redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" --rdb /tmp/${KEY}
+
+                  echo "[4/4] Uploading $KEY to s3://${MINIO_BUCKET}/..."
+                  apk add --no-cache aws-cli >/dev/null 2>&1 || true
+                  aws --endpoint-url "$MINIO_ENDPOINT" s3 cp /tmp/${KEY} \
+                    s3://${MINIO_BUCKET}/${KEY}
+
+                  echo "Backup complete: ${KEY}"
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi

--- a/deployments/kubernetes/staging/manifests/network-policies.yaml
+++ b/deployments/kubernetes/staging/manifests/network-policies.yaml
@@ -98,6 +98,39 @@ spec:
           port: 6379
 
 ---
+# Allow MCP service to access FalkorDB (graph-backed hierarchical search)
+# See xenoISA/isA_MCP epic #525 for the discovery acceleration work that uses this.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-falkordb-access
+  namespace: isa-cloud-staging
+  labels:
+    app.kubernetes.io/part-of: isa-cloud
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: falkordb
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: mcp-service
+        - podSelector:
+            matchLabels:
+              app: mcp-worker-service
+        # Backup CronJob lives in this namespace; allow same-ns scrape too
+        - podSelector:
+            matchLabels:
+              component: backup
+      ports:
+        - protocol: TCP
+          port: 6379
+
+---
 # Allow services to access Consul
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/deployments/kubernetes/staging/scripts/deploy.sh
+++ b/deployments/kubernetes/staging/scripts/deploy.sh
@@ -187,6 +187,19 @@ deploy_infrastructure() {
         -f ${VALUES_DIR}/qdrant.yaml \
         --wait --timeout ${TIMEOUT}
 
+    # 5b. Deploy graph database (FalkorDB - Redis module)
+    log_step "Deploying FalkorDB..."
+    helm upgrade --install falkordb bitnami/redis \
+        -n ${NAMESPACE} \
+        -f ${VALUES_DIR}/falkordb.yaml \
+        --wait --timeout ${TIMEOUT}
+
+    # Apply FalkorDB daily backup CronJob
+    if [ -f "${MANIFESTS_DIR}/falkordb-backup-cronjob.yaml" ]; then
+        log_step "Applying FalkorDB backup CronJob..."
+        kubectl apply -f "${MANIFESTS_DIR}/falkordb-backup-cronjob.yaml"
+    fi
+
     # 6. Deploy service discovery
     log_step "Deploying Consul..."
     helm upgrade --install consul hashicorp/consul \

--- a/deployments/kubernetes/staging/values/falkordb.yaml
+++ b/deployments/kubernetes/staging/values/falkordb.yaml
@@ -1,0 +1,85 @@
+# FalkorDB Helm Values - STAGING
+# Chart: bitnami/redis (FalkorDB ships as a Redis module)
+# Image: falkordb/falkordb:latest (see https://docs.falkordb.com/operations/k8s-support.html)
+# Install: helm install falkordb bitnami/redis -n isa-cloud-staging -f staging/values/falkordb.yaml
+#
+# FalkorDB powers the hierarchical resource discovery backend for isA_MCP
+# (epic xenoISA/isA_MCP#525). Schema lives in xenoISA/isA_MCP ADR-0001.
+
+# Bitnami Redis runs the FalkorDB image as the Redis binary; allow-list is
+# required because the image is not a Bitnami-published one.
+global:
+  security:
+    allowInsecureImages: true
+
+architecture: standalone
+
+# Use the FalkorDB image instead of upstream Redis
+image:
+  registry: docker.io
+  repository: falkordb/falkordb
+  # Pin a specific tag for reproducibility - update intentionally during upgrades.
+  # See https://hub.docker.com/r/falkordb/falkordb/tags for current releases.
+  tag: "v4.8.7"
+  pullPolicy: IfNotPresent
+
+# Authentication via existing K8s secret (provision via secrets/infrastructure-secrets.yaml)
+auth:
+  enabled: true
+  existingSecret: "falkordb-secret"
+  existingSecretPasswordKey: "falkordb-password"
+
+# Master configuration
+master:
+  # Load the FalkorDB module on Redis startup
+  extraFlags:
+    - "--loadmodule"
+    - "/var/lib/falkordb/bin/falkordb.so"
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+
+  persistence:
+    enabled: true
+    size: 20Gi
+
+  # ClusterIP for in-cluster access only; FalkorDB speaks the Redis protocol on 6379
+  service:
+    type: ClusterIP
+    ports:
+      redis: 6379
+
+  # AOF + periodic RDB snapshots; tuned for graph workloads where queries are
+  # cheaper to replay than full re-indexes
+  configuration: |
+    appendonly yes
+    appendfsync everysec
+    save 900 1
+    save 300 10
+    save 60 10000
+    maxmemory 3gb
+    maxmemory-policy noeviction
+
+  podLabels:
+    tier: infrastructure
+    environment: staging
+    app: falkordb
+
+# No replicas in staging (cost optimization); production is a separate values file
+replica:
+  replicaCount: 0
+
+# Built-in Bitnami metrics exporter; ServiceMonitor wires Prometheus
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    namespace: monitoring
+    additionalLabels:
+      app: falkordb
+      environment: staging

--- a/docs/runbooks/falkordb-recovery.md
+++ b/docs/runbooks/falkordb-recovery.md
@@ -1,0 +1,164 @@
+# Runbook: FalkorDB Recovery
+
+FalkorDB is the graph database (Redis module) that powers the MCP hierarchical
+resource discovery backend (epic xenoISA/isA_MCP#525). Unlike pure Redis, the
+data here is the source-of-truth read projection of MCP tools/prompts/resources
+joined to skills.
+
+## Symptoms
+
+- Application errors from `isa_common.AsyncFalkorClient`: `ConnectionError`,
+  `Authentication required`, or `module falkordb not loaded`
+- isA_MCP `HierarchicalSearchService` returns empty results or falls back to
+  the legacy Qdrant + Postgres path (look for `mcp_search_backend_used{backend="qdrant"}`
+  metric spike in Grafana)
+- Slow query latency on graph hot path (`discovery.tool_traverse` span p95 > 200ms)
+
+## Quick Health Check
+
+```bash
+NS=isa-cloud-staging  # or isa-cloud-production
+
+# Pod status
+kubectl get pods -n $NS -l app=falkordb
+
+# Module loaded?
+PASS=$(kubectl get secret falkordb-secret -n $NS -o jsonpath='{.data.falkordb-password}' | base64 -d)
+kubectl exec -n $NS svc/falkordb-master -- redis-cli -a "$PASS" MODULE LIST
+
+# Graph(s) present?
+kubectl exec -n $NS svc/falkordb-master -- redis-cli -a "$PASS" GRAPH.LIST
+
+# Memory + persistence
+kubectl exec -n $NS svc/falkordb-master -- redis-cli -a "$PASS" INFO memory | grep -E "used_memory_human|maxmemory_human"
+kubectl exec -n $NS svc/falkordb-master -- redis-cli -a "$PASS" INFO persistence | grep -E "rdb_last_save_time|aof_enabled"
+
+# Sample query against the discovery graph
+kubectl exec -n $NS svc/falkordb-master -- redis-cli -a "$PASS" \
+  GRAPH.QUERY mcp_discovery "MATCH (s:Skill) RETURN count(s) AS n"
+```
+
+## Common Failure Modes
+
+### 1. Module not loaded
+
+**Symptom**: `MODULE LIST` returns empty; `GRAPH.QUERY` returns
+`(error) ERR unknown command 'GRAPH.QUERY'`.
+
+**Cause**: Pod restarted but `--loadmodule` flag missing, or Bitnami chart
+upgrade dropped the `master.extraFlags` block.
+
+**Resolution**:
+```bash
+# Verify values file still has the loadmodule extraFlags
+helm get values falkordb -n $NS | grep -A 3 extraFlags
+
+# Re-apply with the values file
+helm upgrade falkordb bitnami/redis -n $NS \
+  -f deployments/kubernetes/staging/values/falkordb.yaml \
+  --wait
+```
+
+### 2. Pod crash / OOMKilled
+
+**Symptom**: Pod in `CrashLoopBackOff`; events show `OOMKilled`.
+
+**Cause**: Graph grew past `maxmemory`; common when bulk migration runs without
+the noeviction policy being respected by the workload.
+
+**Resolution**:
+1. Bump memory in the values file under `master.resources.limits.memory` and
+   `master.configuration.maxmemory`, then `helm upgrade`.
+2. If the workload should not have grown that much, check for runaway writes:
+   ```bash
+   kubectl exec -n $NS svc/falkordb-master -- redis-cli -a "$PASS" \
+     GRAPH.QUERY mcp_discovery "MATCH (n) RETURN labels(n)[0] AS label, count(n) AS c"
+   ```
+
+### 3. PVC corruption / data loss
+
+**Symptom**: Pod restarts but `GRAPH.LIST` is empty; RDB file present but won't
+load (`Bad file format` in logs).
+
+**Resolution — restore from MinIO backup**:
+
+```bash
+# 1. List available backups
+aws --endpoint-url http://minio.$NS.svc.cluster.local:9000 \
+  s3 ls s3://falkordb-backups/
+
+# 2. Pick the latest good one and copy locally
+aws --endpoint-url http://minio.$NS.svc.cluster.local:9000 \
+  s3 cp s3://falkordb-backups/falkordb-20260419-031500.rdb /tmp/restore.rdb
+
+# 3. Scale FalkorDB master to 0 (master statefulset has only one replica)
+kubectl scale statefulset falkordb-master -n $NS --replicas=0
+
+# 4. Get the PVC name
+PVC=$(kubectl get pvc -n $NS -l app.kubernetes.io/name=redis,app.kubernetes.io/component=master -o jsonpath='{.items[0].metadata.name}')
+
+# 5. Mount the PVC in a temporary pod and copy the RDB into place
+kubectl run -n $NS rdb-restore --rm -it --restart=Never \
+  --image=busybox \
+  --overrides='{"spec":{"containers":[{"name":"rdb-restore","image":"busybox","stdin":true,"tty":true,"volumeMounts":[{"name":"data","mountPath":"/data"}]}],"volumes":[{"name":"data","persistentVolumeClaim":{"claimName":"'$PVC'"}}]}}' \
+  -- sh
+
+# Inside the pod:
+#   cp /tmp/restore.rdb /data/dump.rdb
+#   chown 1001:1001 /data/dump.rdb
+#   exit
+
+# 6. Scale master back up
+kubectl scale statefulset falkordb-master -n $NS --replicas=1
+
+# 7. Verify
+kubectl exec -n $NS svc/falkordb-master -- redis-cli -a "$PASS" GRAPH.LIST
+```
+
+### 4. Auth failures
+
+**Symptom**: `Authentication required` from clients; `WRONGPASS` in logs.
+
+**Cause**: `falkordb-secret` rotated but pods not restarted, or client config
+points at the wrong secret.
+
+**Resolution**:
+```bash
+# Roll the master to pick up the new secret
+kubectl rollout restart statefulset/falkordb-master -n $NS
+
+# Verify the consumers (mcp-service) have the matching env var
+kubectl get pod -n $NS -l app=mcp-service -o jsonpath='{.items[0].spec.containers[0].env}' | jq '.[] | select(.name=="FALKOR_PASSWORD")'
+```
+
+## Recovery from Empty Graph (No Backup)
+
+If the graph is gone and there's no backup, rebuild from PostgreSQL — it stays
+the source of truth.
+
+```bash
+# Trigger the migration job from xenoISA/isA_MCP (story #528)
+kubectl -n $NS create job --from=cronjob/mcp-falkor-migration mcp-falkor-rebuild-$(date +%s)
+kubectl -n $NS logs -f job/mcp-falkor-rebuild-<timestamp>
+```
+
+While the rebuild runs, the MCP service should auto-fall-back to the Qdrant
+path (story #529 circuit breaker); confirm by checking
+`mcp_search_backend_used{backend="qdrant"}` in Grafana.
+
+## Cutover Back to Qdrant Fallback
+
+If FalkorDB is impaired and we want to flip MCP off it temporarily:
+
+```bash
+kubectl -n $NS set env deployment/mcp-service MCP_SEARCH_BACKEND=qdrant
+kubectl rollout status deployment/mcp-service -n $NS
+```
+
+When restored, flip back to `falkor` (or `dual` to verify diffs first).
+
+## Escalation
+
+- On-call rotation: `#mcp-platform`
+- Owner: ISA MCP Team
+- Related: `docs/runbooks/redis-recovery.md` (FalkorDB shares Bitnami Redis chart mechanics)


### PR DESCRIPTION
## Summary

- Adds FalkorDB to staging/dev/production via the Bitnami Redis chart with `falkordb/falkordb` image and `--loadmodule` flag (per [official k8s guide](https://docs.falkordb.com/operations/k8s-support.html))
- Daily backup CronJob: `BGSAVE` → RDB → MinIO bucket `falkordb-backups`
- NetworkPolicy restricts ingress to `mcp-service`, `mcp-worker-service`, and same-ns backup pods
- Runbook covers module-not-loaded, OOMKilled, PVC corruption + restore, no-backup rebuild from Postgres, and emergency Qdrant cutover

## Per-environment sizing

| Env | Replicas | Memory (req/limit) | PVC | Auth |
|---|---|---|---|---|
| dev | 1 | 256Mi / 1Gi | 5Gi | off |
| staging | 1 | 1Gi / 4Gi | 20Gi | on |
| production | master + 1 | 4Gi / 8Gi | 50Gi | on, PDB enabled |

## Validation

- [x] `helm template` renders cleanly for all three env values files
- [x] CronJob and NetworkPolicy parse under `kubectl --dry-run=client`
- [ ] Deploy to staging and run sample queries against the discovery graph
- [ ] Verify backup CronJob writes to MinIO; rehearse restore on a scratch namespace
- [ ] Production rollout pending manual approval after staging burn-in

Fixes xenoISA/isA_Cloud#202
Parent epic: xenoISA/isA_MCP#525
Sibling: xenoISA/isA_Cloud#203 (PR for the AsyncFalkorClient that consumes this deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)