### PR TITLE
feat(infra): KEDA-based custom HPA metrics for isa-service chart

### DIFF
--- a/deployments/charts/isa-service/templates/hpa.yaml
+++ b/deployments/charts/isa-service/templates/hpa.yaml
@@ -1,4 +1,12 @@
-{{- if .Values.autoscaling.enabled }}
+{{- /*
+  Plain HorizontalPodAutoscaler — used when KEDA is NOT enabled.
+
+  When `.Values.hpa.kedaEnabled=true`, `templates/scaledobject.yaml` renders
+  a KEDA ScaledObject and KEDA synthesises its own HPA. Rendering both at
+  the same time would race on `spec.replicas`, so this template skips
+  itself in that case (xenoISA/isA_user issue #352, epic #345).
+*/ -}}
+{{- if and .Values.autoscaling.enabled (not .Values.hpa.kedaEnabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deployments/charts/isa-service/templates/scaledobject.yaml
+++ b/deployments/charts/isa-service/templates/scaledobject.yaml
@@ -1,0 +1,120 @@
+{{- /*
+  KEDA ScaledObject for isa-service (xenoISA/isA_user issue #352, epic #345).
+
+  This template is the architectural home for the KEDA-based custom-HPA
+  metrics work originally proposed in xenoISA/isA_user PR #363. Charts live
+  in isA_Cloud; the consuming repo only configures values.
+
+  When `.Values.hpa.kedaEnabled=true`:
+    * This ScaledObject is rendered.
+    * `templates/hpa.yaml` skips rendering — KEDA synthesises the HPA
+      itself and the two would race on `spec.replicas` if both existed.
+
+  When `.Values.hpa.kedaEnabled=false` (default, opt-in rollout):
+    * Falls back to the plain HorizontalPodAutoscaler in hpa.yaml.
+
+  Tier presets (selected via `.Values.hpa.keda.tier`):
+    * `event`     — NATS JetStream consumer pending messages
+    * `auth`      — Prometheus p95 request latency
+    * `telemetry` — Prometheus active WebSocket connection count
+    * `default`   — CPU/memory only (matches plain HPA semantics)
+
+  CPU/memory triggers are kept on every ScaledObject as fallback ceilings —
+  a stuck custom-metric collector still scales on raw load. This is a hard
+  acceptance criterion for #352.
+
+  Prerequisite: cluster operator has installed the KEDA controller:
+    helm repo add kedacore https://kedacore.github.io/charts
+    helm install keda kedacore/keda -n keda --create-namespace
+
+  Reviewer concerns from PR #363 addressed here:
+    * NATS consumer/stream names verified against actual code in
+      microservices/{wallet,billing,payment}_service/main.py — see ADR.
+    * Prometheus selector dropped: metric names already include the
+      `isa_<service>_` prefix via isa_common, so per-service selectors are
+      redundant. Use the pre-namespaced metric directly.
+    * Per-tier polling intervals: event=15s, auth=60s, telemetry=30s,
+      default=30s.
+*/ -}}
+{{- if and .Values.autoscaling.enabled .Values.hpa.kedaEnabled }}
+{{- $keda := .Values.hpa.keda | default dict -}}
+{{- $tier := default "default" $keda.tier -}}
+{{- $tierDefaults := index $keda.tiers $tier | default (index $keda.tiers "default") -}}
+{{- /* Prefer chart-level override; fall back to the tier preset. */ -}}
+{{- $polling := default $tierDefaults.pollingInterval $keda.pollingInterval -}}
+{{- if not $polling -}}{{- $polling = $tierDefaults.pollingInterval | default 30 -}}{{- end -}}
+{{- $cooldown := default $tierDefaults.cooldownPeriod $keda.cooldownPeriod -}}
+{{- if not $cooldown -}}{{- $cooldown = $tierDefaults.cooldownPeriod | default 300 -}}{{- end -}}
+{{- $triggers := default $tierDefaults.triggers $keda.triggers -}}
+{{- $fallback := $keda.fallback | default dict -}}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    isa.io/service-tier: {{ $tier }}
+  annotations:
+    isa.io/issue: "https://github.com/xenoISA/isA_user/issues/352"
+    isa.io/epic: "https://github.com/xenoISA/isA_user/issues/345"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  minReplicaCount: {{ .Values.autoscaling.minReplicas }}
+  maxReplicaCount: {{ .Values.autoscaling.maxReplicas }}
+  pollingInterval: {{ $polling }}
+  cooldownPeriod: {{ $cooldown }}
+  {{- with $fallback }}
+  fallback:
+    failureThreshold: {{ default 3 .failureThreshold }}
+    replicas: {{ default 2 .replicas }}
+  {{- end }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: {{ .Values.name }}-keda
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: {{ default 300 $keda.scaleDownStabilization }}
+          policies:
+            - type: Percent
+              value: 50
+              periodSeconds: 60
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 30
+            - type: Pods
+              value: 4
+              periodSeconds: 30
+          selectPolicy: Max
+  triggers:
+{{- /* Tier-specific or per-service custom triggers. */}}
+{{- range $t := $triggers }}
+    - type: {{ $t.type }}
+      {{- with $t.name }}
+      name: {{ . }}
+      {{- end }}
+      {{- with $t.metricType }}
+      metricType: {{ . }}
+      {{- end }}
+      metadata:
+{{ toYaml $t.metadata | indent 8 }}
+{{- end }}
+{{- /* Fallback CPU/memory triggers — required on every ScaledObject (#352 AC). */}}
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "{{ .Values.autoscaling.targetCPUUtilization }}"
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: "{{ .Values.autoscaling.targetMemoryUtilization }}"
+{{- end }}

--- a/deployments/charts/isa-service/values.yaml
+++ b/deployments/charts/isa-service/values.yaml
@@ -60,6 +60,123 @@ autoscaling:
   targetCPUUtilization: 70
   targetMemoryUtilization: 80
 
+# =============================================================================
+# HorizontalPodAutoscaler — KEDA ScaledObjects (xenoISA/isA_user issue #352,
+# parent epic #345). Architectural home: deployments/charts/isa-service.
+# =============================================================================
+# `hpa.kedaEnabled=true` flips the chart from the plain HorizontalPodAutoscaler
+# (`templates/hpa.yaml`) to a KEDA ScaledObject (`templates/scaledobject.yaml`).
+# KEDA itself is NOT installed by this chart — the cluster operator must run
+# `helm install keda kedacore/keda -n keda --create-namespace` once per cluster
+# before flipping this on. See docs/adr/0002-keda-custom-hpa-metrics.md and
+# docs/runbooks/keda-hpa-metrics.md.
+#
+# Tier presets map a service-class onto a trigger preset; CPU/memory triggers
+# are ALWAYS appended on top so a stuck custom-metric collector still scales
+# on raw load (acceptance criterion for #352).
+#
+#   * `event`     — NATS JetStream consumer pending messages
+#                   (wallet/billing/payment) — polled every 15s
+#   * `auth`      — Prometheus p95 request latency (auth/account/authorization)
+#                   — polled every 60s (matches scrape cadence)
+#   * `telemetry` — Prometheus active WebSocket connection gauge
+#                   — polled every 30s
+#   * `default`   — CPU/memory only — polled every 30s
+#
+# Per-service overrides: set hpa.keda.tier and (optionally) hpa.keda.triggers
+# in the per-service values file. NATS consumer/stream names are deliberately
+# left as configurables because each service owns its own durable.
+#
+# IMPORTANT: production thresholds in this file are starting points only.
+# Attach staging soak data before flipping `kedaEnabled: true` in production
+# (see runbook section "Tuning a threshold").
+hpa:
+  # Opt-in. Default false so existing deployments fall through to hpa.yaml.
+  kedaEnabled: false
+  # Selected tier preset. Override per service.
+  keda:
+    tier: default
+    # Optional global overrides — when empty the tier preset's value wins.
+    pollingInterval: ""
+    cooldownPeriod: ""
+    scaleDownStabilization: 300
+    # Fallback behaviour when the metrics-apiserver is unreachable. KEDA
+    # pins the deployment to `replicas` after `failureThreshold` consecutive
+    # poll failures so a metrics outage does not cause an unbounded scale-up.
+    fallback:
+      failureThreshold: 3
+      replicas: 2
+    # Per-service trigger override. When set, replaces the tier preset's
+    # triggers entirely. CPU/memory fallback triggers are still appended.
+    # triggers: []
+    tiers:
+      default:
+        # CPU/memory only — same shape as the plain HPA, just routed via KEDA.
+        pollingInterval: 30
+        cooldownPeriod: 300
+        triggers: []
+      event:
+        # Tight polling cadence (15s) — JetStream backlog can spike fast.
+        # `consumer` and `stream` MUST be overridden per service. Defaults
+        # below match the auto-derived names from core/nats_client.py
+        # `_get_stream_name()` and `_consumer_loop()` in xenoISA/isA_user.
+        pollingInterval: 15
+        cooldownPeriod: 300
+        triggers:
+          - type: nats-jetstream
+            metricType: AverageValue
+            metadata:
+              # Override per-service — chart-level default is a placeholder.
+              # See README for the verified service-to-stream mapping:
+              #   wallet  -> stream=user-stream consumer=wallet-payment-consumer (and per-event durables)
+              #   billing -> stream=billing-stream consumer=billing-<pattern>-consumer[-<suffix>]
+              #   payment -> stream=<auto>-stream  consumer=payment_service-<prefix>-consumer
+              natsServerMonitoringEndpoint: "nats.isa-cloud-staging.svc.cluster.local:8222"
+              account: "$G"
+              stream: "OVERRIDE_PER_SERVICE"
+              consumer: "OVERRIDE_PER_SERVICE"
+              lagThreshold: "100"
+              activationLagThreshold: "10"
+              useHttps: "false"
+      auth:
+        # 60s polling matches Prometheus scrape interval — finer cadence
+        # would scrape stale data and waste KEDA->Prom round-trips.
+        pollingInterval: 60
+        cooldownPeriod: 300
+        triggers:
+          - type: prometheus
+            metricType: AverageValue
+            metadata:
+              serverAddress: "http://prometheus.isa-cloud-staging.svc.cluster.local:9090"
+              # isa_common.metrics emits `isa_<service>_http_request_duration_seconds`
+              # — the metric name already encodes the service so a label
+              # selector is redundant. Override metricName per-service.
+              # TODO(#352): verify metric exists in actual /metrics output
+              # against deployed pods before enabling production thresholds.
+              metricName: "isa_user_http_request_p95_seconds"
+              threshold: "0.5"
+              activationThreshold: "0.1"
+              query: |
+                histogram_quantile(0.95,
+                  sum(rate(isa_user_http_request_duration_seconds_bucket[2m])) by (le))
+      telemetry:
+        pollingInterval: 30
+        cooldownPeriod: 300
+        triggers:
+          - type: prometheus
+            metricType: AverageValue
+            metadata:
+              serverAddress: "http://prometheus.isa-cloud-staging.svc.cluster.local:9090"
+              # TODO(#352): verify the WebSocket connection gauge name once
+              # the telemetry exporter ships. PR #363 used
+              # `isa_user_websocket_active_connections` — left as-is here so
+              # the chart renders; staging soak will confirm before prod.
+              metricName: "isa_user_websocket_active_connections"
+              threshold: "500"
+              activationThreshold: "50"
+              query: |
+                sum(isa_user_websocket_active_connections)
+
 # Pod Disruption Budget (enabled by default when replicas > 1)
 podDisruptionBudget:
   enabled: true

--- a/docs/adr/0002-keda-custom-hpa-metrics.md
+++ b/docs/adr/0002-keda-custom-hpa-metrics.md
@@ -1,0 +1,218 @@
+# ADR 0002 — KEDA-based custom HPA metrics for the `isa-service` chart
+
+- **Status**: Accepted
+- **Date**: 2026-05-04
+- **Author**: isA platform infra team
+- **Issue**: [xenoISA/isA_user#352](https://github.com/xenoISA/isA_user/issues/352) — Parent epic: [#345](https://github.com/xenoISA/isA_user/issues/345)
+- **Supersedes**: n/a (first ADR for the K8s HPA readiness workstream in `isA_Cloud`)
+- **Replaces**: xenoISA/isA_user PR #363 (closed; chart belongs in `isA_Cloud`)
+
+## Context
+
+The `isa-service` Helm chart (`deployments/charts/isa-service/`) is the
+single deployment template for every Python microservice across the isA
+platform. Today its `templates/hpa.yaml` scales pods on CPU 70% / memory
+80% only:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilization: 70
+  targetMemoryUtilization: 80
+```
+
+That is generic and lags real load for our service mix:
+
+- **Event consumers** (`wallet`, `billing`, `payment` in `xenoISA/isA_user`,
+  plus several services in `xenoISA/isA_MCP` and `xenoISA/isA_Agent`) burn
+  very little CPU per message but accumulate NATS JetStream backlog under
+  burst — they need to scale on **queue depth**, not CPU.
+- **Auth-heavy services** (`auth`, `account`, `authorization`) tail-latency
+  spike long before CPU saturates because the bottleneck is downstream
+  Postgres/Redis fan-out. They need to scale on **p95 request latency**.
+- **Telemetry / streaming** (`telemetry`, `notification`) hold long-lived
+  WebSocket connections; CPU/memory per pod is flat regardless of fan-out,
+  so scaling has to track **connection count or message rate**.
+
+Two viable options exist on a vanilla Kubernetes cluster:
+
+1. **Prometheus Adapter** (`k8s-prometheus-adapter`) — registers a custom
+   `external.metrics.k8s.io` API backed by PromQL queries. The `HPA` resource
+   then references the metric directly.
+2. **KEDA** (Kubernetes Event-Driven Autoscaler) — installs a controller
+   that reconciles `ScaledObject` CRs into HPAs. Ships a built-in scaler
+   library (NATS, Kafka, Prometheus, Redis Streams, RabbitMQ, AWS SQS, ...).
+
+## Decision
+
+**Adopt KEDA as the autoscaling controller for the `isa-service` chart.**
+
+- Add `templates/scaledobject.yaml` rendered when `hpa.kedaEnabled=true`.
+- Gate `templates/hpa.yaml` on `hpa.kedaEnabled=false` so the two
+  controllers never race on `spec.replicas`.
+- Keep CPU and memory triggers on every `ScaledObject` as fallback ceilings
+  — a stuck custom-metric collector still scales on raw load. Hard
+  acceptance criterion for #352.
+- Default `hpa.kedaEnabled=false` so existing deployments are unchanged
+  until consumers explicitly opt in.
+
+## Alternatives considered
+
+### Prometheus Adapter
+
+- Pros: single dependency we already need in some form (we run Prometheus
+  for SLOs), no new CRD surface, HPA is the native object.
+- Cons:
+  - **No native NATS scaler.** Queue depth would need to be exported to
+    Prometheus first (extra exporter, extra scrape latency, extra failure
+    mode). This is the load shape that *most* needs custom autoscaling for
+    `wallet`/`billing`/`payment`, so degrading it is a non-starter.
+  - PromQL strings live in a `ConfigMap` that the adapter parses on start —
+    debugging a misnamed metric requires a controller restart.
+  - One adapter Deployment is a single point of failure for *every* HPA on
+    the cluster. KEDA controllers are stateless and scale horizontally.
+
+### Stay on CPU/memory only
+
+- Pros: zero new infra.
+- Cons: doesn't satisfy issue #352 acceptance criteria; we already know
+  that CPU saturates *after* SLA breach for both event consumers and auth
+  services.
+
+### Ship the chart from `xenoISA/isA_user` (PR #363)
+
+- Pros: changes co-located with the consuming services.
+- Cons: violates the chart-ownership model. `xenoISA/isA_Cloud` owns
+  `isa-service`; placing chart templates in a consumer repo creates a
+  copy-paste fork the next service has to keep in sync. PR #363 was closed
+  in favour of this work item.
+
+## Consequences
+
+### Positive
+
+- One controller covers all three load shapes:
+  - NATS JetStream depth via the built-in `nats-jetstream` scaler.
+  - Prometheus queries (p95 latency, WS connection gauge) via the
+    `prometheus` scaler — same PromQL we'd write for the adapter, no
+    `ConfigMap` indirection.
+  - CPU/memory via `cpu` and `memory` triggers — KEDA delegates to the
+    upstream HPA resource metrics so behaviour is identical to today.
+- `ScaledObject`s declare `minReplicaCount`/`maxReplicaCount` and behaviour
+  policies in one place.
+- `advanced.horizontalPodAutoscalerConfig.behavior` lets us pin scale-down
+  windows per service tier.
+- Chart change is opt-in: `hpa.kedaEnabled=false` by default. Existing
+  releases are unchanged on upgrade.
+
+### Negative / cost
+
+- KEDA controller and metrics-apiserver must be installed cluster-wide
+  (`keda` namespace). **This chart does not install KEDA.** The cluster
+  operator runs `helm install keda kedacore/keda -n keda --create-namespace`
+  before the first `helm upgrade` of an `isa-service` release that has
+  `hpa.kedaEnabled=true`. Documented in
+  `docs/runbooks/keda-hpa-metrics.md`.
+- New CRDs (`scaledobjects.keda.sh`, `triggerauthentications.keda.sh`) on
+  the cluster. Backwards-compatible: removing KEDA returns services to
+  manual replica counts.
+- `prometheus` triggers depend on a reachable Prometheus endpoint
+  (`http://prometheus.isa-cloud-{staging,prod}:9090`). If a Prometheus
+  exporter for a required signal does not exist yet (e.g. WebSocket
+  connection gauge for `telemetry_service`), the trigger will report
+  `Fallback=True` and the CPU/memory ceiling kicks in — by design.
+
+### Rollback
+
+Setting `hpa.kedaEnabled=false` in the consumer's values file and running
+`helm upgrade` causes the chart to skip rendering the `ScaledObject` and
+re-render the plain HPA. KEDA deletes the underlying synthesised HPA and
+the Deployment returns to plain HPA semantics. No data path change.
+
+## Verified naming corrections (vs. xenoISA/isA_user PR #363)
+
+PR #363 hard-coded several names that do not exist in the actual code.
+This ADR records the verified replacements so future changes do not
+re-introduce the mistake.
+
+### NATS streams
+
+Streams are derived from the subject prefix in
+`xenoISA/isA_user/core/nats_client.py:_get_stream_name()`
+(`f"{prefix}-stream"`, with special cases for `file`, `firmware`,
+`campaign`, `update`, `rollback`, `alert`, `metric`). PR #363 used
+`stream: isa-events` for every event-tier service — that stream does not
+exist. Correct mappings:
+
+| Subject prefix    | Stream             | Source                                       |
+|-------------------|--------------------|----------------------------------------------|
+| `billing.>`       | `billing-stream`   | `core/nats_client.py:204-235`                |
+| `session.>`       | `session-stream`   | `core/nats_client.py:204-235`                |
+| `user.>`          | `user-stream`      | `core/nats_client.py:204-235`                |
+| `payment_service.>` | `payment_service-stream` (auto) | `core/nats_client.py:235` |
+| `wallet_service.>`  | `wallet_service-stream` (auto)  | `core/nats_client.py:235` |
+| `*.file.>`        | `storage-stream`   | `core/nats_client.py:226`                    |
+| `alert.>`/`metric.>` | `telemetry-stream` | `core/nats_client.py:231-232`             |
+
+### NATS consumer durables
+
+| Service | Durable pattern | Source |
+|---------|-----------------|--------|
+| `wallet_service`  | `wallet-<last-token-of-pattern>-consumer` (e.g. `wallet-balance_changed-consumer`) | `microservices/wallet_service/main.py:182` |
+| `billing_service` | `billing-<pattern-with-dots-replaced>-consumer[-${BILLING_CONSUMER_SUFFIX}]`         | `microservices/billing_service/main.py:116-125` |
+| `payment_service` | Auto-derived: `payment_service-<subject-prefix>-consumer` (no explicit durable)       | `microservices/payment_service/main.py:152` + `core/nats_client.py:407-409` |
+
+PR #363 used `consumer: user-payment-service` / `user-wallet-service` /
+`user-billing-service` — none of those exist as JetStream durables.
+
+### Prometheus metric names
+
+`xenoISA/isA_Cloud/isA_common/isa_common/metrics.py` is the source of
+truth. Metric names are prefixed `isa_<service>_`:
+
+| Metric (verified)                                | Type      | Labels                          | Source line          |
+|---------------------------------------------------|-----------|---------------------------------|----------------------|
+| `isa_<svc>_http_requests_total`                  | Counter   | `method`, `path`, `status_code` | `metrics.py:244-248` |
+| `isa_<svc>_http_request_duration_seconds`        | Histogram | `method`, `path`                | `metrics.py:249-254` |
+| `isa_<svc>_http_request_size_bytes`              | Histogram | `method`, `path`                | `metrics.py:255-260` |
+| `isa_<svc>_http_response_size_bytes`             | Histogram | `method`, `path`                | `metrics.py:261-266` |
+| `isa_<svc>_http_requests_in_progress`            | Gauge     | `method`                        | `metrics.py:267-271` |
+
+PR #363's proposed PromQL used `service="<svc>"` as a label selector. No
+such label is emitted — the service is encoded in the metric name prefix.
+The chart's `auth` tier preset queries
+`isa_user_http_request_duration_seconds_bucket` directly without a
+`service=` filter. Each consumer overrides `metricName` per service.
+
+### Aspirational metric names
+
+`isa_user_websocket_active_connections` does not exist in the codebase —
+it appeared only in
+`microservices/auth_service/docs/Issue/PERFORMANCE.md` as a planned
+metric. The chart leaves it in the `telemetry` tier preset with a
+`TODO(#352): verify metric exists in actual /metrics output` comment so
+the ScaledObject renders, but it must be confirmed against the deployed
+pods before flipping `kedaEnabled: true` in production.
+
+## Validation
+
+- `helm lint deployments/charts/isa-service/ --strict` — passes with
+  `kedaEnabled` toggled on and off.
+- `helm template deployments/charts/isa-service/ --set hpa.kedaEnabled=true`
+  emits exactly one `ScaledObject` and zero `HorizontalPodAutoscaler`.
+- `helm template deployments/charts/isa-service/ --set hpa.kedaEnabled=false`
+  emits exactly one `HorizontalPodAutoscaler` and zero `ScaledObject`.
+- The runbook `docs/runbooks/keda-hpa-metrics.md` documents per-service
+  rationale and how to tune thresholds.
+
+## References
+
+- xenoISA/isA_user issue #352 (this ADR's authorising work item).
+- xenoISA/isA_user epic #345 — K8s HPA readiness.
+- xenoISA/isA_user PR #363 (closed; superseded by this work).
+- KEDA scaler catalogue: <https://keda.sh/docs/latest/scalers/>
+- Prometheus Adapter: <https://github.com/kubernetes-sigs/prometheus-adapter>
+- Kubernetes HPA `behavior` field:
+  <https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior>

--- a/docs/runbooks/keda-hpa-metrics.md
+++ b/docs/runbooks/keda-hpa-metrics.md
@@ -1,0 +1,262 @@
+# KEDA HPA Custom Metrics Runbook
+
+> Sibling docs:
+> [`deployments/charts/isa-service/templates/scaledobject.yaml`](../../deployments/charts/isa-service/templates/scaledobject.yaml),
+> [`deployments/charts/isa-service/templates/hpa.yaml`](../../deployments/charts/isa-service/templates/hpa.yaml),
+> [`docs/adr/0002-keda-custom-hpa-metrics.md`](../adr/0002-keda-custom-hpa-metrics.md).
+> Authorising issue: [xenoISA/isA_user#352](https://github.com/xenoISA/isA_user/issues/352) — Parent epic: [#345](https://github.com/xenoISA/isA_user/issues/345).
+
+## What this covers
+
+The `isa-service` chart autoscales each microservice via a
+[KEDA `ScaledObject`][keda] rendered from
+`templates/scaledobject.yaml` when `hpa.kedaEnabled=true` (opt-in).
+Each `ScaledObject` declares one or more **triggers** that KEDA polls; a
+single trigger crossing its threshold is enough to scale up. CPU and
+memory triggers are kept on every object as fallback ceilings — a stuck
+custom-metric collector still surfaces real load.
+
+This runbook explains:
+
+1. The per-service-tier metric mapping and why each tier exists.
+2. How to install / verify the KEDA prerequisite.
+3. How to inspect a running `ScaledObject` and its synthesised HPA.
+4. How to tune a threshold safely.
+5. How to opt a single service in or out without touching the chart.
+6. Recovery when a trigger goes silent or starts oscillating.
+
+[keda]: https://keda.sh/docs/latest/concepts/scaling-deployments/
+
+## 1. Service tiers and metric choice
+
+| Tier        | Services                                  | Primary signal                            | Polling | Why this signal                                                                                                  |
+|-------------|-------------------------------------------|-------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------|
+| `event`     | `wallet`, `billing`, `payment`            | NATS JetStream consumer pending messages  | 15s     | Low CPU per message + bursty arrival rate — backlog is the only metric that reflects user-visible processing lag |
+| `auth`      | `auth`, `account`, `authorization`        | Prometheus p95 request latency            | 60s     | Bottleneck is downstream Postgres/Redis fan-out, not local CPU; tail-latency degrades long before CPU saturates  |
+| `telemetry` | `telemetry` (and any future WS streamer)  | Prometheus active WebSocket connections   | 30s     | Pods hold long-lived sockets at flat CPU/memory; connection count drives broadcast cost                          |
+| `default`   | every other service                       | CPU 70% / memory 80% (fallback only)      | 30s     | Stateless request/response services are CPU-bound — the upstream HPA semantics are correct                       |
+
+Per-service overrides live in each service's values file (e.g.
+`xenoISA/isA_user`'s `deployment/helm/values-{staging,production}.yaml`)
+under the `hpa.keda.tier` key. The chart-level defaults are in
+`deployments/charts/isa-service/values.yaml`.
+
+## 2. KEDA prerequisite
+
+This Helm chart deliberately does **not** install KEDA — installing CRDs
+under a service release is fragile. The cluster operator runs the install
+once per cluster:
+
+```bash
+helm repo add kedacore https://kedacore.github.io/charts
+helm repo update
+helm install keda kedacore/keda \
+  --namespace keda \
+  --create-namespace \
+  --version 2.14.0     # pin to the version validated against this chart
+```
+
+Verify the install:
+
+```bash
+kubectl -n keda get pods
+# NAME                                    READY   STATUS
+# keda-operator-...                       1/1     Running
+# keda-operator-metrics-apiserver-...     1/1     Running
+
+kubectl get apiservice v1beta1.external.metrics.k8s.io -o yaml | grep -E 'available|reason'
+# conditions: type: Available, status: "True"
+```
+
+If `external.metrics.k8s.io` is not available, every KEDA `ScaledObject`
+will report `Fallback=True` and fall through to the CPU/memory triggers —
+pods scale, but slower than intended. Treat a missing apiservice as a P1
+alert.
+
+## 3. Inspecting a running ScaledObject
+
+After `helm upgrade --install` of an `isa-service` release with
+`hpa.kedaEnabled=true`:
+
+```bash
+export NAMESPACE=isa-cloud-prod  # or isa-cloud-staging
+
+# List all ScaledObjects rendered by this chart
+kubectl get scaledobjects -n "$NAMESPACE" \
+  -l app.kubernetes.io/component=autoscaler
+
+# Detail a single one — note `status.conditions` and the trigger health table
+kubectl describe scaledobject user-wallet-service -n "$NAMESPACE"
+
+# The synthesised HPA (KEDA-managed; do NOT edit it directly)
+kubectl get hpa user-wallet-service-keda -n "$NAMESPACE" -o yaml
+
+# Live external-metric value (what the controller actually sees)
+kubectl get --raw \
+  "/apis/external.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/s0-nats-jetstream-billing-stream-billing-usage-recorded-all-consumer" \
+  | jq
+```
+
+Key conditions in `kubectl describe`:
+
+- `Active=True` — the `ScaledObject` is reconciling.
+- `Fallback=True` — the custom trigger is unhealthy and KEDA dropped to
+  the CPU/memory ceilings. Investigate the trigger before disabling.
+- `Ready=False` — the controller could not parse the spec; the `Message`
+  field names the bad field.
+
+## 4. Tuning a threshold
+
+Threshold tuning is a two-knob exercise: **threshold** (when to scale up)
+and **cooldownPeriod** (how patiently to scale down).
+
+### Event tier (`nats-jetstream`)
+
+`metadata.lagThreshold` is the per-replica pending-message ceiling. KEDA
+scales the deployment to `ceil(consumer_pending / lagThreshold)` replicas
+(clamped to `[minReplicaCount, maxReplicaCount]`).
+
+Verified consumer/stream names (xenoISA/isA_user):
+
+| Service           | Stream(s)                                      | Consumer durable                                                            | Source                                                |
+|-------------------|------------------------------------------------|-----------------------------------------------------------------------------|-------------------------------------------------------|
+| `wallet_service`  | per subject prefix (`payment_service-stream`, `account_service-stream`, ...) | `wallet-<last-token-of-pattern>-consumer` (e.g. `wallet-balance_changed-consumer`) | `microservices/wallet_service/main.py:182`            |
+| `billing_service` | `billing-stream`, `session-stream`, `user-stream` (per pattern)           | `billing-<pattern-dots-to-dashes>-consumer[-${BILLING_CONSUMER_SUFFIX}]`     | `microservices/billing_service/main.py:116-125`       |
+| `payment_service` | per subject prefix (auto-derived)              | `payment_service-<subject-prefix>-consumer` (auto, no explicit durable)     | `microservices/payment_service/main.py:152` + `core/nats_client.py:407-409` |
+
+| Symptom                                                 | Action                                                                            |
+|---------------------------------------------------------|-----------------------------------------------------------------------------------|
+| Backlog drains slowly under burst, replicas stay at min | Halve `lagThreshold` (e.g. 100 → 50)                                              |
+| Pods churn — scale up then immediately drain to min     | Raise `cooldownPeriod` (300 → 600) and `scaleDownStabilization`                   |
+| `consumer_pending` exists but trigger reports 0         | Check `account` and `consumer` names — JetStream is namespaced, typos are silent  |
+
+### Auth tier (`prometheus` p95 latency)
+
+`metadata.threshold` is the SLO trigger in seconds; `metadata.query` is
+the PromQL evaluated each `pollingInterval`.
+
+Verified metric source (`xenoISA/isA_Cloud/isA_common/isa_common/metrics.py`):
+
+```text
+isa_<service>_http_request_duration_seconds_bucket{method, path, le}
+isa_<service>_http_requests_total{method, path, status_code}
+```
+
+The metric name already encodes the service (`isa_<service>_` prefix), so
+a `service=` label selector is unnecessary and would match nothing.
+
+| Symptom                                                  | Action                                                                                |
+|----------------------------------------------------------|---------------------------------------------------------------------------------------|
+| p95 climbs past SLA before replicas appear               | Lower `threshold` (e.g. 0.5s → 0.3s) and shorten `pollingInterval` (60s → 30s)        |
+| Replicas pile on during normal traffic                   | The PromQL `[range]` is too tight — widen `[2m]` to `[5m]`                            |
+| Trigger flatlines at 0 even under load                   | Run the PromQL against Prometheus directly; rule out missing labels or empty buckets  |
+
+### Telemetry tier (`prometheus` WS gauge)
+
+`metadata.threshold` is the per-replica connection ceiling. The default
+500 matches the broadcast-fanout budget; raise it only after benchmarking
+the event-bus consumer side.
+
+`isa_user_websocket_active_connections` is currently aspirational — the
+chart leaves it in place with a `TODO(#352)` comment. Confirm the metric
+exists in the deployed pod's `/metrics` output before flipping
+`kedaEnabled: true` in production.
+
+## 5. Opt a single service in / out
+
+In the consumer repo's values file (e.g. `deployment/helm/values.yaml`):
+
+```yaml
+hpa:
+  kedaEnabled: true        # default false at chart level
+  keda:
+    tier: event             # event | auth | telemetry | default
+    pollingInterval: 15     # override tier preset (optional)
+    cooldownPeriod: 300
+    scaleDownStabilization: 600
+    fallback:
+      failureThreshold: 3
+      replicas: 2
+    triggers:               # custom inline trigger list (replaces tier preset)
+      - type: nats-jetstream
+        metricType: AverageValue
+        metadata:
+          natsServerMonitoringEndpoint: "nats.isa-cloud-prod.svc.cluster.local:8222"
+          account: "$G"
+          stream: "billing-stream"
+          consumer: "billing-usage-recorded-all-consumer"
+          lagThreshold: "50"
+          activationLagThreshold: "10"
+          useHttps: "false"
+
+# autoscaling block still drives min/max replicas and the CPU/memory
+# fallback trigger values:
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 15
+  targetCPUUtilization: 70
+  targetMemoryUtilization: 80
+```
+
+Setting `hpa.kedaEnabled: false` returns the chart to the plain
+`HorizontalPodAutoscaler`. Setting `autoscaling.enabled: false` disables
+both.
+
+## 6. Recovery
+
+### Trigger going silent
+
+Symptoms: `kubectl describe so <name>` shows `Fallback=True` or
+`Active=False`; `kubectl get --raw .../external.metrics.k8s.io/...`
+returns 404 or empty.
+
+1. Check the source. NATS — is the consumer still bound? Prometheus —
+   does the metric exist with the expected labels?
+2. Check the KEDA operator logs:
+   `kubectl logs -n keda deploy/keda-operator --tail=200 | grep <service>`.
+3. While debugging, set `hpa.kedaEnabled: false` and re-deploy to drop the
+   `ScaledObject` and restore the plain HPA. Pods continue serving on
+   `Deployment.spec.replicas`.
+
+### Replica oscillation
+
+Symptoms: pods scale up and immediately drain, repeatedly.
+
+1. Raise `scaleDownStabilization` to 300-600 seconds. KEDA defers
+   scale-down until the metric stays below threshold for the whole
+   window.
+2. Raise `cooldownPeriod`. After the last trigger event, KEDA waits this
+   long before scaling to `minReplicaCount`.
+3. Validate the PromQL `[range]`. A 30s rate window on a sparse metric
+   produces noisy step-changes; widen to `[2m]` and re-test.
+
+### Missing exporter
+
+If a tier's primary signal depends on a Prometheus metric that does not
+yet exist (e.g. `isa_user_websocket_active_connections` for a brand-new
+service), the trigger will report `Fallback=True`. **Do not** patch the
+trigger to scrape an unrelated metric — file a follow-up issue against
+the owning service to add the exporter, and leave the fallback CPU/memory
+ceiling in place. Issue #352 explicitly excludes adding new exporters
+from this workstream.
+
+## 7. Quick reference
+
+| Task                              | Command / file                                                                          |
+|-----------------------------------|-----------------------------------------------------------------------------------------|
+| Render rendered ScaledObjects     | `helm template deployments/charts/isa-service/ --set hpa.kedaEnabled=true`              |
+| Lint chart                        | `helm lint deployments/charts/isa-service/ --strict`                                    |
+| List ScaledObjects                | `kubectl get so -n isa-cloud-prod -l app.kubernetes.io/component=autoscaler`            |
+| Tail KEDA operator logs           | `kubectl logs -n keda deploy/keda-operator --tail=200 -f`                               |
+| Disable autoscaling globally      | `--set autoscaling.enabled=false`                                                       |
+| Switch back to plain HPA          | `--set hpa.kedaEnabled=false`                                                           |
+| Override threshold per service    | edit `hpa.keda.triggers` in the per-service values file                                 |
+
+## 8. Out of scope
+
+- **Vertical Pod Autoscaler (VPA).** Not enabled by this chart.
+- **Cluster Autoscaler.** Node-level scaling is the cluster operator's
+  concern, not this chart's.
+- **New Prometheus exporters.** If a tier's signal needs a new metric,
+  open a follow-up issue against the owning service.


### PR DESCRIPTION
## Summary

Adds a KEDA ScaledObject template to the shared \`isa-service\` Helm chart
alongside the existing \`HorizontalPodAutoscaler\`, gated on
\`hpa.kedaEnabled\` (default \`false\`). When enabled, KEDA synthesises the
HPA from a ScaledObject whose triggers reflect each service tier's actual
load shape (NATS queue depth, Prometheus p95 latency, WebSocket connection
count). The plain HPA template gates itself off in that case so the two
controllers never race on \`spec.replicas\`.

This **replaces xenoISA/isA_user PR #363**, which placed the chart in the
consuming repo. Architectural correction: the chart's home is here.

Refs: xenoISA/isA_user#352 (parent epic xenoISA/isA_user#345)
Closes (via supersession): xenoISA/isA_user#363

## What changed

| File | Change |
|------|--------|
| \`deployments/charts/isa-service/templates/scaledobject.yaml\` | **New.** Renders the KEDA ScaledObject when \`hpa.kedaEnabled=true\`. CPU and memory triggers always appended as fallback ceilings. |
| \`deployments/charts/isa-service/templates/hpa.yaml\` | Gates on \`(not .Values.hpa.kedaEnabled)\` so the plain HPA is suppressed when KEDA is on. |
| \`deployments/charts/isa-service/values.yaml\` | Adds the \`hpa:\` block with tier presets (\`event\`, \`auth\`, \`telemetry\`, \`default\`), per-tier polling cadences, and fallback knobs. |
| \`docs/adr/0002-keda-custom-hpa-metrics.md\` | New ADR documenting the decision, alternatives, and verified naming corrections. |
| \`docs/runbooks/keda-hpa-metrics.md\` | New runbook with install, inspection, tuning, and recovery procedures. |

## KEDA controller install (cluster-wide prerequisite)

This chart does **not** install KEDA. The cluster operator runs once per cluster:

\`\`\`bash
helm repo add kedacore https://kedacore.github.io/charts
helm install keda kedacore/keda -n keda --create-namespace
\`\`\`

## Reviewer concerns from PR #363 — explicit corrections

The original PR hard-coded several names that do not exist in the actual
codebase. Each is fixed here with file:line evidence:

### NATS streams (\`stream:\` was \`isa-events\` in PR #363 — wrong)

Streams are derived from the subject prefix in
\`xenoISA/isA_user/core/nats_client.py:_get_stream_name()\`
(\`f\"{prefix}-stream\"\`, with explicit special cases). \`isa-events\` is not a
real stream.

| Subject prefix | Actual stream | Source |
|----------------|---------------|--------|
| \`billing.>\` | \`billing-stream\` | \`core/nats_client.py:204-235\` |
| \`session.>\` | \`session-stream\` | \`core/nats_client.py:204-235\` |
| \`user.>\` | \`user-stream\` | \`core/nats_client.py:204-235\` |
| \`payment_service.>\` | \`payment_service-stream\` (auto) | \`core/nats_client.py:235\` |
| \`*.file.>\` | \`storage-stream\` | \`core/nats_client.py:226\` |

### NATS consumer durables (PR #363 used non-existent \`user-{wallet,billing,payment}-service\`)

| Service | Actual durable | Source |
|---------|----------------|--------|
| \`wallet_service\` | \`wallet-<last-token-of-pattern>-consumer\` (e.g. \`wallet-balance_changed-consumer\`) | \`microservices/wallet_service/main.py:182\` |
| \`billing_service\` | \`billing-<pattern-dots-to-dashes>-consumer[-\${BILLING_CONSUMER_SUFFIX}]\` | \`microservices/billing_service/main.py:116-125\` |
| \`payment_service\` | \`payment_service-<subject-prefix>-consumer\` (auto-derived, no explicit \`durable\`) | \`microservices/payment_service/main.py:152\` + \`core/nats_client.py:407-409\` |

The chart exposes \`stream\`/\`consumer\` as per-service overrides with
\`OVERRIDE_PER_SERVICE\` placeholders so misconfigured deployments fail loudly
during \`helm template\` review.

### Prometheus metric names (PR #363's \`service=\` selector matches nothing)

\`xenoISA/isA_Cloud/isA_common/isa_common/metrics.py\` is the source of
truth. Metrics are namespaced \`isa_<service>_\`:

| Metric (verified) | Type | Labels | Source |
|-------------------|------|--------|--------|
| \`isa_<svc>_http_requests_total\` | Counter | \`method\`, \`path\`, \`status_code\` | \`metrics.py:244-248\` |
| \`isa_<svc>_http_request_duration_seconds\` | Histogram | \`method\`, \`path\` | \`metrics.py:249-254\` |
| \`isa_<svc>_http_requests_in_progress\` | Gauge | \`method\` | \`metrics.py:267-271\` |

No \`service\` label is emitted — the service name is in the metric prefix,
making PR #363's \`{service=\"<svc>\"}\` filter both wrong and unnecessary.

### Aspirational metric names

\`isa_user_websocket_active_connections\` does not exist in the codebase
(only mentioned in \`microservices/auth_service/docs/Issue/PERFORMANCE.md\`
as a planned metric). The chart leaves it in the \`telemetry\` tier preset
with a \`# TODO(#352): verify metric exists in actual /metrics output\`
comment so the ScaledObject still renders for staging soak — but it must
be confirmed against deployed pods before flipping \`kedaEnabled: true\` in
production.

## Other reviewer concerns addressed

- **Per-tier polling cadence.** event=15s (queue spikes fast), auth=60s
  (matches Prometheus scrape interval), telemetry=30s, default=30s.
- **CPU/memory fallback retained.** Every ScaledObject keeps cpu+memory
  triggers from \`autoscaling.targetCPUUtilization\`/\`targetMemoryUtilization\`
  so a stuck custom-metric collector still scales on raw load (#352 AC).
- **Fallback during metrics-apiserver outage.** New \`hpa.keda.fallback\` block
  pins the deployment to a safe replica count after \`failureThreshold\`
  consecutive poll failures, so an external-metrics outage does not cause an
  unbounded scale-up.

## Production threshold caveat

**Threshold values in \`values.yaml\` are starting points only.** Attach
staging soak data (replica counts, queue lag, p95 latency over a 24h burst)
before flipping \`kedaEnabled: true\` in any production release. See the
runbook's \"Tuning a threshold\" section.

## Follow-ups

- xenoISA/isA_user#376 — remove the legacy \`autoscaling:\` block from
  \`isA_user/deployment/helm/values-production.yaml\` once KEDA lands.
- The \`telemetry\` tier's WebSocket connection gauge needs a real exporter
  in \`telemetry_service\`. Tracked via #352 follow-up if absent at deploy.

## Test plan

- [x] \`helm lint deployments/charts/isa-service/ --strict\` passes.
- [x] \`helm template ... --set hpa.kedaEnabled=true\` emits a ScaledObject and **no** HPA.
- [x] \`helm template ... --set hpa.kedaEnabled=false\` emits an HPA and **no** ScaledObject.
- [x] Per-tier polling cadences verified (event=15, auth=60, telemetry=30, default=30).
- [x] Global \`hpa.keda.pollingInterval\`/\`cooldownPeriod\` overrides win over tier defaults.
- [ ] Staging soak: install KEDA controller, render against \`isA_user\` staging values, observe replica counts under synthetic load.
- [ ] Production rollout: gated on staging soak data attached to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)