### PR TITLE
feat(infra): require key-auth on /mlflow APISIX route (#784)

### DIFF
--- a/deployments/kubernetes/local/manifests/mlflow-apisix-route.yaml
+++ b/deployments/kubernetes/local/manifests/mlflow-apisix-route.yaml
@@ -42,7 +42,8 @@ data:
       },
       "request-id": { "algorithm": "uuid", "include_in_response": true },
       "proxy-rewrite": { "regex_uri": ["^/mlflow/?(.*)$", "/$1"] },
-      "prometheus": {}
+      "prometheus": {},
+      "key-auth": {}
     }')
 
     UPSTREAM=$(jq -n '{


### PR DESCRIPTION
## Summary

Locks down anonymous access to MLflow via APISIX `key-auth` plugin. Replaces #219 with a clean cherry-pick on top of current main (the prior branch carried unrelated commits from a stale base).

## Verified

- `GET /mlflow/health` (no header) → **401**
- `GET /mlflow/health` with `apikey: <K8s secret>` → **200**
- `POST /mlflow/api/2.0/mlflow/experiments/search` with apikey → **200**

## Pivot note (vs original story)

Original [xenoISA/isA_Model#784](https://github.com/xenoISA/isA_Model/issues/784) called for JWT auth from `isA_user/auth_service`. Investigation showed:
- auth_service local JWT secret (`local_jwt_secret` / `LOCAL_JWT_SECRET` / `JWT_SECRET`) is **not configured** in the local dev process — falls through to None / Auth0 RS256 path
- APISIX `jwt-auth` plugin needs a shared HS256 secret or RS256 + JWKS endpoint to validate

`key-auth` is the immediate hardening; a follow-up will swap to JWT once auth_service local issuance is wired or APISIX is configured for RS256 + JWKS.

## Out-of-band setup

- APISIX consumer `mlflow_client` registered via admin API
- API key value in K8s secret `mlflow-api-key` (key `apikey`)
- Re-running this Job is idempotent