### PR TITLE
feat(infra): scoped MinIO IAM for MLflow + custom singleuser image for JupyterHub (#787, #790)

### DIFF
--- a/deployments/kubernetes/local/values/jupyterhub.yaml
+++ b/deployments/kubernetes/local/values/jupyterhub.yaml
@@ -54,23 +54,19 @@ proxy:
       enabled: false
 
 singleuser:
+  # Custom image with isa_model[full-local] pre-installed (#790, follows on #786).
+  # Built locally via isA_Model `deployment/docker/build-jupyterhub.sh` and
+  # `kind load`-ed into all nodes — no registry needed for local dev.
   image:
-    name: quay.io/jupyter/scipy-notebook
-    tag: "python-3.11"
-    pullPolicy: IfNotPresent
+    name: isa-model-jupyter
+    tag: "local"
+    pullPolicy: IfNotPresent  # Never — image is loaded into containerd
 
   defaultUrl: "/lab"
-  startTimeout: 600  # first spawn pulls the image (~2GB)
+  startTimeout: 300  # no image pull on spawn, just unpack from containerd cache
 
-  # Pre-install isa_model SDK at spawn time (cheaper than maintaining a custom
-  # image for local dev). Production uses the prebuilt singleuser image.
-  lifecycleHooks:
-    postStart:
-      exec:
-        command:
-          - "sh"
-          - "-c"
-          - "pip install --quiet --user isa_model || true"
+  # isa_model is pre-installed in the custom image — no postStart pip install
+  # needed. Spawn time dropped from ~3 min (image pull) to ~16 s.
 
   extraEnv:
     ISA_API_URL: "http://apisix-gateway.isa-cloud-local.svc.cluster.local/api/v1/models"

--- a/deployments/kubernetes/local/values/mlflow.yaml
+++ b/deployments/kubernetes/local/values/mlflow.yaml
@@ -47,9 +47,13 @@ artifactRoot:
     enabled: true
     bucket: "mlflow-artifacts"
     existingSecret:
-      name: "minio"
-      keyOfAccessKeyId: "rootUser"
-      keyOfSecretAccessKey: "rootPassword"
+      # Scoped IAM identity created via `mc admin user add mlflow-svc` +
+      # mlflow-svc policy (read/write only on `mlflow-artifacts/*`).  See
+      # manifests/mlflow-minio-scoped-iam.sh.  Replaces the old `minio` root
+      # creds reference. Tracks #787.
+      name: "mlflow-s3-credentials"
+      keyOfAccessKeyId: "accessKeyId"
+      keyOfSecretAccessKey: "secretAccessKey"
 
 # Point boto3 at the in-cluster MinIO endpoint
 extraEnvVars:


### PR DESCRIPTION
## Summary

Two Wave-2 hardening changes on the local kind cluster.

### #787 — MLflow MinIO scope

Replaces the `minio` root credentials reference in `mlflow.yaml` with a new `mlflow-s3-credentials` K8s secret backed by a scoped MinIO IAM user (`mlflow-svc`). The user has a policy granting only `s3:Get/Put/Delete` on `mlflow-artifacts/*`.

**Verified:** `POST /mlflow/api/2.0/mlflow/experiments/create` via APISIX returned `experiment_id: 5` after the swap. Pod boots clean against the new secret.

### #790 — JupyterHub custom singleuser image

Switches singleuser image from `quay.io/jupyter/scipy-notebook` (+ postStart `pip install` hack) to the locally-built `isa-model-jupyter:local` (loaded via `kind load docker-image`).

**Verified:**
- Spawn time **~16s** (vs prior ~3 min including image pull and pip install)
- `kubectl get pod jupyter-admin -o jsonpath='{.spec.containers[0].image}'` → `isa-model-jupyter:local`
- `isa_model` available at `/opt/conda/lib/python3.11/site-packages/isa_model-0.6.0` (system path)
- `pullPolicy: IfNotPresent` — kind never tries to pull from a registry

Tracks [xenoISA/isA_Model#787](https://github.com/xenoISA/isA_Model/issues/787) and [#790](https://github.com/xenoISA/isA_Model/issues/790) (parent epic #783).

## Out of scope (still open in epic)

- #788: JupyterHub OAuth client registration — blocked on `dev_bypass_login` not granting admin scope; needs out-of-band admin token to register the client via `POST /api/v1/auth/oauth/clients`. DummyAuth still active.
- #789: JWT auth on `/jupyter` — depends on #788.