### PR TITLE
Protect MLflow APISIX route with auth_service JWT

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -1,0 +1,37 @@
+# isA Cloud Secrets
+
+## MLflow APISIX JWT Auth
+
+`/mlflow` is protected by APISIX `jwt-auth` in local deployments. The APISIX
+consumer validates JWTs issued by `isA_user/auth_service`, which currently signs
+local tokens with `HS256` and `JWT_SECRET`.
+
+Create the APISIX validation secret with the same value used by auth_service:
+
+```bash
+kubectl create secret generic auth-service-jwt \
+  -n isa-cloud-local \
+  --from-literal=jwt-secret="${JWT_SECRET}"
+```
+
+Issue a client-credentials token through auth_service:
+
+```bash
+curl -X POST http://localhost:8201/oauth/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d "grant_type=client_credentials&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&scope=mlflow.read mlflow.write"
+```
+
+Use the returned token when calling MLflow through APISIX:
+
+```bash
+curl http://127.0.0.1:9080/mlflow/api/2.0/mlflow/experiments/search \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}"
+```
+
+For Python MLflow clients, export:
+
+```bash
+export MLFLOW_TRACKING_URI=http://127.0.0.1:9080/mlflow
+export MLFLOW_TRACKING_TOKEN="${ACCESS_TOKEN}"
+```

--- a/deployments/kubernetes/local/manifests/mlflow-apisix-route.yaml
+++ b/deployments/kubernetes/local/manifests/mlflow-apisix-route.yaml
@@ -10,17 +10,53 @@ data:
   register_routes.sh: |
     #!/bin/bash
     # Register MLflow APISIX routes — /mlflow and /mlflow/*
-    # Tracking: xenoISA/isA_Model#764
+    # Tracking: xenoISA/isA_Model#764, #784
     set -e
 
     APISIX_ADMIN_URL="${APISIX_ADMIN_URL:-http://apisix-admin.isa-cloud-local.svc.cluster.local:9180}"
     ADMIN_KEY="${APISIX_ADMIN_KEY:-edd1c9f034335f136f87ad84b625c8f1}"
     CORS_ORIGINS="${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:4100,http://localhost:4200,http://localhost:4300}"
+    AUTH_SERVICE_JWT_KEY="${AUTH_SERVICE_JWT_KEY:-isA_user}"
+    AUTH_SERVICE_JWT_ALGORITHM="${AUTH_SERVICE_JWT_ALGORITHM:-HS256}"
 
     GREEN='\033[0;32m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
     ok()   { echo -e "${GREEN}OK  $1${NC}"; }
     err()  { echo -e "${RED}ERR $1${NC}"; }
     info() { echo -e "${BLUE}INFO $1${NC}"; }
+
+    if [ -z "${AUTH_SERVICE_JWT_SECRET:-}" ]; then
+      err "AUTH_SERVICE_JWT_SECRET is required to validate auth_service HS256 JWTs"
+      exit 1
+    fi
+
+    info "Registering auth-service-jwt consumer for auth_service-issued JWTs..."
+    CONSUMER_RESP=$(curl -s -w "\n%{http_code}" -X PUT \
+      "${APISIX_ADMIN_URL}/apisix/admin/consumers/auth-service-jwt" \
+      -H "X-API-KEY: ${ADMIN_KEY}" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n \
+          --arg key "$AUTH_SERVICE_JWT_KEY" \
+          --arg secret "$AUTH_SERVICE_JWT_SECRET" \
+          --arg algorithm "$AUTH_SERVICE_JWT_ALGORITHM" \
+          '{
+            "username": "auth-service-jwt",
+            "plugins": {
+              "jwt-auth": {
+                "key": $key,
+                "secret": $secret,
+                "algorithm": $algorithm
+              }
+            }
+          }')")
+
+    CONSUMER_HTTP=$(echo "$CONSUMER_RESP" | tail -n1)
+    if [ "$CONSUMER_HTTP" = "200" ] || [ "$CONSUMER_HTTP" = "201" ]; then
+      ok "auth-service-jwt consumer registered (HTTP $CONSUMER_HTTP)"
+    else
+      err "Failed to register auth-service-jwt consumer (HTTP $CONSUMER_HTTP)"
+      echo "$CONSUMER_RESP" | head -n -1
+      exit 1
+    fi
 
     info "Registering mlflow_route (/mlflow[/*] -> mlflow-tracking:5000)..."
 
@@ -43,7 +79,17 @@ data:
       "request-id": { "algorithm": "uuid", "include_in_response": true },
       "proxy-rewrite": { "regex_uri": ["^/mlflow/?(.*)$", "/$1"] },
       "prometheus": {},
