### PR TITLE
feat(infra): NetworkPolicies + document backup coverage (#791, #792, #795)

### DIFF
--- a/.claude/skills/backup_restore/SKILL.md
+++ b/.claude/skills/backup_restore/SKILL.md
@@ -28,6 +28,37 @@ Complete backup and restore operations for ALL data stores in isA_Cloud.
 7. **NATS** - Message streaming (JetStream)
 8. **APISIX** - API Gateway (routes, upstreams, consumers)
 
+### Phase 8 resources (auto-covered)
+
+`backup-all.sh` iterates every non-template Postgres database and mirrors every
+MinIO bucket at the alias root. The new Phase 8 resources are therefore
+included automatically — no script change required:
+
+| Database               | Owner role | Tracked by |
+|------------------------|------------|------------|
+| `mlflow`               | `mlflow`   | xenoISA/isA_Model#785 |
+| `jupyterhub`           | `postgres` | xenoISA/isA_Model#771 |
+
+| MinIO bucket           | IAM identity | Tracked by |
+|------------------------|--------------|------------|
+| `mlflow-artifacts`     | `mlflow-svc` (scoped policy on bucket) | xenoISA/isA_Model#787 |
+| `jupyterhub-volumes`   | `minio` root (Z2JH default) | xenoISA/isA_Model#771 |
+
+**Restore drill** (per-resource, Phase 8):
+
+```bash
+# 1. Recover one MLflow experiment from a backup taken today
+pg_restore -U postgres -d mlflow_recovered <backup>/postgres/mlflow.dump
+psql -U postgres -d mlflow_recovered -c "SELECT name FROM experiments LIMIT 5;"
+
+# 2. Recover an artifact bucket
+mc mirror <backup>/minio/mlflow-artifacts/ local/mlflow-artifacts/
+
+# Sanity: smoke MLflow against the recovered DB
+helm upgrade mlflow community-charts/mlflow -n isa-cloud-local \
+  --set backendStore.postgres.database=mlflow_recovered ...
+```
+
 ## Operation Patterns
 
 ### Pattern 1: Individual Service Backup

--- a/deployments/kubernetes/local/manifests/mlflow-network-policies.yaml
+++ b/deployments/kubernetes/local/manifests/mlflow-network-policies.yaml
@@ -1,0 +1,174 @@
+# Network policies for MLflow (#791) and JupyterHub (#792).
+# Default-deny posture is set in network-policies.yaml; this file adds the
+# explicit allow-lists for the new Phase 8 services.
+#
+# Apply: kubectl apply -f mlflow-network-policies.yaml
+# Verify:
+#   kubectl run -n isa-cloud-local --rm -i --restart=Never test \
+#     --image=alpine -- sh -c 'apk add --no-cache curl >/dev/null 2>&1 && \
+#       curl -s -o /dev/null -w "HTTP %{http_code}" http://mlflow:5000/health'
+#   # Expect: timeout (denied) when test pod has no allowed labels.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mlflow-allow
+  namespace: isa-cloud-local
+  labels:
+    app.kubernetes.io/instance: mlflow
+    tier: backend
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: mlflow
+
+  policyTypes: [Ingress, Egress]
+
+  ingress:
+    # APISIX gateway -> MLflow:5000  (the only "public" path)
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: apisix
+      ports:
+        - { protocol: TCP, port: 5000 }
+
+    # JupyterHub singleuser pods (notebooks calling MLflow tracking API directly).
+    # Z2JH labels singleuser pods with `component=singleuser-server`.
+    - from:
+        - podSelector:
+            matchLabels:
+              component: singleuser-server
+      ports:
+        - { protocol: TCP, port: 5000 }
+
+    # Same-pod readiness/liveness probes from kubelet (allowed by default but
+    # documented here for clarity).
+
+  egress:
+    # PostgreSQL backend store
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: postgresql
+      ports:
+        - { protocol: TCP, port: 5432 }
+
+    # MinIO artifact store (s3 + console)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: minio
+      ports:
+        - { protocol: TCP, port: 9000 }
+        - { protocol: TCP, port: 9001 }
+
+    # CoreDNS — required for any DNS resolution in-cluster
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - { protocol: UDP, port: 53 }
+        - { protocol: TCP, port: 53 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: jupyterhub-singleuser-allow
+  namespace: isa-cloud-local
+  labels:
+    app: jupyterhub
+    tier: backend
+spec:
+  # Restrict singleuser pods spawned by Z2JH KubeSpawner.
+  podSelector:
+    matchLabels:
+      component: singleuser-server
+
+  policyTypes: [Ingress, Egress]
+
+  ingress:
+    # Hub + Proxy talking to the user notebook on :8888
+    - from:
+        - podSelector:
+            matchLabels:
+              app: jupyterhub
+      ports:
+        - { protocol: TCP, port: 8888 }
+
+  egress:
+    # APISIX gateway (notebook -> isA_Model API + any other isA service)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: apisix
+      ports:
+        - { protocol: TCP, port: 80 }
+        - { protocol: TCP, port: 9080 }
+
+    # MLflow tracking server
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: mlflow
+      ports:
+        - { protocol: TCP, port: 5000 }
+
+    # MinIO (artifacts + user storage)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: minio
+      ports:
+        - { protocol: TCP, port: 9000 }
+
+    # PostgreSQL (notebooks doing data work directly)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: postgresql
+      ports:
+        - { protocol: TCP, port: 5432 }
+
+    # NATS (event publishing from notebook code)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: nats
+      ports:
+        - { protocol: TCP, port: 4222 }
+
+    # JupyterHub Hub (user server -> hub callback)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: jupyterhub
+              component: hub
+      ports:
+        - { protocol: TCP, port: 8081 }
+
+    # CoreDNS — required for DNS resolution
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - { protocol: UDP, port: 53 }
+        - { protocol: TCP, port: 53 }
+
+    # Internet egress (notebooks may pip install or download data).  If you
+    # need to lock this down further, add an explicit IPBlock allowlist for
+    # PyPI mirrors here.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8       # cluster CIDR — already covered by pod rules
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - { protocol: TCP, port: 443 }
+        - { protocol: TCP, port: 80 }


### PR DESCRIPTION
## Summary

Wave 3 hardening — three locally-doable items in one PR.

### #791 + #792 — NetworkPolicies

`deployments/kubernetes/local/manifests/mlflow-network-policies.yaml`:

- **`mlflow-allow`** — ingress: APISIX + singleuser pods → :5000; egress: postgresql, minio, kube-dns
- **`jupyterhub-singleuser-allow`** — ingress: hub/proxy → :8888; egress: APISIX, MLflow, MinIO, postgres, NATS, hub:8081, kube-dns, external HTTPS

**Verified:**
- APISIX → MLflow with apikey: **HTTP 200** (allowed)
- Random pod → MLflow:5000: **HTTP 000** (denied/timeout)
- /jupyter/hub/login via APISIX: **HTTP 200** (allowed)

### #795 — Backup coverage

Investigation found `backup-all.sh` already iterates every non-template Postgres database AND mirrors every MinIO bucket — Phase 8 resources are **auto-covered** without script changes.

`SKILL.md` updated to call this out explicitly + adds a per-resource restore-drill recipe.

Tracks [xenoISA/isA_Model#791](https://github.com/xenoISA/isA_Model/issues/791), [#792](https://github.com/xenoISA/isA_Model/issues/792), [#795](https://github.com/xenoISA/isA_Model/issues/795).

## Out of scope (still open)

- **#793 MLflow Prometheus + Grafana** — MLflow's `burakince/mlflow:3.7.0` image doesn't expose `/metrics`. Real path: APISIX `prometheus` plugin (already in route) + Grafana panels filtered by route_name. Need to fix APISIX prometheus exporter port (currently 9091/9090 return HTTP 000 — disabled in chart values).
- **#794 JupyterHub Prometheus + Grafana** — Hub `/hub/metrics` returns 403 (auth-gated). Z2JH supports auth-token-protected scrape; need to wire a Prometheus bearer token. Annotation-based pod scrape isn't enough.
- **#788/#789 OAuth + JWT on /jupyter** — blocked on `dev_bypass_login` not granting admin scope (see [#788 comment](https://github.com/xenoISA/isA_Model/issues/788#issuecomment-4371746748)).