### PR TITLE
Enable local JupyterHub OAuth

### DIFF
--- a/deployments/kubernetes/local/values/jupyterhub.yaml
+++ b/deployments/kubernetes/local/values/jupyterhub.yaml
@@ -2,26 +2,47 @@
 # Chart: jupyterhub/jupyterhub 4.3.x
 # Tracking issue: xenoISA/isA_Model#771 (parent epic #763)
 #
-# Local-dev only — uses native (DummyAuthenticator) auth + the upstream
-# jupyter/scipy-notebook image with isa_model installed at spawn time via
-# lifecycleHooks.postStart. Production should use the custom singleuser image
-# from isA_Model deployment/docker/jupyterhub-singleuser.Dockerfile + OAuth
-# (already wired in deployments/helm/jupyterhub of isA_Model).
+# Local-dev only — uses isA Auth OAuth with the custom singleuser image
+# from isA_Model deployment/docker/jupyterhub-singleuser.Dockerfile.
 #
 # Profiles capped to small/medium (max 4Gi) — kind cluster has limited RAM.
 #
 # Reuses in-cluster PostgreSQL ('jupyterhub' db) for hub state.
 
 hub:
+  # OAuth client credentials:
+  #   kubectl -n isa-cloud-local create secret generic jupyterhub-oauth \
+  #     --from-literal=client-id=<isa-auth-client-id> \
+  #     --from-literal=client-secret=<isa-auth-client-secret>
+  # Crypt key:
+  #   kubectl -n isa-cloud-local create secret generic jupyterhub-crypt-key \
+  #     --from-literal=crypt-key="$(openssl rand -hex 32)"
   config:
     Authenticator:
       admin_users:
         - admin
     JupyterHub:
-      authenticator_class: dummy  # local dev — no real auth, any password works
+      authenticator_class: generic-oauth
       admin_access: true
-    DummyAuthenticator:
-      password: "isa-local-dev"  # documented dev default — see SECRETS.md note
+    GenericOAuthenticator:
+      client_id: "${OAUTH_CLIENT_ID}"
+      client_secret: "${OAUTH_CLIENT_SECRET}"
+      oauth_callback_url: "http://localhost:18000/hub/oauth_callback"
+      authorize_url: "http://127.0.0.1:8201/oauth/authorize"
+      token_url: "http://127.0.0.1:8201/oauth/token"
+      userdata_url: "http://127.0.0.1:8201/oauth/userinfo"
+      userdata_method: "GET"
+      username_claim: "preferred_username"
+      claim_groups_key: "roles"
+      admin_groups:
+        - "admin"
+      allow_all: true
+      scope:
+        - openid
+        - profile
+        - email
+        - roles
+      login_service: "isA Auth"
 
   db:
     type: postgres
@@ -34,6 +55,71 @@ hub:
         secretKeyRef:
           name: postgresql
           key: postgres-password
+    OAUTH_CLIENT_ID:
+      valueFrom:
+        secretKeyRef:
+          name: jupyterhub-oauth
+          key: client-id
+    OAUTH_CLIENT_SECRET:
+      valueFrom:
+        secretKeyRef:
+          name: jupyterhub-oauth
+          key: client-secret
+    JUPYTERHUB_CRYPT_KEY:
+      valueFrom:
+        secretKeyRef:
+          name: jupyterhub-crypt-key
+          key: crypt-key
+
+  extraConfig:
+    10-isa-auth-state: |
+      c.GenericOAuthenticator.enable_auth_state = True
+
+      import os
+      _crypt_key = os.environ.get("JUPYTERHUB_CRYPT_KEY")
+      if _crypt_key:
+          c.CryptKeeper.keys = [_crypt_key]
+
+      async def isa_auth_state_hook(spawner, auth_state):
+          if not auth_state:
+              spawner.log.warning(
+                  "No auth_state for %s; tenant isolation cannot be enforced",
+                  spawner.user.name,
+              )
+              return
+          oauth_user = auth_state.get("oauth_user", {}) or {}
+          spawner.userdata = {
+              "tenant_id": oauth_user.get("tenant_id")
+                  or oauth_user.get("org_id")
+                  or oauth_user.get("organization_id", ""),
+              "roles": oauth_user.get("roles", []),
+              "email": oauth_user.get("email", ""),
+              "user_id": oauth_user.get("sub", ""),
+          }
+
+      async def isa_pre_spawn_hook(spawner):
+          auth_state = await spawner.user.get_auth_state()
+          await isa_auth_state_hook(spawner, auth_state)
+          ud = getattr(spawner, "userdata", {}) or {}
+          tenant_id = ud.get("tenant_id", "")
+          if not tenant_id:
+              spawner.log.error(
+                  "Refusing to spawn %s: no tenant_id in OAuth claims",
+                  spawner.user.name,
+              )
+              raise RuntimeError(
+                  "isA Auth did not return a tenant_id claim; "
+                  "refusing to spawn untenanted notebook server."
+              )
+          spawner.environment.update({
+              "ISA_TENANT_ID": tenant_id,
+              "ISA_USER_ID": ud.get("user_id", ""),
+              "ISA_USER_EMAIL": ud.get("email", ""),
+              "ISA_USER_ROLES": ",".join(ud.get("roles", []) or []),
+          })
+
+      c.GenericOAuthenticator.auth_state_hook = isa_auth_state_hook
+      c.KubeSpawner.pre_spawn_hook = isa_pre_spawn_hook
 
   # Allow Prometheus to scrape /hub/metrics without a bearer token (local dev only).
   # Production wiring uses a service-token via `services:` block + scrape_configs

