### PR TITLE
feat(skills): add FalkorDB to cluster_operations + backup_restore

### DIFF
--- a/.claude/skills/backup_restore/scripts/backup-all.sh
+++ b/.claude/skills/backup_restore/scripts/backup-all.sh
@@ -62,7 +62,7 @@ echo "Backup directory: $BACKUP_DIR"
 echo ""
 
 # Create backup directories
-mkdir -p "$BACKUP_DIR"/{postgres,redis,qdrant,neo4j,minio,consul,nats,apisix}
+mkdir -p "$BACKUP_DIR"/{postgres,redis,qdrant,falkordb,neo4j,minio,consul,nats,apisix}
 
 # =============================================================================
 # 1. PostgreSQL Backup
@@ -144,6 +144,32 @@ else
 fi
 
 kill $PF_PID 2>/dev/null || true
+
+# =============================================================================
+# 3b. FalkorDB Backup
+# =============================================================================
+echo ""
+echo -e "${YELLOW}[3b] Backing up FalkorDB...${NC}"
+FALKORDB_POD="falkordb-0"
+if kubectl get pod -n "$NAMESPACE" "$FALKORDB_POD" &>/dev/null; then
+    # Trigger background save then copy the RDB file out — same pattern as
+    # the Helm chart's CronJob in deployments/kubernetes/staging/manifests.
+    LASTSAVE_BEFORE=$(kubectl exec -n "$NAMESPACE" "$FALKORDB_POD" -- redis-cli LASTSAVE 2>/dev/null || echo "")
+    kubectl exec -n "$NAMESPACE" "$FALKORDB_POD" -- redis-cli BGSAVE >/dev/null 2>&1
+    # Wait for LASTSAVE to advance (max 30s)
+    for _ in $(seq 1 30); do
+        sleep 1
+        LASTSAVE_NOW=$(kubectl exec -n "$NAMESPACE" "$FALKORDB_POD" -- redis-cli LASTSAVE 2>/dev/null || echo "")
+        [ -n "$LASTSAVE_NOW" ] && [ "$LASTSAVE_NOW" != "$LASTSAVE_BEFORE" ] && break
+    done
+    # Copy the snapshot out (FalkorDB image stores at /var/lib/falkordb/data)
+    kubectl cp "$NAMESPACE/$FALKORDB_POD:/var/lib/falkordb/data/dump.rdb" \
+        "$BACKUP_DIR/falkordb/dump.rdb" 2>/dev/null && \
+        echo -e "  ${GREEN}✓ FalkorDB RDB snapshot ($(du -h "$BACKUP_DIR/falkordb/dump.rdb" 2>/dev/null | cut -f1))${NC}" || \
+        echo -e "  ${YELLOW}⚠ FalkorDB RDB copy failed${NC}"
+else
+    echo -e "  ${YELLOW}⚠ FalkorDB pod not found (skipping)${NC}"
+fi
 
 # =============================================================================
 # 4. Neo4j Backup
@@ -330,6 +356,7 @@ cat > "$BACKUP_DIR/metadata.json" << EOF
         "postgresql": $([ -f "$BACKUP_DIR/postgres/full_backup.sql" ] && echo "true" || echo "false"),
         "redis": $([ -f "$BACKUP_DIR/redis/dump.rdb" ] && echo "true" || echo "false"),
         "qdrant": $([ "$(ls -A "$BACKUP_DIR/qdrant" 2>/dev/null)" ] && echo "true" || echo "false"),
+        "falkordb": $([ "$(ls -A "$BACKUP_DIR/falkordb" 2>/dev/null)" ] && echo "true" || echo "false"),
         "neo4j": $([ -f "$BACKUP_DIR/neo4j/neo4j.dump" ] && echo "true" || echo "false"),
         "minio": $([ "$(ls -A "$BACKUP_DIR/minio" 2>/dev/null)" ] && echo "true" || echo "false"),
         "consul": $([ -f "$BACKUP_DIR/consul/consul.snap" ] && echo "true" || echo "false"),

--- a/.claude/skills/backup_restore/scripts/restore-all.sh
+++ b/.claude/skills/backup_restore/scripts/restore-all.sh
@@ -255,6 +255,32 @@ if should_restore "qdrant"; then
 fi
 
 # =============================================================================
