### PR TITLE
feat(infra): add JupyterHub for local kind cluster

### DIFF
--- a/.claude/skills/cluster_operations/scripts/setup-local.sh
+++ b/.claude/skills/cluster_operations/scripts/setup-local.sh
@@ -190,6 +190,29 @@ values_for() {
 }
 VALUES_DIR="$STAGING_VALUES_DIR"  # back-compat alias for any inline -f references
 
+TEMP_RENDERED_FILES=()
+cleanup_rendered_files() {
+    if [ "${#TEMP_RENDERED_FILES[@]}" -gt 0 ]; then
+        rm -f "${TEMP_RENDERED_FILES[@]}"
+    fi
+}
+trap cleanup_rendered_files EXIT
+
+render_local_template() {
+    local src="$1"
+
+    if [ -z "$src" ] || [ ! -f "$src" ] || [ "$NAMESPACE" = "isa-cloud-local" ]; then
+        echo "$src"
+        return
+    fi
+
+    local rendered
+    rendered="$(mktemp)"
+    sed "s/isa-cloud-local/${NAMESPACE}/g" "$src" > "$rendered"
+    TEMP_RENDERED_FILES+=("$rendered")
+    echo "$rendered"
+}
+
 # PostgreSQL
 echo "  Installing PostgreSQL..."
 helm upgrade --install postgresql bitnami/postgresql \
@@ -259,11 +282,12 @@ helm upgrade --install neo4j neo4j/neo4j \
     --wait --timeout 5m && echo -e "    ${GREEN}✓ Neo4j${NC}" || echo -e "    ${YELLOW}⚠ Neo4j${NC}"
 
 # NATS
+# NodePort + nodePort:30422 is set via service.merge in values/nats.yaml
+# (the 2.12.x chart dropped the flat service.type key).
 echo "  Installing NATS..."
 helm upgrade --install nats nats/nats \
     -n "$NAMESPACE" \
     -f "$(values_for nats)" \
-    --set service.type=NodePort \
     --wait --timeout 5m 2>/dev/null && echo -e "    ${GREEN}✓ NATS${NC}" || echo -e "    ${YELLOW}⚠ NATS${NC}"
 
 # Consul
@@ -277,12 +301,28 @@ helm upgrade --install consul hashicorp/consul \
 
 # APISIX
 echo "  Installing APISIX..."
+APISIX_VALUES_FILE="$(render_local_template "$(values_for apisix)")"
+APISIX_HELM_ARGS=()
+if [ -n "$APISIX_VALUES_FILE" ]; then
+    APISIX_HELM_ARGS=(-f "$APISIX_VALUES_FILE")
+fi
 helm upgrade --install apisix apisix/apisix \
     -n "$NAMESPACE" \
-    --set gateway.type=NodePort \
-    --set gateway.http.nodePort=30080 \
-    --set admin.type=NodePort \
+    "${APISIX_HELM_ARGS[@]}" \
     --wait --timeout 5m 2>/dev/null && echo -e "    ${GREEN}✓ APISIX${NC}" || echo -e "    ${YELLOW}⚠ APISIX${NC}"
+
+echo "  Applying Consul-APISIX sync resources..."
+CONSUL_APISIX_SYNC_MANIFEST="$(render_local_template "$ISA_CLOUD_DIR/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml")"
+if [ -f "$CONSUL_APISIX_SYNC_MANIFEST" ]; then
+    kubectl apply -f "$CONSUL_APISIX_SYNC_MANIFEST" 2>/dev/null \
+        && echo -e "    ${GREEN}✓ Consul-APISIX sync${NC}" \
+        || echo -e "    ${YELLOW}⚠ Consul-APISIX sync${NC}"
+    kubectl rollout status deployment/consul-apisix-watch -n "$NAMESPACE" --timeout=120s 2>/dev/null \
+        && echo -e "    ${GREEN}✓ Consul-APISIX watch${NC}" \
+        || echo -e "    ${YELLOW}⚠ Consul-APISIX watch (deployment not ready in 120s)${NC}"
+else
+    echo -e "    ${YELLOW}⚠ Consul-APISIX sync manifest not found${NC}"
+fi
 
 # =============================================================================
 # Step 5: Verify Deployment
@@ -312,4 +352,5 @@ echo ""
 echo "Next steps:"
 echo "  1. Run MCP service: cd isA_MCP && ./deployment/local-dev.sh"
 echo "  2. Run Model service: cd isA_Model && ./deployment/local-dev.sh"
+echo "  3. Native macOS services can export SERVICE_HOST=host.docker.internal; Consul registration will normalize it to the Docker Desktop gateway IP for APISIX"
 echo "=============================================="

--- a/.claude/skills/service_operation/SKILL.md
+++ b/.claude/skills/service_operation/SKILL.md
@@ -28,7 +28,7 @@ Operations for managing API services in Consul and APISIX gateway.
 
 ### Service Host for Local Dev
 
-Services running on Mac need to register with `SERVICE_HOST=192.168.65.254` (Docker gateway IP) to be reachable from Kind cluster.
+Services running natively on macOS should register with `SERVICE_HOST=host.docker.internal`. `ConsulRegistry` normalizes that Docker Desktop alias to the host-gateway IP (typically `192.168.65.254`) so Kind/APISIX can reach it reliably.
 
 ## Operation 1: Check Service Status
 
@@ -325,7 +325,8 @@ Automatically find and remove stale Consul registrations and orphaned APISIX rou
 **Fix**:
 1. Check service logs for Consul registration errors
 2. Verify `CONSUL_ENABLED=true` in service's dev.env
-3. Verify `SERVICE_HOST=192.168.65.254` for local dev
+3. Verify `SERVICE_HOST=host.docker.internal` for local dev
+   `ConsulRegistry` should advertise the resolved gateway IP, not a hostname, in Consul.
 4. Check Consul is accessible: `curl http://localhost:8500/v1/status/leader`
 
 ### Service in Consul but No APISIX Route
@@ -342,8 +343,8 @@ Automatically find and remove stale Consul registrations and orphaned APISIX rou
 **Cause**: APISIX can't reach the service (wrong address)
 
 **Fix**:
-1. Check service address in Consul - should be `192.168.65.254`, NOT `localhost`
-2. Fix `SERVICE_HOST=192.168.65.254` in service's dev.env
+1. Check service address in Consul - should be a routable IP (often `192.168.65.254`), NOT `localhost`
+2. Fix `SERVICE_HOST=host.docker.internal` in service's dev.env
 3. Restart service and re-sync APISIX
 
 ### APISIX Returns 404 Not Found
@@ -460,7 +461,7 @@ Before deploying a service, verify:
 For a service to work via APISIX:
 
 - [ ] `CONSUL_ENABLED=true` in dev.env
-- [ ] `SERVICE_HOST=192.168.65.254` in dev.env (for local dev)
+- [ ] `SERVICE_HOST=host.docker.internal` in dev.env (for local dev; registration should normalize to a routable IP)
 - [ ] `base_path` or `api_path` in routes_registry.py metadata
 - [ ] Service import uses `from isa_common.consul_client import ConsulRegistry`
 - [ ] Service started and running