-      "key-auth": {}
+      "serverless-pre-function": {
+        "phase": "access",
+        "functions": [
+          "return function(conf, ctx) local core = require(\"apisix.core\"); local authorization = core.request.header(ctx, \"authorization\"); if authorization then local token = authorization:match(\"^[Bb]earer%s+(.+)$\") or authorization; core.request.set_header(ctx, \"x-mlflow-jwt\", token); end end"
+        ]
+      },
+      "jwt-auth": {
+        "header": "x-mlflow-jwt",
+        "key_claim_name": "iss",
+        "hide_credentials": true
+      }
     }')
 
     UPSTREAM=$(jq -n '{
@@ -123,6 +169,15 @@ spec:
               value: "http://apisix-admin.isa-cloud-local.svc.cluster.local:9180"
             - name: APISIX_ADMIN_KEY
               value: "edd1c9f034335f136f87ad84b625c8f1"
+            - name: AUTH_SERVICE_JWT_KEY
+              value: "isA_user"
+            - name: AUTH_SERVICE_JWT_ALGORITHM
+              value: "HS256"
+            - name: AUTH_SERVICE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: auth-service-jwt
+                  key: jwt-secret
           resources:
             requests:
               cpu: 50m

--- a/deployments/kubernetes/local/values/mlflow.yaml
+++ b/deployments/kubernetes/local/values/mlflow.yaml
@@ -6,6 +6,7 @@
 # Secrets required (created out-of-band, never inline):
 #   - mlflow-db-credentials  (keys: username, password)  — wraps postgresql/postgres-password
 #   - minio                  (keys: rootUser, rootPassword) — already exists
+#   - auth-service-jwt       (key: jwt-secret) — same HS256 JWT_SECRET used by isA_user/auth_service
 #
 # Re-deploy:  helm upgrade --install mlflow community-charts/mlflow -n isa-cloud-local -f mlflow.yaml
 

--- a/tests/unit/test_mlflow_apisix_jwt_auth.sh
+++ b/tests/unit/test_mlflow_apisix_jwt_auth.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Unit test: Validate the local MLflow APISIX route uses auth_service JWTs.
+# L1 — Static config validation, no live services needed.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ROUTE_MANIFEST="$REPO_ROOT/deployments/kubernetes/local/manifests/mlflow-apisix-route.yaml"
+
+pass() { echo -e "${GREEN}PASS${NC} $1"; ((TESTS_PASSED++)); }
+fail() { echo -e "${RED}FAIL${NC} $1"; ((TESTS_FAILED++)); }
+
+echo "=== MLflow APISIX JWT Auth Validation ==="
+
+if [ ! -f "$ROUTE_MANIFEST" ]; then
+    fail "MLflow APISIX route manifest not found"
+else
+    if grep -q '"jwt-auth"' "$ROUTE_MANIFEST"; then
+        pass "mlflow_route enables APISIX jwt-auth"
+    else
+        fail "mlflow_route does not enable APISIX jwt-auth"
+    fi
+
+    if grep -q '"key-auth"' "$ROUTE_MANIFEST"; then
+        fail "mlflow_route still enables key-auth"
+    else
+        pass "mlflow_route no longer enables key-auth"
+    fi
+
+    if grep -q '"key_claim_name": "iss"' "$ROUTE_MANIFEST"; then
+        pass "jwt-auth matches auth_service issuer claim"
+    else
+        fail "jwt-auth does not match auth_service issuer claim"
+    fi
+
+    if grep -q '"serverless-pre-function"' "$ROUTE_MANIFEST" && grep -q 'x-mlflow-jwt' "$ROUTE_MANIFEST"; then
+        pass "route normalizes Authorization Bearer tokens for APISIX jwt-auth"
+    else
+        fail "route does not normalize Authorization Bearer tokens for APISIX jwt-auth"
+    fi
+
+    if grep -q '/apisix/admin/consumers/auth-service-jwt' "$ROUTE_MANIFEST"; then
+        pass "job registers auth_service JWT APISIX consumer idempotently"
+    else
+        fail "job does not register auth_service JWT APISIX consumer"
+    fi
+
+    if grep -q 'AUTH_SERVICE_JWT_SECRET' "$ROUTE_MANIFEST"; then
+        pass "job reads auth_service JWT secret from environment"
+    else
+        fail "job does not read auth_service JWT secret from environment"
+    fi
+fi
+
+echo ""
+echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed ==="
+
+[ "$TESTS_FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- replace MLflow route key-auth with APISIX jwt-auth
- register an idempotent auth-service-jwt consumer using the shared auth_service HS256 secret
- normalize Authorization Bearer tokens into an internal jwt-auth header for MLflow clients
- document local secret/token setup in SECRETS.md

## Tests
- bash tests/unit/test_mlflow_apisix_jwt_auth.sh
- git diff --check

Fixes xenoISA/isA_Model#784