+# 3b. FalkorDB Restore
+# =============================================================================
+if should_restore "falkordb"; then
+    echo ""
+    echo -e "${YELLOW}[3b] Restoring FalkorDB...${NC}"
+    if [ -f "$BACKUP_DIR/falkordb/dump.rdb" ]; then
+        FALKORDB_POD="falkordb-0"
+        if kubectl get pod -n "$NAMESPACE" "$FALKORDB_POD" &>/dev/null; then
+            # Stop the server, drop the new RDB into the data dir, restart.
+            # The image auto-loads dump.rdb on startup.
+            kubectl cp "$BACKUP_DIR/falkordb/dump.rdb" \
+                "$NAMESPACE/$FALKORDB_POD:/var/lib/falkordb/data/dump.rdb" 2>/dev/null && \
+                kubectl exec -n "$NAMESPACE" "$FALKORDB_POD" -- redis-cli SHUTDOWN NOSAVE 2>/dev/null || true
+            # Pod restarts via StatefulSet readiness probe; wait for it
+            kubectl wait --for=condition=ready pod/$FALKORDB_POD -n "$NAMESPACE" --timeout=60s 2>/dev/null && \
+                echo -e "  ${GREEN}✓ FalkorDB restored from RDB${NC}" || \
+                echo -e "  ${YELLOW}⚠ FalkorDB pod restart timed out${NC}"
+        else
+            echo -e "  ${YELLOW}⚠ FalkorDB pod not found${NC}"
+        fi
+    else
+        echo -e "  ${YELLOW}⚠ No FalkorDB backup found${NC}"
+    fi
+fi
+
+# =============================================================================
 # 4. Neo4j Restore
 # =============================================================================
 if should_restore "neo4j"; then

--- a/.claude/skills/cluster_operations/SKILL.md
+++ b/.claude/skills/cluster_operations/SKILL.md
@@ -55,6 +55,7 @@ Comprehensive cluster operations including environment setup, backup, restore, a
 **What gets deployed:**
 - PostgreSQL (localhost:5432)
 - Redis (localhost:6379)
+- FalkorDB (localhost:6380) — graph DB for MCP hierarchical search
 - Qdrant (localhost:6333/6334)
 - MinIO (localhost:9000/9001)
 - Neo4j (localhost:7474/7687)

--- a/.claude/skills/cluster_operations/scripts/setup-local.sh
+++ b/.claude/skills/cluster_operations/scripts/setup-local.sh
@@ -83,6 +83,11 @@ nodes:
       - containerPort: 30379
         hostPort: 6379
         protocol: TCP
+      # FalkorDB (Redis-protocol graph DB; coexists with Redis on a different host port)
+      # Powers MCP hierarchical search (xenoISA/isA_MCP epic #525)
+      - containerPort: 30380
+        hostPort: 6380
+        protocol: TCP
       # Qdrant gRPC
       - containerPort: 30334
         hostPort: 6334
@@ -192,6 +197,28 @@ helm upgrade --install qdrant qdrant/qdrant \
     --set service.type=NodePort \
     --set service.nodePort=30333 \
     --wait --timeout 5m 2>/dev/null && echo -e "    ${GREEN}✓ Qdrant${NC}" || echo -e "    ${YELLOW}⚠ Qdrant${NC}"
+
+# FalkorDB (graph DB for MCP hierarchical search)
+# Skips the Bitnami Redis chart because it hard-codes module paths under
+# /opt/bitnami/redis/lib that don't exist in the falkordb image — the image
+# auto-loads its module from /FalkorDB/bin/src/falkordb.so on startup.
+echo "  Installing FalkorDB..."
+FALKORDB_MANIFEST="$ISA_CLOUD_DIR/deployments/kubernetes/local/manifests/falkordb.yaml"
+if [ -f "$FALKORDB_MANIFEST" ]; then
+    # Manifest hard-codes namespace `isa-cloud-local`; fall back to a sed
+    # rewrite when the bootstrap targets a different namespace.
+    if [ "$NAMESPACE" = "isa-cloud-local" ]; then
+        kubectl apply -f "$FALKORDB_MANIFEST" 2>/dev/null
+    else
+        sed "s/namespace: isa-cloud-local/namespace: $NAMESPACE/g" "$FALKORDB_MANIFEST" \
+            | kubectl apply -f - 2>/dev/null
+    fi
+    kubectl wait --for=condition=ready pod/falkordb-0 -n "$NAMESPACE" --timeout=120s 2>/dev/null \
+        && echo -e "    ${GREEN}✓ FalkorDB${NC}" \
+        || echo -e "    ${YELLOW}⚠ FalkorDB (pod not ready in 120s)${NC}"
+else
+    echo -e "    ${YELLOW}⚠ FalkorDB manifest not found at $FALKORDB_MANIFEST${NC}"
+fi
 
 # MinIO
 echo "  Installing MinIO..."


### PR DESCRIPTION
Brings FalkorDB to first-class infra status across the operator skills:

- `setup-local.sh` extraPortMapping (host 6380 -> NodePort 30380) + install step (applies the local manifest, waits for ready)
- SKILL.md mentions FalkorDB in 'What gets deployed'
- `backup-all.sh` phase 3b: BGSAVE + LASTSAVE poll + kubectl cp the RDB
- `restore-all.sh` phase 3b: kubectl cp + SHUTDOWN NOSAVE so the StatefulSet auto-loads on restart

Without these changes, future fresh kind clusters bootstrapped via setup-local.sh wouldn't have FalkorDB reachable at localhost:6380, and the canonical backup script wouldn't capture FalkorDB state.

Story: xenoISA/isA_MCP#525.