### PR TITLE
fix(skills): close FalkorDB + doc gaps in cluster_operations

### DIFF
--- a/.claude/skills/cluster_operations/SKILL.md
+++ b/.claude/skills/cluster_operations/SKILL.md
@@ -92,6 +92,7 @@ AWS_REGION=eu-west-1 ./scripts/setup-staging.sh
 **Production deploys HA versions:**
 - PostgreSQL HA (3 replicas + pgpool)
 - Redis Cluster (6 nodes)
+- FalkorDB (master + replica + PDB; Redis-protocol graph DB for MCP)
 - Qdrant Distributed
 - MinIO Distributed
 - Neo4j Cluster
@@ -107,10 +108,13 @@ AWS_REGION=eu-west-1 ./scripts/setup-staging.sh
 backups/cluster-backup-{timestamp}/
 ├── postgres/           # PostgreSQL dumps
 ├── redis/             # Redis RDB snapshots
+├── falkordb/          # FalkorDB RDB snapshot (graph DB for MCP)
 ├── neo4j/             # Neo4j graph database
 ├── minio/             # Object storage buckets
 ├── qdrant/            # Vector database snapshots
 ├── consul/            # Service registry KV store
+├── nats/              # JetStream data
+├── apisix/            # Routes / upstreams / services / consumers
 └── metadata.json      # Backup metadata
 ```
 
@@ -162,10 +166,13 @@ cat > backups/cluster-backup-*/BACKUP_INFO.md << EOF
 ## Services Backed Up
 - PostgreSQL
 - Redis
+- FalkorDB
 - Neo4j
 - MinIO
 - Qdrant
 - Consul
+- NATS (JetStream)
+- APISIX
 
 ## Backup Command
 \`\`\`bash
@@ -266,7 +273,7 @@ bash scripts/backup-cluster-data.sh
 
 **Step 2: Delete existing cluster**
 ```bash
-kind delete cluster --name isa-cloud
+kind delete cluster --name isa-cloud-local
 ```
 
 **Step 3: Create new cluster**

--- a/.claude/skills/cluster_operations/scripts/setup-production.sh
+++ b/.claude/skills/cluster_operations/scripts/setup-production.sh
@@ -197,6 +197,16 @@ if [ "$DRY_RUN" = false ]; then
             --wait --timeout 15m && echo -e "    ${GREEN}✓ Qdrant Distributed${NC}"
     fi
 
+    # FalkorDB (graph DB for MCP hierarchical search)
+    # Production values use Bitnami Redis chart with master + replica + PDB.
+    # See deployments/kubernetes/production/values/falkordb.yaml.
+    echo "  Installing FalkorDB..."
+    if [ -f "$VALUES_DIR/falkordb.yaml" ]; then
+        helm upgrade --install falkordb bitnami/redis \
+            -n "$NAMESPACE" -f "$VALUES_DIR/falkordb.yaml" \
+            --wait --timeout 15m && echo -e "    ${GREEN}✓ FalkorDB${NC}"
+    fi
+
     # MinIO Distributed
     echo "  Installing MinIO Distributed..."
     if [ -f "$VALUES_DIR/minio-distributed.yaml" ]; then

--- a/.claude/skills/cluster_operations/scripts/setup-staging.sh
+++ b/.claude/skills/cluster_operations/scripts/setup-staging.sh
@@ -129,7 +129,7 @@ echo -e "${YELLOW}[5/6] Deploying infrastructure...${NC}"
 VALUES_DIR="$ISA_CLOUD_DIR/deployments/kubernetes/staging/values"
 
 # Deploy each service with staging values
-for service in postgresql redis qdrant minio neo4j nats consul; do
+for service in postgresql redis falkordb qdrant minio neo4j nats consul; do
     if [ -f "$VALUES_DIR/${service}.yaml" ]; then
         echo "  Installing $service..."
 
@@ -138,6 +138,13 @@ for service in postgresql redis qdrant minio neo4j nats consul; do
                 helm upgrade --install $service bitnami/postgresql -n "$NAMESPACE" -f "$VALUES_DIR/${service}.yaml" --wait --timeout 10m
                 ;;
             redis)
+                helm upgrade --install $service bitnami/redis -n "$NAMESPACE" -f "$VALUES_DIR/${service}.yaml" --wait --timeout 10m
+                ;;
+            falkordb)
+                # FalkorDB rides on the Bitnami Redis chart with a custom image
+                # (see deployments/kubernetes/staging/values/falkordb.yaml).
+                # The chart's allowInsecureImages flag is required because the
+                # falkordb image isn't a Bitnami-published one.
                 helm upgrade --install $service bitnami/redis -n "$NAMESPACE" -f "$VALUES_DIR/${service}.yaml" --wait --timeout 10m
                 ;;
             qdrant)


### PR DESCRIPTION
Audit found 3 real gaps and 3 doc inconsistencies after PR #207 (which fixed local-only).

Real gaps:
- setup-staging.sh: falkordb missing from the install loop
- setup-production.sh: no FalkorDB install step

Doc fixes:
- Production HA list now includes FalkorDB
- 'What Gets Backed Up' tree lists falkordb/ (and nats/, apisix/ which the actual backup-all.sh creates but doc was stale)
- 'Services Backed Up' template list includes FalkorDB
- Operation 3 cluster name typo: `isa-cloud` -> `isa-cloud-local`

All scripts pass `bash -n` syntax check. Both staging + production values files already landed in PR #204.

Story: xenoISA/isA_MCP#525.