--- a/tests/unit/test_jupyterhub_oauth_local.sh
+++ b/tests/unit/test_jupyterhub_oauth_local.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Unit test: Validate local JupyterHub uses isA Auth OAuth, not DummyAuthenticator.
+# L1 — Static config validation, no live cluster needed.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VALUES_FILE="$REPO_ROOT/deployments/kubernetes/local/values/jupyterhub.yaml"
+
+pass() { echo -e "${GREEN}PASS${NC} $1"; ((TESTS_PASSED++)); }
+fail() { echo -e "${RED}FAIL${NC} $1"; ((TESTS_FAILED++)); }
+
+echo "=== Local JupyterHub OAuth Validation ==="
+
+if [ ! -f "$VALUES_FILE" ]; then
+    fail "local JupyterHub values file not found"
+else
+    if grep -q 'authenticator_class: generic-oauth' "$VALUES_FILE"; then
+        pass "JupyterHub uses GenericOAuthenticator"
+    else
+        fail "JupyterHub does not use GenericOAuthenticator"
+    fi
+
+    if grep -q 'DummyAuthenticator:' "$VALUES_FILE"; then
+        fail "DummyAuthenticator config is still present"
+    else
+        pass "DummyAuthenticator config is removed"
+    fi
+
+    if grep -q 'jupyterhub-oauth' "$VALUES_FILE" && grep -q 'jupyterhub-crypt-key' "$VALUES_FILE"; then
+        pass "OAuth client and crypt key secrets are referenced"
+    else
+        fail "OAuth client and crypt key secrets are not referenced"
+    fi
+
+    if grep -q 'http://localhost:18000/hub/oauth_callback' "$VALUES_FILE"; then
+        pass "local OAuth callback URL is configured"
+    else
+        fail "local OAuth callback URL is missing"
+    fi
+
+    if grep -q 'http://127.0.0.1:8201/oauth/authorize' "$VALUES_FILE" &&
+       grep -q 'http://127.0.0.1:8201/oauth/token' "$VALUES_FILE" &&
+       grep -q 'http://127.0.0.1:8201/oauth/userinfo' "$VALUES_FILE"; then
+        pass "local auth_service OAuth endpoints are configured"
+    else
+        fail "local auth_service OAuth endpoints are missing"
+    fi
+
+    if grep -q 'ISA_TENANT_ID' "$VALUES_FILE" && grep -q 'Refusing to spawn' "$VALUES_FILE"; then
+        pass "tenant claim propagation and refusal path are configured"
+    else
+        fail "tenant claim propagation/refusal path is missing"
+    fi
+fi
+
+echo ""
+echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed ==="
+
+[ "$TESTS_FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- switch local JupyterHub from DummyAuthenticator to GenericOAuthenticator against isA Auth
- wire jupyterhub-oauth and jupyterhub-crypt-key secrets
- propagate tenant/user claims to singleuser pods and refuse spawns without tenant_id
- add static config validation for the local JupyterHub OAuth values

Fixes xenoISA/isA_Model#788

## Tests
- bash tests/unit/test_jupyterhub_oauth_local.sh
- git diff --check