--- a/deployments/charts/isa-service/README.md
+++ b/deployments/charts/isa-service/README.md
@@ -51,6 +51,8 @@ deployment/
 └── local-dev.sh          # Local development script
 ```
 
+For native macOS local development, set `SERVICE_HOST=host.docker.internal` in `deployment/environments/dev.env`. `ConsulRegistry` will normalize that alias to the Docker Desktop gateway IP so Kind/APISIX can reach it reliably.
+
 ## Services
 
 | Service | Port | Values File |

--- a/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml
@@ -299,6 +299,12 @@ data:
         local uri_path=$2
         local upstream_host=$3
         local upstream_port=$4
+        local cors_origins="${CORS_ALLOWED_ORIGINS:-http://localhost:4100,http://localhost:4200,http://localhost:4300,http://localhost:3000}"
+        local uris_json="[\"${uri_path}\", \"${uri_path}/*\"]"
+
+        if [ "$uri_path" = "/" ]; then
+            uris_json='["/", "/*"]'
+        fi
 
         print_info "Syncing frontend zone: $route_name → ${upstream_host}:${upstream_port}${uri_path}"
 
@@ -308,14 +314,15 @@ data:
             -H "Content-Type: application/json" \
             -d "{
                 \"name\": \"${route_name}\",
-                \"uris\": [\"${uri_path}\", \"${uri_path}/*\"],
+                \"uris\": ${uris_json},
                 \"priority\": 5,
                 \"status\": 1,
                 \"plugins\": {
                     \"cors\": {
-                        \"allow_origins\": \"**\",
+                        \"allow_origins\": \"${cors_origins}\",
                         \"allow_methods\": \"GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD\",
-                        \"allow_headers\": \"*\",
+                        \"allow_headers\": \"DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID\",
+                        \"expose_headers\": \"X-Request-ID\",
                         \"max_age\": 86400,
                         \"allow_credential\": true
                     },
@@ -751,14 +758,14 @@ data:
         done
 
         # Sync Mate service route (static upstream, not Consul-discovered)
-        local MATE_HOST="${MATE_HOST:-isa-mate.isa-cloud-local.svc.cluster.local}"
+        local MATE_HOST="${MATE_HOST:-host.docker.internal}"
         create_frontend_zone_route "mate_service_route" "/mate" "$MATE_HOST" "18789"
         processed_services+=("mate_service_route")
 
         # Sync frontend zone routes (static upstreams, not Consul-discovered)
-        local FRONTEND_HOST="${FRONTEND_HOST:-isa-app.isa-cloud-local.svc.cluster.local}"
-        local CONSOLE_HOST="${CONSOLE_HOST:-isa-console.isa-cloud-local.svc.cluster.local}"
-        local DOCS_HOST="${DOCS_HOST:-isa-docs.isa-cloud-local.svc.cluster.local}"
+        local FRONTEND_HOST="${FRONTEND_HOST:-host.docker.internal}"
+        local CONSOLE_HOST="${CONSOLE_HOST:-host.docker.internal}"
+        local DOCS_HOST="${DOCS_HOST:-host.docker.internal}"
 
         create_frontend_zone_route "frontend_app_route" "/" "$FRONTEND_HOST" "4100"
         processed_services+=("frontend_app_route")
@@ -872,7 +879,7 @@ spec:
     spec:
       containers:
         - name: watch
-          image: hashicorp/consul:1.17
+          image: hashicorp/consul:1.22.6
           command:
             - /bin/sh
             - -c
@@ -938,7 +945,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: sync
-              image: alpine:latest
+              image: hashicorp/consul:1.22.6
               command:
                 - /bin/sh
                 - -c

--- a/deployments/kubernetes/local/manifests/jupyterhub-apisix-route.yaml
+++ b/deployments/kubernetes/local/manifests/jupyterhub-apisix-route.yaml
@@ -1,0 +1,129 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jupyterhub-apisix-route-script
+  namespace: isa-cloud-local
+  labels:
+    app: jupyterhub-apisix-route
+    tier: infrastructure
+data:
+  register_routes.sh: |
+    #!/bin/bash
+    # Register JupyterHub APISIX routes — /jupyter and /jupyter/*
+    # Tracking: xenoISA/isA_Model#771
+    set -e
+
+    APISIX_ADMIN_URL="${APISIX_ADMIN_URL:-http://apisix-admin.isa-cloud-local.svc.cluster.local:9180}"
+    ADMIN_KEY="${APISIX_ADMIN_KEY:-edd1c9f034335f136f87ad84b625c8f1}"
+    CORS_ORIGINS="${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:4100,http://localhost:4200,http://localhost:4300}"
+
+    GREEN='\033[0;32m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+    ok()   { echo -e "${GREEN}OK  $1${NC}"; }
+    err()  { echo -e "${RED}ERR $1${NC}"; }
+    info() { echo -e "${BLUE}INFO $1${NC}"; }
+
+    info "Registering jupyterhub_route (/jupyter[/*] -> proxy-public:80)..."
+
+    PLUGINS=$(jq -n --arg cors "$CORS_ORIGINS" '{
+      "cors": {
+        "allow_origins": $cors,
+        "allow_methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD",
+        "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID,X-XSRFToken",
+        "expose_headers": "X-Request-ID",
+        "max_age": 86400,
+        "allow_credential": true
+      },
+      "request-id": { "algorithm": "uuid", "include_in_response": true },
+      "proxy-rewrite": { "regex_uri": ["^/jupyter/?(.*)$", "/$1"] },
+      "prometheus": {}
+    }')
+
+    UPSTREAM=$(jq -n '{
+      "type": "roundrobin",
+      "scheme": "http",
+      "pass_host": "pass",
+      "retries": 2,
+      "retry_timeout": 6,
+      "timeout": { "connect": 6, "send": 60, "read": 600 },
+      "keepalive_pool": { "size": 320, "idle_timeout": 60, "requests": 1000 },
+      "nodes": {
+        "proxy-public.isa-cloud-local.svc.cluster.local:80": 1
+      }
+    }')
+
+    RESP=$(curl -s -w "\n%{http_code}" -X PUT \
+      "${APISIX_ADMIN_URL}/apisix/admin/routes/jupyterhub_route" \
+      -H "X-API-KEY: ${ADMIN_KEY}" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n \
+          --argjson plugins "$PLUGINS" \
+          --argjson upstream "$UPSTREAM" \
+          '{
+            "name": "jupyterhub_route",
+            "uris": ["/jupyter", "/jupyter/*"],
+            "priority": 10,
+            "status": 1,
+            "plugins": $plugins,
+            "upstream": $upstream
+          }')")
+
+    HTTP=$(echo "$RESP" | tail -n1)
+    if [ "$HTTP" = "200" ] || [ "$HTTP" = "201" ]; then
+      ok "jupyterhub_route registered (HTTP $HTTP)"
+    else
+      err "Failed to register jupyterhub_route (HTTP $HTTP)"
+      echo "$RESP" | head -n -1
+      exit 1
+    fi
+
+    info "JupyterHub APISIX route registered successfully."
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: jupyterhub-apisix-route-register
+  namespace: isa-cloud-local
+  labels:
+    app: jupyterhub-apisix-route
+    tier: infrastructure
+  annotations:
+    # Re-run to reconcile:
+    #   kubectl delete job jupyterhub-apisix-route-register -n isa-cloud-local
+    #   kubectl apply -f jupyterhub-apisix-route.yaml
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app: jupyterhub-apisix-route
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: register
+          image: alpine:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache bash curl jq > /dev/null 2>&1
+              bash /scripts/register_routes.sh
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+          env:
+            - name: APISIX_ADMIN_URL
+              value: "http://apisix-admin.isa-cloud-local.svc.cluster.local:9180"
+            - name: APISIX_ADMIN_KEY
+              value: "edd1c9f034335f136f87ad84b625c8f1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+      volumes:
+        - name: script
+          configMap:
+            name: jupyterhub-apisix-route-script
+            defaultMode: 0755

--- a/deployments/kubernetes/local/manifests/mlflow-apisix-route.yaml
+++ b/deployments/kubernetes/local/manifests/mlflow-apisix-route.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mlflow-apisix-route-script
+  namespace: isa-cloud-local
+  labels:
+    app: mlflow-apisix-route
+    tier: infrastructure
+data:
+  register_routes.sh: |
+    #!/bin/bash
+    # Register MLflow APISIX routes — /mlflow and /mlflow/*
+    # Tracking: xenoISA/isA_Model#764
+    set -e
+
+    APISIX_ADMIN_URL="${APISIX_ADMIN_URL:-http://apisix-admin.isa-cloud-local.svc.cluster.local:9180}"
+    ADMIN_KEY="${APISIX_ADMIN_KEY:-edd1c9f034335f136f87ad84b625c8f1}"
+    CORS_ORIGINS="${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:4100,http://localhost:4200,http://localhost:4300}"
+
+    GREEN='\033[0;32m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+    ok()   { echo -e "${GREEN}OK  $1${NC}"; }
+    err()  { echo -e "${RED}ERR $1${NC}"; }
+    info() { echo -e "${BLUE}INFO $1${NC}"; }
+
+    info "Registering mlflow_route (/mlflow[/*] -> mlflow-tracking:5000)..."
+
+    PLUGINS=$(jq -n --arg cors "$CORS_ORIGINS" '{
+      "cors": {
+        "allow_origins": $cors,
+        "allow_methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD",
+        "allow_headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID",
+        "expose_headers": "X-Request-ID",
+        "max_age": 86400,
+        "allow_credential": true
+      },
+      "limit-count": {
+        "count": 100,
+        "time_window": 60,
+        "rejected_code": 429,
+        "rejected_msg": "Rate limit exceeded",
+        "policy": "local"
+      },
+      "request-id": { "algorithm": "uuid", "include_in_response": true },
+      "proxy-rewrite": { "regex_uri": ["^/mlflow/?(.*)$", "/$1"] },
+      "prometheus": {}
+    }')
+
+    UPSTREAM=$(jq -n '{
+      "type": "roundrobin",
+      "scheme": "http",
+      "pass_host": "pass",
+      "retries": 2,
+      "retry_timeout": 6,
+      "timeout": { "connect": 6, "send": 30, "read": 60 },
+      "keepalive_pool": { "size": 320, "idle_timeout": 60, "requests": 1000 },
+      "nodes": {
+        "mlflow.isa-cloud-local.svc.cluster.local:5000": 1
+      }
+    }')
+
+    RESP=$(curl -s -w "\n%{http_code}" -X PUT \
+      "${APISIX_ADMIN_URL}/apisix/admin/routes/mlflow_route" \
+      -H "X-API-KEY: ${ADMIN_KEY}" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n \
+          --argjson plugins "$PLUGINS" \
+          --argjson upstream "$UPSTREAM" \
+          '{
+            "name": "mlflow_route",
+            "uris": ["/mlflow", "/mlflow/*"],
+            "priority": 10,
+            "status": 1,
+            "plugins": $plugins,
+            "upstream": $upstream
+          }')")
+
+    HTTP=$(echo "$RESP" | tail -n1)
+    if [ "$HTTP" = "200" ] || [ "$HTTP" = "201" ]; then
+      ok "mlflow_route registered (HTTP $HTTP)"
+    else
+      err "Failed to register mlflow_route (HTTP $HTTP)"
+      echo "$RESP" | head -n -1
+      exit 1
+    fi
+
+    info "MLflow APISIX route registered successfully."
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mlflow-apisix-route-register
+  namespace: isa-cloud-local
+  labels:
+    app: mlflow-apisix-route
+    tier: infrastructure
+  annotations:
+    # Re-run to reconcile:
+    #   kubectl delete job mlflow-apisix-route-register -n isa-cloud-local
+    #   kubectl apply -f mlflow-apisix-route.yaml
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app: mlflow-apisix-route
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: register
+          image: alpine:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache bash curl jq > /dev/null 2>&1
+              bash /scripts/register_routes.sh
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+          env:
+            - name: APISIX_ADMIN_URL
+              value: "http://apisix-admin.isa-cloud-local.svc.cluster.local:9180"
+            - name: APISIX_ADMIN_KEY
+              value: "edd1c9f034335f136f87ad84b625c8f1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+      volumes:
+        - name: script
+          configMap:
+            name: mlflow-apisix-route-script
+            defaultMode: 0755

--- a/deployments/kubernetes/local/values/apisix.yaml
+++ b/deployments/kubernetes/local/values/apisix.yaml
@@ -5,7 +5,7 @@
 # Note: Built-in etcd is for dev/testing only. For production, use external etcd.
 # Source: https://github.com/apache/apisix-helm-chart
 
-# Service configuration (gateway)
+# Gateway service configuration
 service:
   type: NodePort
   http:
@@ -14,26 +14,34 @@ service:
     containerPort: 9080
     nodePort: 30080
   tls:
-    enabled: true
     servicePort: 443
-    containerPort: 9443
     nodePort: 30943  # Matches kind-config mapping to localhost:9443
   stream:
     enabled: false
 
-# APISIX configuration
-apisix:
-  image:
-    repository: apache/apisix
-    tag: 3.8.0-debian
+# APISIX image/runtime settings
+image:
+  repository: apache/apisix
+  tag: 3.8.0-debian
 
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+apisix:
+  ssl:
+    enabled: true
+    containerPort: 9443
+
+  dns:
+    resolvers:
+      - 10.96.0.10
+    validity: 30
+    timeout: 5
 
   # Admin API configuration
   admin:
@@ -48,17 +56,15 @@ apisix:
       ipList:
         - 0.0.0.0/0
 
-  nginx:
-    configurationSnippet:
-      http: |
-        resolver 10.96.0.10 valid=30s;
-
   discovery:
     enabled: true
     registry:
       consul:
         servers:
-          - "http://consul-ui.isa-cloud-local.svc.cluster.local"
+          - "http://consul-server.isa-cloud-local.svc.cluster.local:8500"
+        default_service:
+          host: 127.0.0.1
+          port: 20999
         fetch_interval: 3
         timeout:
           connect: 2000
@@ -67,22 +73,9 @@ apisix:
         keepalive: true
         default_weight: 1
 
-dns:
-  resolvers:
-    - 10.96.0.10
-  validity: 30
-  timeout: 5
-
-# etcd - use external etcd (deployed separately with official image)
+# Local dev uses the chart-managed etcd statefulset (apisix-etcd)
 etcd:
-  enabled: false
-
-# External etcd configuration
-externalEtcd:
-  host:
-    - http://etcd.isa-cloud-local.svc.cluster.local:2379
-  user: ""
-  password: ""
+  enabled: true
 
 # Dashboard - enabled for local dev
 dashboard:
@@ -97,8 +90,3 @@ ingress-controller:
 
 # Single replica for local
 replicaCount: 1
-
-# Pod labels
-podLabels:
-  tier: infrastructure
-  environment: local

--- a/deployments/kubernetes/local/values/jupyterhub.yaml
+++ b/deployments/kubernetes/local/values/jupyterhub.yaml
@@ -1,0 +1,146 @@
+# JupyterHub — local kind cluster (isa-cloud-local)
+# Chart: jupyterhub/jupyterhub 4.3.x
+# Tracking issue: xenoISA/isA_Model#771 (parent epic #763)
+#
+# Local-dev only — uses native (DummyAuthenticator) auth + the upstream
+# jupyter/scipy-notebook image with isa_model installed at spawn time via
+# lifecycleHooks.postStart. Production should use the custom singleuser image
+# from isA_Model deployment/docker/jupyterhub-singleuser.Dockerfile + OAuth
+# (already wired in deployments/helm/jupyterhub of isA_Model).
+#
+# Profiles capped to small/medium (max 4Gi) — kind cluster has limited RAM.
+#
+# Reuses in-cluster PostgreSQL ('jupyterhub' db) for hub state.
+
+hub:
+  config:
+    Authenticator:
+      admin_users:
+        - admin
+    JupyterHub:
+      authenticator_class: dummy  # local dev — no real auth, any password works
+      admin_access: true
+    DummyAuthenticator:
+      password: "isa-local-dev"  # documented dev default — see SECRETS.md note
+
+  db:
+    type: postgres
+    url: "postgresql+psycopg2://postgres@postgresql.isa-cloud-local.svc.cluster.local:5432/jupyterhub"
+    password: ""  # injected via env from secret below
+
+  extraEnv:
+    PGPASSWORD:
+      valueFrom:
+        secretKeyRef:
+          name: postgresql
+          key: postgres-password
+
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits:   { cpu: 500m, memory: 512Mi }
+
+  networkPolicy:
+    enabled: false  # use cluster-level network-policies.yaml manifests instead
+
+# CHP — Configurable HTTP Proxy
+proxy:
+  service:
+    type: ClusterIP  # NOT LoadBalancer — APISIX handles ingress
+  chp:
+    resources:
+      requests: { cpu: 50m, memory: 128Mi }
+      limits:   { cpu: 200m, memory: 256Mi }
+    networkPolicy:
+      enabled: false
+
+singleuser:
+  image:
+    name: quay.io/jupyter/scipy-notebook
+    tag: "python-3.11"
+    pullPolicy: IfNotPresent
+
+  defaultUrl: "/lab"
+  startTimeout: 600  # first spawn pulls the image (~2GB)
+
+  # Pre-install isa_model SDK at spawn time (cheaper than maintaining a custom
+  # image for local dev). Production uses the prebuilt singleuser image.
+  lifecycleHooks:
+    postStart:
+      exec:
+        command:
+          - "sh"
+          - "-c"
+          - "pip install --quiet --user isa_model || true"
+
+  extraEnv:
+    ISA_API_URL: "http://apisix-gateway.isa-cloud-local.svc.cluster.local/api/v1/models"
+    MLFLOW_TRACKING_URI: "http://mlflow.isa-cloud-local.svc.cluster.local:5000"
+    MLFLOW_S3_ENDPOINT_URL: "http://minio.isa-cloud-local.svc.cluster.local:9000"
+    AWS_ACCESS_KEY_ID:
+      valueFrom:
+        secretKeyRef:
+          name: minio
+          key: rootUser
+    AWS_SECRET_ACCESS_KEY:
+      valueFrom:
+        secretKeyRef:
+          name: minio
+          key: rootPassword
+
+  storage:
+    type: dynamic
+    dynamic:
+      storageClass: standard  # kind local-path
+    capacity: 2Gi  # smaller than default 10Gi — kind RAM constraints
+    homeMountPath: /home/jovyan
+
+  cpu:
+    guarantee: 0.5
+    limit: 1.0
+  memory:
+    guarantee: 512M
+    limit: 2G
+
+  profileList:
+    - display_name: "Small (1 CPU, 2 Gi)"
+      description: "Minimal — runs the 01–03 demo notebooks"
+      default: true
+      kubespawner_override:
+        cpu_guarantee: 0.5
+        cpu_limit: 1.0
+        mem_guarantee: 512M
+        mem_limit: 2G
+    - display_name: "Medium (2 CPU, 4 Gi)"
+      description: "More room for data work; still safe on kind"
+      kubespawner_override:
+        cpu_guarantee: 1.0
+        cpu_limit: 2.0
+        mem_guarantee: 1G
+        mem_limit: 4G
+
+  networkPolicy:
+    enabled: false
+
+  # Cull idle servers after 30 min — protect kind cluster RAM
+  cmd: null
+
+cull:
+  enabled: true
+  timeout: 1800  # 30 min
+  every: 300
+
+scheduling:
+  userScheduler:
+    enabled: false  # not needed for single-node-pool kind
+
+prePuller:
+  hook:
+    enabled: false  # speeds up install on kind
+  continuous:
+    enabled: false
+
+ingress:
+  enabled: false  # APISIX route handles external exposure
+
+debug:
+  enabled: false

--- a/deployments/kubernetes/local/values/mlflow.yaml
+++ b/deployments/kubernetes/local/values/mlflow.yaml
@@ -1,0 +1,70 @@
+# MLflow Tracking Server — local kind cluster (isa-cloud-local)
+# Reuses the in-cluster PostgreSQL ('mlflow' DB) and MinIO ('mlflow-artifacts' bucket).
+# Chart: community-charts/mlflow (1.8.x — Bitnami chart deprecated in 2026)
+# Tracking issue: xenoISA/isA_Model#764
+#
+# Secrets required (created out-of-band, never inline):
+#   - mlflow-db-credentials  (keys: username, password)  — wraps postgresql/postgres-password
+#   - minio                  (keys: rootUser, rootPassword) — already exists
+#
+# Re-deploy:  helm upgrade --install mlflow community-charts/mlflow -n isa-cloud-local -f mlflow.yaml
+
+replicaCount: 1  # local dev — single replica
+
+# image: chart default is burakince/mlflow:<appVersion> — used as-is (ghcr.io/mlflow not published)
+
+service:
+  type: ClusterIP
+  port: 5000
+
+resources:
+  requests:
+    cpu: "200m"
+    memory: "1Gi"
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"  # 4 gunicorn workers + py3.13 + sqlalchemy on first start hit 1Gi cap
+
+# Backend store — reuse in-cluster PostgreSQL, 'mlflow' database
+backendStore:
+  databaseMigration: true   # let MLflow run alembic on first start
+  databaseConnectionCheck: true
+  postgres:
+    enabled: true
+    host: "postgresql.isa-cloud-local.svc.cluster.local"
+    port: 5432
+    database: "mlflow"
+    driver: "psycopg2"
+  existingDatabaseSecret:
+    name: "mlflow-db-credentials"
+    usernameKey: "username"
+    passwordKey: "password"
+
+# Artifact store — reuse in-cluster MinIO, 'mlflow-artifacts' bucket
+artifactRoot:
+  proxiedArtifactStorage: true
+  s3:
+    enabled: true
+    bucket: "mlflow-artifacts"
+    existingSecret:
+      name: "minio"
+      keyOfAccessKeyId: "rootUser"
+      keyOfSecretAccessKey: "rootPassword"
+
+# Point boto3 at the in-cluster MinIO endpoint
+extraEnvVars:
+  MLFLOW_S3_ENDPOINT_URL: "http://minio.isa-cloud-local.svc.cluster.local:9000"
+  AWS_DEFAULT_REGION: "us-east-1"  # MinIO ignores but boto3 requires it
+  MLFLOW_S3_IGNORE_TLS: "true"
+  GUNICORN_CMD_ARGS: "--workers=2 --worker-class=sync"  # 2 workers, fits in 2Gi limit
+  # MLflow 3.x security middleware: allow APISIX gateway + in-cluster + localhost.
+  # Without this, all non-localhost API requests are rejected as "DNS rebinding".
+  MLFLOW_SERVER_ALLOWED_HOSTS: "*"  # local dev — APISIX layers JWT for prod
+  MLFLOW_SERVER_CORS_ALLOWED_ORIGINS: "*"
+
+# No ingress — APISIX route handles external exposure (see manifests/mlflow-apisix-route.yaml)
+ingress:
+  enabled: false
+
+serviceAccount:
+  create: true

--- a/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml
@@ -304,6 +304,12 @@ data:
         local uri_path=$2
         local upstream_host=$3
         local upstream_port=$4
+        local cors_origins="${CORS_ALLOWED_ORIGINS:-https://app.isa-cloud.example.com,https://www.isa-cloud.example.com}"
+        local uris_json="[\"${uri_path}\", \"${uri_path}/*\"]"
+
+        if [ "$uri_path" = "/" ]; then
+            uris_json='["/", "/*"]'
+        fi
 
         print_info "Syncing frontend zone: $route_name → ${upstream_host}:${upstream_port}${uri_path}"
 
@@ -313,14 +319,15 @@ data:
             -H "Content-Type: application/json" \
             -d "{
                 \"name\": \"${route_name}\",
-                \"uris\": [\"${uri_path}\", \"${uri_path}/*\"],
+                \"uris\": ${uris_json},
                 \"priority\": 5,
                 \"status\": 1,
                 \"plugins\": {
                     \"cors\": {
-                        \"allow_origins\": \"**\",
+                        \"allow_origins\": \"${cors_origins}\",
                         \"allow_methods\": \"GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD\",
-                        \"allow_headers\": \"*\",
+                        \"allow_headers\": \"DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID\",
+                        \"expose_headers\": \"X-Request-ID\",
                         \"max_age\": 86400,
                         \"allow_credential\": true
                     },
@@ -881,7 +888,7 @@ spec:
     spec:
       containers:
         - name: watch
-          image: hashicorp/consul:1.17
+          image: hashicorp/consul:1.22.6
           command:
             - /bin/sh
             - -c
@@ -955,7 +962,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: sync
-              image: alpine:latest
+              image: hashicorp/consul:1.22.6
               command:
                 - /bin/sh
                 - -c

--- a/deployments/kubernetes/production/values/apisix.yaml
+++ b/deployments/kubernetes/production/values/apisix.yaml
@@ -5,7 +5,7 @@
 # Note: Built-in etcd is for dev/testing only. For production, use external etcd.
 # Source: https://github.com/apache/apisix-helm-chart
 
-# Service configuration (gateway)
+# Gateway service configuration
 service:
   type: ClusterIP
   http:
@@ -17,19 +17,28 @@ service:
   stream:
     enabled: false
 
-# APISIX configuration
-apisix:
-  image:
-    repository: apache/apisix
-    tag: 3.8.0-debian
+# APISIX image/runtime settings
+image:
+  repository: apache/apisix
+  tag: 3.8.0-debian
 
-  resources:
-    requests:
-      cpu: 500m
-      memory: 512Mi
-    limits:
-      cpu: 2000m
-      memory: 2Gi
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+
+apisix:
+  ssl:
+    enabled: true
+
+  dns:
+    resolvers:
+      - 10.96.0.10
+    validity: 30
+    timeout: 5
 
   # Admin API configuration
   admin:
@@ -47,17 +56,15 @@ apisix:
         - 172.16.0.0/12
         - 192.168.0.0/16
 
-  nginx:
-    configurationSnippet:
-      http: |
-        resolver 10.96.0.10 valid=30s;
-
   discovery:
     enabled: true
     registry:
       consul:
         servers:
-          - "http://consul-ui.isa-cloud-production.svc.cluster.local"
+          - "http://consul-server.isa-cloud-production.svc.cluster.local:8500"
+        default_service:
+          host: 127.0.0.1
+          port: 20999
         fetch_interval: 3
         timeout:
           connect: 2000
@@ -65,12 +72,6 @@ apisix:
           wait: 60
         keepalive: true
         default_weight: 1
-
-dns:
-  resolvers:
-    - 10.96.0.10
-  validity: 30
-  timeout: 5
 
 # etcd - use external etcd (deployed separately with official image)
 etcd:

--- a/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
+++ b/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml
@@ -304,6 +304,12 @@ data:
         local uri_path=$2
         local upstream_host=$3
         local upstream_port=$4
+        local cors_origins="${CORS_ALLOWED_ORIGINS:-https://app.isa-cloud.example.com,https://staging.isa-cloud.example.com}"
+        local uris_json="[\"${uri_path}\", \"${uri_path}/*\"]"
+
+        if [ "$uri_path" = "/" ]; then
+            uris_json='["/", "/*"]'
+        fi
 
         print_info "Syncing frontend zone: $route_name → ${upstream_host}:${upstream_port}${uri_path}"
 
@@ -313,14 +319,15 @@ data:
             -H "Content-Type: application/json" \
             -d "{
                 \"name\": \"${route_name}\",
-                \"uris\": [\"${uri_path}\", \"${uri_path}/*\"],
+                \"uris\": ${uris_json},
                 \"priority\": 5,
                 \"status\": 1,
                 \"plugins\": {
                     \"cors\": {
-                        \"allow_origins\": \"**\",
+                        \"allow_origins\": \"${cors_origins}\",
                         \"allow_methods\": \"GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD\",
-                        \"allow_headers\": \"*\",
+                        \"allow_headers\": \"DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-API-Key,X-Request-ID\",
+                        \"expose_headers\": \"X-Request-ID\",
                         \"max_age\": 86400,
                         \"allow_credential\": true
                     },
@@ -881,7 +888,7 @@ spec:
     spec:
       containers:
         - name: watch
-          image: hashicorp/consul:1.17
+          image: hashicorp/consul:1.22.6
           command:
             - /bin/sh
             - -c
@@ -955,7 +962,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: sync
-              image: alpine:latest
+              image: hashicorp/consul:1.22.6
               command:
                 - /bin/sh
                 - -c

--- a/deployments/kubernetes/staging/values/apisix.yaml
+++ b/deployments/kubernetes/staging/values/apisix.yaml
@@ -5,7 +5,7 @@
 # Note: Built-in etcd is for dev/testing only. For production, use external etcd.
 # Source: https://github.com/apache/apisix-helm-chart
 
-# Service configuration (gateway)
+# Gateway service configuration
 service:
   type: NodePort
   http:
@@ -18,19 +18,28 @@ service:
   stream:
     enabled: false
 
-# APISIX configuration
-apisix:
-  image:
-    repository: apache/apisix
-    tag: 3.8.0-debian
+# APISIX image/runtime settings
+image:
+  repository: apache/apisix
+  tag: 3.8.0-debian
 
-  resources:
-    requests:
-      cpu: 200m
-      memory: 256Mi
-    limits:
-      cpu: 1000m
-      memory: 1Gi
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+apisix:
+  ssl:
+    enabled: true
+
+  dns:
+    resolvers:
+      - 10.96.0.10
+    validity: 30
+    timeout: 5
 
   # Admin API configuration
   admin:
@@ -47,17 +56,15 @@ apisix:
       ipList:
         - 0.0.0.0/0
 
-  nginx:
-    configurationSnippet:
-      http: |
-        resolver 10.96.0.10 valid=30s;
-
   discovery:
     enabled: true
     registry:
       consul:
         servers:
-          - "http://consul-ui.isa-cloud-staging.svc.cluster.local"
+          - "http://consul-server.isa-cloud-staging.svc.cluster.local:8500"
+        default_service:
+          host: 127.0.0.1
+          port: 20999
         fetch_interval: 3
         timeout:
           connect: 2000
@@ -65,12 +72,6 @@ apisix:
           wait: 60
         keepalive: true
         default_weight: 1
-
-dns:
-  resolvers:
-    - 10.96.0.10
-  validity: 30
-  timeout: 5
 
 # etcd - use external etcd (deployed separately with official image)
 etcd:

--- a/isA_common/isa_common/consul_client.py
+++ b/isA_common/isa_common/consul_client.py
@@ -7,7 +7,9 @@ Provides service registration and health check functionality for microservices
 import asyncio
 import json
 import logging
+import os
 import socket
+import sys
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Optional
 
@@ -26,6 +28,100 @@ def _is_loopback(host: str) -> bool:
         return ipaddress.ip_address(host).is_loopback
     except ValueError:
         return host.lower() == "localhost"
+
+
+def _usable_service_host(addr: Optional[str]) -> bool:
+    """Return True when *addr* can be advertised to gateways/other services."""
+    return bool(addr) and addr != "0.0.0.0" and not _is_loopback(addr)
+
+
+def _is_resolvable(host: str) -> bool:
+    """Return True if the current runtime can resolve *host*."""
+    try:
+        socket.getaddrinfo(host, None)
+        return True
+    except socket.gaierror:
+        return False
+
+
+def _first_non_loopback_ip(host: str) -> Optional[str]:
+    """Resolve *host* to a non-loopback IP, preferring IPv4 for local dev."""
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return None
+
+    ipv6_candidate = None
+    for family, _, _, _, sockaddr in infos:
+        address = sockaddr[0]
+        if not _usable_service_host(address):
+            continue
+
+        if family == socket.AF_INET:
+            return address
+
+        if family == socket.AF_INET6 and ipv6_candidate is None:
+            ipv6_candidate = address
+
+    return ipv6_candidate
+
+
+def _desktop_gateway_host() -> Optional[str]:
+    """
+    Prefer Docker Desktop's stable host-gateway IP for native macOS dev services.
+
+    This keeps local services reachable from Kind/APISIX without requiring every
+    service repo to export SERVICE_HOST manually. APISIX 3.16 rejects Consul
+    discovery nodes that are still domain-shaped hosts, so we normalize the
+    Docker Desktop alias to a concrete IP before advertising it. Kubernetes
+    workloads must not use this fallback, so it is only considered outside
+    cluster runtimes.
+    """
+    if sys.platform != "darwin" or os.getenv("KUBERNETES_SERVICE_HOST"):
+        return None
+
+    return _first_non_loopback_ip("host.docker.internal")
+
+
+def _normalize_service_host(host: Optional[str]) -> Optional[str]:
+    """
+    Normalize a host before advertising it to Consul.
+
+    For native macOS local development we prefer concrete IPs over DNS names so
+    APISIX Consul discovery can forward to them without tripping over domain
+    host restrictions.
+    """
+    if not _usable_service_host(host):
+        return host
+
+    if sys.platform != "darwin" or os.getenv("KUBERNETES_SERVICE_HOST"):
+        return host
+
+    try:
+        ipaddress.ip_address(host)
+        return host
+    except ValueError:
+        return _first_non_loopback_ip(host) or host
+
+
+def _resolve_service_host(service_host: Optional[str]) -> str:
+    """Resolve the address that Consul should advertise for the service."""
+    if _usable_service_host(service_host):
+        return _normalize_service_host(service_host)
+
+    env_host = os.getenv("SERVICE_HOST")
+    if _usable_service_host(env_host):
+        return _normalize_service_host(env_host)
+
+    desktop_gateway = _desktop_gateway_host()
+    if desktop_gateway:
+        return desktop_gateway
+
+    hostname = os.getenv("HOSTNAME", socket.gethostname())
+    if _usable_service_host(hostname):
+        return _normalize_service_host(hostname)
+
+    return hostname
 
 
 class ConsulRegistry:
@@ -67,26 +163,7 @@ class ConsulRegistry:
 
         # Only set these if we're registering (have service_name and service_port)
         if service_name and service_port is not None:
-            # Resolve the address that Consul advertises to APISIX / other consumers.
-            # Loopback (127.x.x.x / ::1) and unspecified (0.0.0.0) are never
-            # routable from a gateway context, so we skip them and fall through
-            # to hostname-based detection.
-            import os
-
-            def _usable(addr: str | None) -> bool:
-                return bool(addr) and addr != "0.0.0.0" and not _is_loopback(addr)
-
-            if _usable(service_host):
-                self.service_host = service_host
-            else:
-                # Priority: SERVICE_HOST (K8s Service DNS) > HOSTNAME (Docker container name) > hostname
-                env_host = os.getenv("SERVICE_HOST")
-                if _usable(env_host):
-                    self.service_host = env_host
-                else:
-                    self.service_host = os.getenv(
-                        "HOSTNAME", socket.gethostname()
-                    )
+            self.service_host = _resolve_service_host(service_host)
 
             # Final guard: warn if the resolved address is still loopback
             if _is_loopback(self.service_host):
@@ -100,8 +177,6 @@ class ConsulRegistry:
 
             self.service_id = f"{service_name}-{self.service_host}-{service_port}"
         else:
-            import os
-
             self.service_host = service_host or os.getenv(
                 "HOSTNAME", socket.gethostname()
             )
@@ -708,20 +783,8 @@ class AsyncConsulRegistry(AsyncBaseClient):
         self._health_check_task = None
 
         # Resolve service host (same logic as sync ConsulRegistry)
-        import os
-
-        def _usable(addr: str | None) -> bool:
-            return bool(addr) and addr != "0.0.0.0" and not _is_loopback(addr)
-
         if service_name and service_port is not None:
-            if _usable(service_host):
-                self.service_host = service_host
-            else:
-                env_host = os.getenv("SERVICE_HOST")
-                if _usable(env_host):
-                    self.service_host = env_host
-                else:
-                    self.service_host = os.getenv("HOSTNAME", socket.gethostname())
+            self.service_host = _resolve_service_host(service_host)
 
             if _is_loopback(self.service_host):
                 logger.warning(
@@ -1056,10 +1119,8 @@ async def consul_lifespan(
         ))
     """
     # Startup
-    # Use SERVICE_HOST env var if available, otherwise use hostname
-    import os
-
-    service_host = os.getenv("SERVICE_HOST", socket.gethostname())
+    # Prefer SERVICE_HOST, then macOS Docker Desktop host alias, then hostname.
+    service_host = _resolve_service_host(None)
 
     registry = ConsulRegistry(
         service_name=service_name,

--- a/isA_common/tests/unit/test_async_consul_unit.py
+++ b/isA_common/tests/unit/test_async_consul_unit.py
@@ -47,6 +47,57 @@ class TestAsyncConsulContextManager:
                 assert client.is_connected
 
 
+class TestAsyncConsulRegistryInit:
+    """AsyncConsulRegistry host resolution."""
+
+    def test_init_prefers_desktop_gateway_ip_for_native_macos_dev(self):
+        with patch("isa_common.consul_client.consul.Consul"):
+            from isa_common.consul_client import AsyncConsulRegistry
+
+            with patch("isa_common.consul_client.sys.platform", "darwin"), \
+                 patch(
+                     "isa_common.consul_client.socket.getaddrinfo",
+                     return_value=[
+                         (2, None, None, None, ("192.168.65.254", 0)),
+                     ],
+                 ), \
+                 patch("isa_common.consul_client.socket.gethostname", return_value="my-mac.local"), \
+                 patch.dict("os.environ", {}, clear=True):
+                registry = AsyncConsulRegistry(
+                    service_name="test-service",
+                    service_port=8080,
+                    lazy_connect=True,
+                )
+
+        assert registry.service_host == "192.168.65.254"
+        assert registry.service_id == "test-service-192.168.65.254-8080"
+
+    def test_init_normalizes_service_host_alias_to_ip_for_native_macos_dev(self):
+        with patch("isa_common.consul_client.consul.Consul"):
+            from isa_common.consul_client import AsyncConsulRegistry
+
+            with patch("isa_common.consul_client.sys.platform", "darwin"), \
+                 patch(
+                     "isa_common.consul_client.socket.getaddrinfo",
+                     return_value=[
+                         (2, None, None, None, ("192.168.65.254", 0)),
+                     ],
+                 ), \
+                 patch.dict(
+                     "os.environ",
+                     {"SERVICE_HOST": "host.docker.internal"},
+                     clear=True,
+                 ):
+                registry = AsyncConsulRegistry(
+                    service_name="test-service",
+                    service_port=8080,
+                    lazy_connect=True,
+                )
+
+        assert registry.service_host == "192.168.65.254"
+        assert registry.service_id == "test-service-192.168.65.254-8080"
+
+
 # ============================================================================
 # L2 — Connect / disconnect lifecycle
 # ============================================================================

--- a/isA_common/tests/unit/test_consul_unit.py
+++ b/isA_common/tests/unit/test_consul_unit.py
@@ -57,6 +57,73 @@ class TestConsulRegistryInit:
             assert registry.service_name is None
             assert registry.service_id is None
 
+    def test_init_prefers_desktop_gateway_ip_for_native_macos_dev(self):
+        with patch("isa_common.consul_client.consul.Consul"):
+            from isa_common.consul_client import ConsulRegistry
+
+            with patch("isa_common.consul_client.sys.platform", "darwin"), \
+                 patch(
+                     "isa_common.consul_client.socket.getaddrinfo",
+                     return_value=[
+                         (2, None, None, None, ("192.168.65.254", 0)),
+                     ],
+                 ), \
+                 patch("isa_common.consul_client.socket.gethostname", return_value="my-mac.local"), \
+                 patch.dict("os.environ", {}, clear=True):
+                registry = ConsulRegistry(
+                    service_name="test-service",
+                    service_port=8080,
+                )
+
+        assert registry.service_host == "192.168.65.254"
+        assert registry.service_id == "test-service-192.168.65.254-8080"
+
+    def test_init_normalizes_service_host_alias_to_ip_for_native_macos_dev(self):
+        with patch("isa_common.consul_client.consul.Consul"):
+            from isa_common.consul_client import ConsulRegistry
+
+            with patch("isa_common.consul_client.sys.platform", "darwin"), \
+                 patch(
+                     "isa_common.consul_client.socket.getaddrinfo",
+                     return_value=[
+                         (2, None, None, None, ("192.168.65.254", 0)),
+                     ],
+                 ), \
+                 patch.dict(
+                     "os.environ",
+                     {"SERVICE_HOST": "host.docker.internal"},
+                     clear=True,
+                 ):
+                registry = ConsulRegistry(
+                    service_name="test-service",
+                    service_port=8080,
+                )
+
+        assert registry.service_host == "192.168.65.254"
+        assert registry.service_id == "test-service-192.168.65.254-8080"
+
+    def test_init_does_not_use_host_docker_internal_inside_kubernetes(self):
+        with patch("isa_common.consul_client.consul.Consul"):
+            from isa_common.consul_client import ConsulRegistry
+
+            with patch("isa_common.consul_client.sys.platform", "darwin"), \
+                 patch("isa_common.consul_client.socket.getaddrinfo", return_value=[object()]), \
+                 patch.dict(
+                     "os.environ",
+                     {
+                         "KUBERNETES_SERVICE_HOST": "10.96.0.1",
+                         "HOSTNAME": "apisix-pod-0",
+                     },
+                     clear=True,
+                 ):
+                registry = ConsulRegistry(
+                    service_name="test-service",
+                    service_port=8080,
+                )
+
+        assert registry.service_host == "apisix-pod-0"
+        assert registry.service_id == "test-service-apisix-pod-0-8080"
+
 
 # ============================================================================
 # L2 — Registration / deregistration

--- a/tests/unit/test_local_setup_apisix_bootstrap.sh
+++ b/tests/unit/test_local_setup_apisix_bootstrap.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Unit test: Validate local bootstrap includes APISIX values + Consul sync wiring
+# L1 — Static config validation, no live services needed
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SETUP_SCRIPT="$REPO_ROOT/.claude/skills/cluster_operations/scripts/setup-local.sh"
+APISIX_VALUES="$REPO_ROOT/deployments/kubernetes/local/values/apisix.yaml"
+SYNC_MANIFEST="$REPO_ROOT/deployments/kubernetes/local/manifests/consul-apisix-sync.yaml"
+STAGING_APISIX_VALUES="$REPO_ROOT/deployments/kubernetes/staging/values/apisix.yaml"
+PRODUCTION_APISIX_VALUES="$REPO_ROOT/deployments/kubernetes/production/values/apisix.yaml"
+STAGING_SYNC_MANIFEST="$REPO_ROOT/deployments/kubernetes/staging/manifests/consul-apisix-sync.yaml"
+PRODUCTION_SYNC_MANIFEST="$REPO_ROOT/deployments/kubernetes/production/manifests/consul-apisix-sync.yaml"
+
+pass() { echo -e "${GREEN}PASS${NC} $1"; ((TESTS_PASSED++)); }
+fail() { echo -e "${RED}FAIL${NC} $1"; ((TESTS_FAILED++)); }
+
+echo "=== Local APISIX Bootstrap Validation ==="
+
+if [ ! -f "$SETUP_SCRIPT" ]; then
+    fail "setup-local.sh not found"
+else
+    if grep -q 'values_for apisix' "$SETUP_SCRIPT"; then
+        pass "setup-local.sh resolves local APISIX values"
+    else
+        fail "setup-local.sh does not resolve APISIX values"
+    fi
+
+    if grep -q 'consul-apisix-sync.yaml' "$SETUP_SCRIPT"; then
+        pass "setup-local.sh applies consul-apisix-sync manifest"
+    else
+        fail "setup-local.sh does not apply consul-apisix-sync manifest"
+    fi
+fi
+
+if [ ! -f "$APISIX_VALUES" ]; then
+    fail "local APISIX values file not found"
+else
+    if grep -q 'default_service:' "$APISIX_VALUES"; then
+        pass "local APISIX values configure discovery default_service"
+    else
+        fail "local APISIX values missing discovery default_service"
+    fi
+
+    if grep -q 'consul-server.isa-cloud-local.svc.cluster.local:8500' "$APISIX_VALUES"; then
+        pass "local APISIX values point discovery at consul-server:8500"
+    else
+        fail "local APISIX values missing consul-server:8500 discovery target"
+    fi
+
+    if grep -A2 '^etcd:' "$APISIX_VALUES" | grep -q 'enabled: true'; then
+        pass "local APISIX values keep chart-managed etcd enabled"
+    else
+        fail "local APISIX values do not keep chart-managed etcd enabled"
+    fi
+fi
+
+if [ ! -f "$SYNC_MANIFEST" ]; then
+    fail "local Consul-APISIX sync manifest not found"
+else
+    if grep -q 'image: hashicorp/consul:1.22.6' "$SYNC_MANIFEST"; then
+        pass "local sync manifest pins watch/sync image to hashicorp/consul:1.22.6"
+    else
+        fail "local sync manifest does not pin the validated consul image"
+    fi
+
+    if grep -q 'host.docker.internal' "$SYNC_MANIFEST"; then
+        pass "local sync manifest defaults frontend static upstreams to host.docker.internal"
+    else
+        fail "local sync manifest does not default frontend static upstreams to host.docker.internal"
+    fi
+fi
+
+for values_file in "$STAGING_APISIX_VALUES" "$PRODUCTION_APISIX_VALUES"; do
+    env_name="$(basename "$(dirname "$(dirname "$values_file")")")"
+    if [ ! -f "$values_file" ]; then
+        fail "$env_name APISIX values file not found"
+        continue
+    fi
+
+    if grep -q 'default_service:' "$values_file"; then
+        pass "$env_name APISIX values configure discovery default_service"
+    else
+        fail "$env_name APISIX values missing discovery default_service"
+    fi
+
+    if grep -q 'consul-server\..*\.svc\.cluster\.local:8500' "$values_file"; then
+        pass "$env_name APISIX values point discovery at consul-server:8500"
+    else
+        fail "$env_name APISIX values missing consul-server:8500 discovery target"
+    fi
+done
+
+for manifest_file in "$STAGING_SYNC_MANIFEST" "$PRODUCTION_SYNC_MANIFEST"; do
+    env_name="$(basename "$(dirname "$(dirname "$manifest_file")")")"
+    if [ ! -f "$manifest_file" ]; then
+        fail "$env_name sync manifest not found"
+        continue
+    fi
+
+    if grep -q 'image: hashicorp/consul:1.22.6' "$manifest_file"; then
+        pass "$env_name sync manifest pins watch/sync image to hashicorp/consul:1.22.6"
+    else
+        fail "$env_name sync manifest does not pin the validated consul image"
+    fi
+
+    if grep -Fq '\"allow_origins\": \"${cors_origins}\"' "$manifest_file"; then
+        pass "$env_name sync manifest uses explicit CORS origins for frontend routes"
+    else
+        fail "$env_name sync manifest still uses invalid wildcard CORS for frontend routes"
+    fi
+done
+
+echo ""
+echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed ==="
+
+[ "$TESTS_FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Deploys JupyterHub 4.3.4 (Z2JH chart) into the existing `isa-cloud-local` namespace.

- DummyAuthenticator for local dev (production OAuth wiring already lives in isA_Model `deployments/helm/jupyterhub/values.yaml`)
- Upstream `jupyter/scipy-notebook:python-3.11` image — `pip install isa_model` at spawn via lifecycleHooks (avoids 10-min custom-image build for local dev demo)
- Hub state in shared in-cluster Postgres (`jupyterhub` db)
- Singleuser env auto-wires `ISA_API_URL`, `MLFLOW_TRACKING_URI`, `MLFLOW_S3_ENDPOINT_URL`, `AWS_*`
- Two profiles: small (1 CPU/2 Gi default) + medium (2 CPU/4 Gi) — capped to protect kind RAM
- Idle servers culled after 30 min

APISIX route exposes `/jupyter[/*]` → `proxy-public:80` with the same plugin set as the MLflow route.

## Test plan

- [x] `helm install` succeeds
- [x] `kubectl get pod hub-* proxy-*` → 1/1 Running
- [x] `GET /jupyter/hub/login` via APISIX → 200
- [ ] Spawn a singleuser pod, run notebook 01_basic_inference (manual — first-spawn pulls scipy-notebook image, ~2GB)

## Out of scope (follow-up)

- Production custom singleuser image build + push (needs CI infra; Dockerfile already in isA_Model `deployment/docker/jupyterhub-singleuser.Dockerfile` from #769)
- OAuth wiring on local (needs isA Auth deployment locally; production wiring already in isA_Model #770)

Tracks xenoISA/isA_Model#771, parent epic xenoISA/isA_Model#763.