### PR TITLE
feat(infra): wire APISIX + JupyterHub metrics to Prometheus + Grafana dashboard (#793, #794)

### DIFF
--- a/deployments/kubernetes/local/manifests/grafana-dashboards.yaml
+++ b/deployments/kubernetes/local/manifests/grafana-dashboards.yaml
@@ -251,3 +251,104 @@ data:
       "uid": "isa-mcp-service",
       "version": 1
     }
+  isa-mlflow-jupyterhub.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "type": "row",
+          "title": "MLflow gateway (APISIX prometheus plugin)",
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 100,
+          "collapsed": false
+        },
+        {
+          "type": "stat",
+          "title": "MLflow requests/sec",
+          "datasource": {"type": "prometheus", "uid": ""},
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+          "id": 101,
+          "targets": [{"refId": "A", "expr": "sum(rate(apisix_http_requests_total[1m]))"}]
+        },
+        {
+          "type": "stat",
+          "title": "MLflow total requests (lifetime)",
+          "datasource": {"type": "prometheus", "uid": ""},
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+          "id": 102,
+          "targets": [{"refId": "A", "expr": "sum(apisix_http_requests_total)"}]
+        },
+        {
+          "type": "timeseries",
+          "title": "Gateway latency p50 / p95 / p99",
+          "datasource": {"type": "prometheus", "uid": ""},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+          "id": 103,
+          "targets": [
+            {"refId": "P50", "expr": "histogram_quantile(0.50, sum(rate(apisix_http_latency_bucket[1m])) by (le))", "legendFormat": "p50"},
+            {"refId": "P95", "expr": "histogram_quantile(0.95, sum(rate(apisix_http_latency_bucket[1m])) by (le))", "legendFormat": "p95"},
+            {"refId": "P99", "expr": "histogram_quantile(0.99, sum(rate(apisix_http_latency_bucket[1m])) by (le))", "legendFormat": "p99"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Gateway HTTP statuses",
+          "datasource": {"type": "prometheus", "uid": ""},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+          "id": 104,
+          "targets": [{"refId": "A", "expr": "sum by (code) (rate(apisix_http_status[1m]))", "legendFormat": "{{code}}"}]
+        },
+        {
+          "type": "row",
+          "title": "JupyterHub (Hub /hub/metrics)",
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 13},
+          "id": 200,
+          "collapsed": false
+        },
+        {
+          "type": "stat",
+          "title": "Active users",
+          "datasource": {"type": "prometheus", "uid": ""},
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 14},
+          "id": 201,
+          "targets": [{"refId": "A", "expr": "jupyterhub_running_servers"}]
+        },
+        {
+          "type": "stat",
+          "title": "Total users registered",
+          "datasource": {"type": "prometheus", "uid": ""},
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 14},
+          "id": 202,
+          "targets": [{"refId": "A", "expr": "jupyterhub_total_users"}]
+        },
+        {
+          "type": "timeseries",
+          "title": "Hub request duration p95 by handler",
+          "datasource": {"type": "prometheus", "uid": ""},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 14},
+          "id": 203,
+          "targets": [{"refId": "A", "expr": "histogram_quantile(0.95, sum by (handler, le) (rate(jupyterhub_request_duration_seconds_bucket[1m])))", "legendFormat": "{{handler}}"}]
+        },
+        {
+          "type": "timeseries",
+          "title": "Hub request rate by status",
+          "datasource": {"type": "prometheus", "uid": ""},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
+          "id": 204,
+          "targets": [{"refId": "A", "expr": "sum by (code) (rate(jupyterhub_request_duration_seconds_count[1m]))", "legendFormat": "{{code}}"}]
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["isa", "mlflow", "jupyterhub", "phase8"],
+      "templating": {"list": []},
+      "time": {"from": "now-1h", "to": "now"},
+      "timezone": "browser",
+      "title": "isA MLflow + JupyterHub",
+      "uid": "isa-mlflow-jhub",
+      "version": 1
+    }

--- a/deployments/kubernetes/local/values/apisix.yaml
+++ b/deployments/kubernetes/local/values/apisix.yaml
@@ -24,6 +24,13 @@ image:
   repository: apache/apisix
   tag: 3.8.0-debian
 
+# Pod annotations — picked up by the kubernetes-pods scrape job in
+# prometheus-server. Tracks #793 (gateway-side metrics for /mlflow + /jupyter).
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "9091"
+  prometheus.io/path: "/apisix/prometheus/metrics"
+
 resources:
   requests:
     cpu: 100m
@@ -42,6 +49,16 @@ apisix:
       - 10.96.0.10
     validity: 30
     timeout: 5
+
+  # Prometheus metrics — exposes /apisix/prometheus/metrics on :9091.
+  # Per-route metrics (request count, latency p50/p95/p99, status codes) become
+  # available for the existing `prometheus` plugin already attached to
+  # mlflow_route + jupyterhub_route. Tracks #793.
+  prometheus:
+    enabled: true
+    path: /apisix/prometheus/metrics
+    metricPrefix: apisix_
+    containerPort: 9091
 
   # Admin API configuration
   admin:

--- a/deployments/kubernetes/local/values/jupyterhub.yaml
+++ b/deployments/kubernetes/local/values/jupyterhub.yaml
@@ -35,6 +35,18 @@ hub:
           name: postgresql
           key: postgres-password
 
+  # Allow Prometheus to scrape /hub/metrics without a bearer token (local dev only).
+  # Production wiring uses a service-token via `services:` block + scrape_configs
+  # bearer_token_file. Tracks #794.
+  authenticatePrometheus: false
+
+  # Annotation-based scrape — picked up by the existing kubernetes-pods job in
+  # the cluster's prometheus-server config (no Prometheus Operator needed).
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8081"
+    prometheus.io/path: "/hub/metrics"
+
   resources:
     requests: { cpu: 100m, memory: 256Mi }
     limits:   { cpu: 500m, memory: 512Mi }


### PR DESCRIPTION
## Summary

Unblocks the two metrics stories deferred from PR #224.

### #793 — APISIX prometheus exposure
- `apisix.prometheus.enabled=true` in `apisix.yaml` → exposes `:9091/apisix/prometheus/metrics`
- `podAnnotations` for `prometheus.io/scrape` — picked up by the cluster's `kubernetes-pods` scrape job (no Prometheus Operator / ServiceMonitor needed)
- **Verified:** `apisix_http_requests_total` = **52** in Prometheus after smoke traffic against `/mlflow/health` + `/jupyter/hub/login`

### #794 — JupyterHub Hub `/hub/metrics`
- `hub.authenticatePrometheus=false` (local dev) — production should issue a service token via `hub.services` block + `bearer_token_file` in scrape_config
- `hub.annotations` for prometheus.io/scrape pattern (port 8081, path /hub/metrics)
- **Verified:** `jupyterhub_running_servers` = **1**, `jupyterhub_total_users` = **1** in Prometheus

### Grafana dashboard `isa-mlflow-jhub`
Auto-provisioned via the existing `grafana-isa-dashboards` ConfigMap. Panels:

**MLflow gateway:** requests/sec, lifetime total, p50/p95/p99 latency, status code timeseries
**JupyterHub:** active-users stat, total-users stat, request duration p95 by handler, request rate by status

Tracks [xenoISA/isA_Model#793](https://github.com/xenoISA/isA_Model/issues/793) + [#794](https://github.com/xenoISA/isA_Model/issues/794).