### PR TITLE
feat(local): FalkorDB kind extraPortMapping + standalone manifest

### DIFF
--- a/deployments/kubernetes/local/kind-config.yaml
+++ b/deployments/kubernetes/local/kind-config.yaml
@@ -49,6 +49,14 @@ nodes:
       hostPort: 6334
       protocol: TCP
 
+    # FalkorDB graph DB (NodePort 30380 -> localhost:6380)
+    # Same Redis-protocol port as Bitnami Redis (6379) but on a different
+    # host port so both can coexist for local dev. Powers the MCP
+    # hierarchical search backend (xenoISA/isA_MCP epic #525).
+    - containerPort: 30380
+      hostPort: 6380
+      protocol: TCP
+
     # ============================================================
     # OBJECT STORAGE
     # ============================================================

--- a/deployments/kubernetes/local/manifests/falkordb.yaml
+++ b/deployments/kubernetes/local/manifests/falkordb.yaml
@@ -1,0 +1,107 @@
+# FalkorDB graph database for local kind cluster.
+#
+# Uses a minimal StatefulSet + NodePort instead of the Bitnami Redis chart
+# because that chart hard-codes module paths under /opt/bitnami/redis/lib/...
+# which don't exist in the falkordb image. The image already auto-loads its
+# module from /FalkorDB/bin/src/falkordb.so on startup.
+#
+# Host access pattern matches Postgres / Redis / Qdrant (kind extraPortMapping):
+#   localhost:6380  ->  kind NodePort 30380  ->  Service falkordb:6379
+#
+# Powers the MCP hierarchical-search backend (xenoISA/isA_MCP epic #525).
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: falkordb
+  namespace: isa-cloud-local
+  labels:
+    app: falkordb
+    tier: infrastructure
+    component: graph-database
+spec:
+  type: NodePort
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      nodePort: 30380
+      protocol: TCP
+  selector:
+    app: falkordb
+---
+# Headless service for stable in-cluster DNS (falkordb-0.falkordb-headless...)
+apiVersion: v1
+kind: Service
+metadata:
+  name: falkordb-headless
+  namespace: isa-cloud-local
+  labels:
+    app: falkordb
+spec:
+  clusterIP: None
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+  selector:
+    app: falkordb
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: falkordb
+  namespace: isa-cloud-local
+  labels:
+    app: falkordb
+    tier: infrastructure
+spec:
+  serviceName: falkordb-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: falkordb
+  template:
+    metadata:
+      labels:
+        app: falkordb
+        tier: infrastructure
+        environment: local
+    spec:
+      containers:
+        - name: falkordb
+          image: falkordb/falkordb:v4.8.7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/falkordb/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 5Gi


### PR DESCRIPTION
Brings FalkorDB to the same host-access pattern as Postgres/Redis/Qdrant/Neo4j/NATS — no port-forward needed.

```
localhost:6380 -> kind hostPort 6380 -> NodePort 30380 -> Service falkordb:6379
```

Adds:
- kind-config.yaml: extraPortMapping for FalkorDB
- local/manifests/falkordb.yaml: minimal StatefulSet + NodePort (skips Bitnami chart since it hard-codes module paths that don't exist in the falkordb image)

After merging, local cluster needs recreation to pick up the new kind mapping:
```bash
./scripts/kind-teardown.sh && ./scripts/kind-setup.sh
kubectl apply -f local/manifests/falkordb.yaml
```

Story: xenoISA/isA_MCP#525.