### PR TITLE
feat(infra): Argo Rollouts canary support for isa-service chart

### DIFF
--- a/deployments/charts/isa-service/templates/analysis-template.yaml
+++ b/deployments/charts/isa-service/templates/analysis-template.yaml
@@ -1,0 +1,158 @@
+{{- /*
+  Argo Rollouts AnalysisTemplate — Prometheus-based canary gate.
+
+  Provenance: ported from xenoISA/isA_user PR #361 (issue #350) with
+  three reviewer-requested fixes applied:
+
+    1. Selector switched from `service="..."` to
+       `app_kubernetes_io_name="..."`. Pods carry the standard
+       `app.kubernetes.io/name` label (added by templates/rollout.yaml);
+       Prometheus replaces dots with underscores so the queryable label
+       is `app_kubernetes_io_name`.
+
+    2. `failureCondition` and `consecutiveErrorLimit: 0` added so an
+       empty Prometheus result vector FAILS the analysis (the original
+       only had `successCondition`, which silently passes when no data
+       returns — defeats auto-rollback).
+
+    3. Metric names are exposed as values (`metricNames.requests`,
+       `metricNames.duration`) so operators can override per-environment
+       without editing the chart. The defaults match what isA_user
+       services expose via `isa_common.metrics`. The actual metric names
+       in production are prefixed (`isa_<service>_http_requests_total`)
+       — operators MUST set the correct prefix when flipping
+       `rollout.enabled=true`.
+       TODO(#350): drop the override knob once we standardize a single
+       canary-friendly metric name across services.
+
+  Both metrics use `failureLimit: 0` AND `consecutiveErrorLimit: 0` so
+  a single breach OR a single empty/error sample aborts the canary.
+
+  Prometheus address defaults to the in-cluster monitoring stack but is
+  overridable via .Values.rollout.analysis.prometheusAddress.
+*/ -}}
+{{- if .Values.rollout.enabled }}
+{{- $analysis := .Values.rollout.analysis | default dict -}}
+{{- $promAddr := $analysis.prometheusAddress | default "http://prometheus-server.monitoring.svc.cluster.local:9090" -}}
+{{- $errorThreshold := $analysis.errorRateThreshold | default "0.01" -}}
+{{- $latencyRatioThreshold := $analysis.latencyRatioThreshold | default "1.5" -}}
+{{- $interval := $analysis.interval | default "30s" -}}
+{{- $count := $analysis.count | default 3 -}}
+{{- $window := $analysis.window | default "2m" -}}
+{{- $consecutiveErrorLimit := $analysis.consecutiveErrorLimit | default 0 -}}
+{{- $metricNames := $analysis.metricNames | default dict -}}
+{{- $requestsMetric := $metricNames.requests | default "http_requests_total" -}}
+{{- $durationMetric := $metricNames.duration | default "http_request_duration_seconds_bucket" -}}
+{{- $statusLabel := $metricNames.statusLabel | default "status_code" -}}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: {{ .Values.name }}-canary-analysis
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: canary-analysis
+spec:
+  args:
+    - name: service-name
+      value: {{ .Values.name }}
+    - name: namespace
+      value: {{ .Values.namespace }}
+    # canary-hash and stable-hash are supplied at run time by the
+    # Rollout via `valueFrom.podTemplateHashValue`. We declare them
+    # without a default so a missing value fails fast.
+    - name: canary-hash
+    - name: stable-hash
+  metrics:
+    # -----------------------------------------------------------------
+    # Metric 1: 5xx error rate on the canary replica set.
+    # Aborts when the rate exceeds errorRateThreshold (default 1%) OR
+    # when Prometheus returns no samples (treated as failure, not pass).
+    # TODO(xenoISA/isA_user#350): verify the exact metric name once a
+    # canary actually runs against the cluster's /metrics output. The
+    # `isa_common` middleware emits `http_requests_total` (and may
+    # prefix with the service name, e.g. `isa_user_auth_service_…`).
+    # Override via .Values.rollout.analysis.metricNames.requests if so.
+    # -----------------------------------------------------------------
+    - name: error-rate
+      interval: {{ $interval }}
+      count: {{ $count }}
+      successCondition: len(result) > 0 && result[0] <= {{ $errorThreshold }}
+      failureCondition: len(result) == 0 || result[0] > {{ $errorThreshold }}
+      failureLimit: 0
+      consecutiveErrorLimit: {{ $consecutiveErrorLimit }}
+      provider:
+        prometheus:
+          address: {{ $promAddr | quote }}
+          query: |
+            sum(
+              rate(
+                {{ $requestsMetric }}{
+                  app_kubernetes_io_name="{{ "{{args.service-name}}" }}",
+                  namespace="{{ "{{args.namespace}}" }}",
+                  rollouts_pod_template_hash="{{ "{{args.canary-hash}}" }}",
+                  {{ $statusLabel }}=~"5.."
+                }[{{ $window }}]
+              )
+            )
+            /
+            sum(
+              rate(
+                {{ $requestsMetric }}{
+                  app_kubernetes_io_name="{{ "{{args.service-name}}" }}",
+                  namespace="{{ "{{args.namespace}}" }}",
+                  rollouts_pod_template_hash="{{ "{{args.canary-hash}}" }}"
+                }[{{ $window }}]
+              )
+            )
+    # -----------------------------------------------------------------
+    # Metric 2: p95 latency ratio (canary / stable).
+    # Aborts when canary p95 > latencyRatioThreshold * stable p95
+    # (default 1.5x) OR when Prometheus returns no samples.
+    # TODO(xenoISA/isA_user#350): same caveat — verify the exact
+    # histogram bucket metric name. Override via
+    # .Values.rollout.analysis.metricNames.duration.
+    # -----------------------------------------------------------------
+    - name: latency-p95-ratio
+      interval: {{ $interval }}
+      count: {{ $count }}
+      successCondition: len(result) > 0 && result[0] <= {{ $latencyRatioThreshold }}
+      failureCondition: len(result) == 0 || result[0] > {{ $latencyRatioThreshold }}
+      failureLimit: 0
+      consecutiveErrorLimit: {{ $consecutiveErrorLimit }}
+      provider:
+        prometheus:
+          address: {{ $promAddr | quote }}
+          query: |
+            (
+              histogram_quantile(0.95,
+                sum by (le) (
+                  rate(
+                    {{ $durationMetric }}{
+                      app_kubernetes_io_name="{{ "{{args.service-name}}" }}",
+                      namespace="{{ "{{args.namespace}}" }}",
+                      rollouts_pod_template_hash="{{ "{{args.canary-hash}}" }}"
+                    }[{{ $window }}]
+                  )
+                )
+              )
+            )
+            /
+            (
+              histogram_quantile(0.95,
+                sum by (le) (
+                  rate(
+                    {{ $durationMetric }}{
+                      app_kubernetes_io_name="{{ "{{args.service-name}}" }}",
+                      namespace="{{ "{{args.namespace}}" }}",
+                      rollouts_pod_template_hash="{{ "{{args.stable-hash}}" }}"
+                    }[{{ $window }}]
+                  )
+                )
+              )
+            )
+{{- end }}

--- a/deployments/charts/isa-service/templates/deployment.yaml
+++ b/deployments/charts/isa-service/templates/deployment.yaml
@@ -1,3 +1,13 @@
+{{- /*
+  Standard Deployment for the service.
+
+  When `.Values.rollout.enabled` is true the chart switches to an Argo
+  Rollouts CR (see templates/rollout.yaml) which OWNS the same Pods.
+  Two controllers cannot reconcile the same Pods, so this Deployment
+  is gated off in that case. See the "Migration path" section in
+  docs/runbooks/canary-deploy.md for the cutover procedure.
+*/ -}}
+{{- if not .Values.rollout.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -124,3 +134,4 @@ spec:
       volumes:
       {{- toYaml .Values.volumes | nindent 6 }}
       {{- end }}
+{{- end }}

--- a/deployments/charts/isa-service/templates/hpa.yaml
+++ b/deployments/charts/isa-service/templates/hpa.yaml
@@ -5,6 +5,15 @@
   a KEDA ScaledObject and KEDA synthesises its own HPA. Rendering both at
   the same time would race on `spec.replicas`, so this template skips
   itself in that case (xenoISA/isA_user issue #352, epic #345).
+
+  When `.Values.rollout.enabled=true`, the chart deletes the Deployment
+  (gated off in templates/deployment.yaml) and creates an Argo Rollouts
+  `Rollout` CR. The HPA must point at the Rollout — not at a Deployment
+  that no longer exists — otherwise autoscaling silently breaks for any
+  service that opts into the canary strategy. Argo Rollouts officially
+  supports being an HPA scale target via `kind: Rollout,
+  apiVersion: argoproj.io/v1alpha1`.
+  See: https://argo-rollouts.readthedocs.io/en/stable/features/scaling-down/
 */ -}}
 {{- if and .Values.autoscaling.enabled (not .Values.hpa.kedaEnabled) }}
 apiVersion: autoscaling/v2
@@ -14,8 +23,8 @@ metadata:
   namespace: {{ .Values.namespace }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: {{ if .Values.rollout.enabled }}argoproj.io/v1alpha1{{ else }}apps/v1{{ end }}
+    kind: {{ if .Values.rollout.enabled }}Rollout{{ else }}Deployment{{ end }}
     name: {{ .Values.name }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/deployments/charts/isa-service/templates/rollout.yaml
+++ b/deployments/charts/isa-service/templates/rollout.yaml
@@ -1,0 +1,247 @@
+{{- /*
+  Argo Rollouts Rollout CR — replaces the Deployment when
+  `.Values.rollout.enabled` is true. Mirrors the Deployment's pod spec so
+  the Rollout owns the same workload (the existing Deployment is gated off
+  in templates/deployment.yaml to avoid two controllers reconciling the
+  same Pods).
+
+  Provenance: ported from xenoISA/isA_user PR #361 (issue #350,
+  parent epic #345). The chart-level differences:
+
+    - One Rollout per release (this chart deploys a single service per
+      release), not a `range $key, $svc := .Values.services`.
+    - Pod spec mirrors templates/deployment.yaml verbatim — same
+      probes, security contexts, env, observability, lifecycle —
+      so a flip from Deployment -> Rollout is behaviour-preserving.
+    - AnalysisTemplate selectors use `app_kubernetes_io_name` (the
+      label Prometheus emits when scraping pods labelled with
+      `app.kubernetes.io/name`), addressing the PR #361 review note
+      that `service=` in the original queries did not match real
+      pod labels.
+
+  Cluster prerequisite: argo-rollouts controller installed.
+  See: https://argo-rollouts.readthedocs.io/en/stable/installation/
+  Original docs: docs/runbooks/canary-deploy.md (ported into isA_Cloud).
+*/ -}}
+{{- if .Values.rollout.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: service
+  annotations:
+    rollout.argoproj.io/revision-history-limit: {{ .Values.rollout.revisionHistoryLimit | default 5 | quote }}
+    isa.io/canary-source-pr: "https://github.com/xenoISA/isA_user/pull/361"
+spec:
+  replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.rollout.revisionHistoryLimit | default 5 }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+        # Adds the K8s standard label so Prometheus emits
+        # `app_kubernetes_io_name` on scrape targets, which the
+        # AnalysisTemplate selectors depend on.
+        app.kubernetes.io/name: {{ .Values.name }}
+      {{- if or .Values.consul.enabled .Values.podAnnotations }}
+      annotations:
+        {{- if .Values.consul.enabled }}
+        consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/service-name: {{ .Values.name }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Values.name }}
+        image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.port }}
+          name: http
+        {{- if .Values.configMapRef }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.configMapRef }}
+        {{- end }}
+        env:
+        {{- if .Values.observability }}
+        - name: TEMPO_HOST
+          value: {{ .Values.observability.tempoHost | quote }}
+        - name: TEMPO_PORT
+          value: {{ .Values.observability.tempoPort | quote }}
+        - name: LOKI_URL
+          value: {{ .Values.observability.lokiUrl | quote }}
+        - name: ISA_ENV
+          value: {{ .Values.observability.isaEnv | quote }}
+        {{- end }}
+        {{- if .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
+        resources:
+          requests:
+            memory: {{ .Values.resources.requests.memory }}
+            cpu: {{ .Values.resources.requests.cpu }}
+          limits:
+            memory: {{ .Values.resources.limits.memory }}
+            cpu: {{ .Values.resources.limits.cpu }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.health.path }}
+            port: {{ .Values.port }}
+          initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+          periodSeconds: {{ .Values.health.periodSeconds }}
+        {{- if .Values.volumeMounts }}
+        volumeMounts:
+        {{- toYaml .Values.volumeMounts | nindent 8 }}
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.liveness.path | default .Values.health.path }}
+            port: {{ .Values.port }}
+          initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds | default 15 }}
+          periodSeconds: {{ .Values.liveness.periodSeconds | default 20 }}
+        {{- if and .Values.startupProbe .Values.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.startupProbe.path | default .Values.health.path }}
+            port: {{ .Values.port }}
+          failureThreshold: {{ .Values.startupProbe.failureThreshold | default 30 }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds | default 5 }}
+        {{- end }}
+        {{- with .Values.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.volumes }}
+      volumes:
+      {{- toYaml .Values.volumes | nindent 6 }}
+      {{- end }}
+  strategy:
+    canary:
+      {{- /*
+        With trafficRouting unset (basic replica-weighted canary),
+        `setCanaryScale.matchTrafficWeight: true` is a no-op (Argo
+        already scales canary replicas to match the weight). Wired
+        in only when an explicit trafficRouting block is provided
+        (Istio / SMI / Gateway API / Nginx / ALB), addressing the
+        PR #361 review note.
+      */ -}}
+      {{- with .Values.rollout.trafficRouting }}
+      trafficRouting:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      maxSurge: {{ .Values.rollout.maxSurge | default "25%" | quote }}
+      maxUnavailable: {{ .Values.rollout.maxUnavailable | default 0 }}
+      scaleDownDelaySeconds: {{ .Values.rollout.scaleDownDelaySeconds | default 30 }}
+      {{- if .Values.rollout.steps }}
+      steps:
+        {{- toYaml .Values.rollout.steps | nindent 8 }}
+      {{- else }}
+      steps:
+        # ---------------------------------------------------------------
+        # Stage 0 — single-replica canary, then a hard health gate.
+        # ---------------------------------------------------------------
+        - setCanaryScale:
+            replicas: 1
+        - pause:
+            duration: {{ .Values.rollout.healthGateSeconds | default 60 }}s
+        {{- if .Values.rollout.trafficRouting }}
+        # `matchTrafficWeight` only meaningful with trafficRouting; without
+        # it the canary scale already tracks the weight automatically.
+        - setCanaryScale:
+            matchTrafficWeight: true
+        {{- end }}
+        # ---------------------------------------------------------------
+        # Stage 1 — 10% traffic, run analysis.
+        # ---------------------------------------------------------------
+        - setWeight: 10
+        - analysis:
+            templates:
+              - templateName: {{ .Values.name }}-canary-analysis
+            args:
+              - name: service-name
+                value: {{ .Values.name }}
+              - name: namespace
+                value: {{ .Values.namespace }}
+              - name: canary-hash
+                valueFrom:
+                  podTemplateHashValue: Latest
+              - name: stable-hash
+                valueFrom:
+                  podTemplateHashValue: Stable
+        - pause:
+            duration: {{ .Values.rollout.stagePauseSeconds | default 30 }}s
+        # ---------------------------------------------------------------
+        # Stage 2 — 25%
+        # ---------------------------------------------------------------
+        - setWeight: 25
+        - analysis:
+            templates:
+              - templateName: {{ .Values.name }}-canary-analysis
+            args:
+              - name: service-name
+                value: {{ .Values.name }}
+              - name: namespace
+                value: {{ .Values.namespace }}
+              - name: canary-hash
+                valueFrom:
+                  podTemplateHashValue: Latest
+              - name: stable-hash
+                valueFrom:
+                  podTemplateHashValue: Stable
+        - pause:
+            duration: {{ .Values.rollout.stagePauseSeconds | default 30 }}s
+        # ---------------------------------------------------------------
+        # Stage 3 — 50%
+        # ---------------------------------------------------------------
+        - setWeight: 50
+        - analysis:
+            templates:
+              - templateName: {{ .Values.name }}-canary-analysis
+            args:
+              - name: service-name
+                value: {{ .Values.name }}
+              - name: namespace
+                value: {{ .Values.namespace }}
+              - name: canary-hash
+                valueFrom:
+                  podTemplateHashValue: Latest
+              - name: stable-hash
+                valueFrom:
+                  podTemplateHashValue: Stable
+        - pause:
+            duration: {{ .Values.rollout.stagePauseSeconds | default 30 }}s
+        # Stage 4 — implicit 100%. Argo promotes after the final step.
+      {{- end }}
+{{- end }}

--- a/deployments/charts/isa-service/values.yaml
+++ b/deployments/charts/isa-service/values.yaml
@@ -305,3 +305,81 @@ volumeMounts: []
 #   mountPath: /tmp
 # - name: cache
 #   mountPath: /app/.cache
+
+# =============================================================================
+# Argo Rollouts canary (ported from xenoISA/isA_user PR #361, issue #350)
+# =============================================================================
+# When `enabled: true`, the chart renders an Argo Rollouts `Rollout` CR
+# (templates/rollout.yaml) and an `AnalysisTemplate` (templates/analysis-
+# template.yaml) instead of the standard `Deployment`. The Rollout owns
+# the same Pods the Deployment used to own, so flipping this flag is a
+# behaviour-preserving migration aside from the canary stages it adds
+# during image bumps.
+#
+# Cluster prerequisite: argo-rollouts controller installed.
+#   See: docs/runbooks/canary-deploy.md section 0
+#   Upstream: https://argo-rollouts.readthedocs.io/en/stable/installation/
+#
+# Defaults match the spec on issue #350:
+#   - 1-replica canary with a 60s health gate
+#   - 10/25/50/100 traffic ramp
+#   - Prometheus error-rate >1% OR p95 latency >1.5x baseline triggers
+#     auto-rollback (single breach aborts: `failureLimit: 0`,
+#     `consecutiveErrorLimit: 0` so empty results also fail).
+# =============================================================================
+rollout:
+  # Opt-in. Operators flip this on per-environment / per-service once the
+  # Argo Rollouts controller is installed in the target cluster.
+  enabled: false
+  # How long the 1-replica canary bakes before any traffic is split.
+  healthGateSeconds: 60
+  # Pause between weight bumps (gives analysis a fresh window).
+  stagePauseSeconds: 30
+  # Argo's surge / unavailable knobs during the canary ramp.
+  maxSurge: "25%"
+  maxUnavailable: 0
+  # Seconds Argo keeps the old ReplicaSet around after a successful
+  # promotion. Bump in production to give a longer rollback window.
+  scaleDownDelaySeconds: 30
+  revisionHistoryLimit: 5
+  # Set to enable L7 traffic splitting via a service mesh / ingress
+  # (Istio, SMI, Gateway API, ALB, Nginx, ...). Leave empty to use the
+  # built-in replica-weighted "basic canary" mode that needs no mesh.
+  # NOTE: when empty, the `setCanaryScale.matchTrafficWeight` step is
+  # skipped because it is a no-op without trafficRouting.
+  trafficRouting: {}
+  # Override `steps` to ship a custom ramp for a service tier (e.g., a
+  # background worker that wants a faster promotion). Leave empty to
+  # render the default 1-replica -> healthGate -> 10/25/50 -> 100% ramp.
+  steps: []
+  # Prometheus analysis knobs, consumed by templates/analysis-template.yaml.
+  analysis:
+    prometheusAddress: "http://prometheus-server.monitoring.svc.cluster.local:9090"
+    # Auto-rollback when 5xx rate exceeds 1% of total RPS over `window`.
+    errorRateThreshold: "0.01"
+    # Auto-rollback when canary p95 latency > 1.5x the stable replica set.
+    latencyRatioThreshold: "1.5"
+    # How frequently each metric is sampled inside one analysis run.
+    interval: "30s"
+    # Number of samples per analysis run before passing the gate.
+    count: 3
+    # Time window each Prometheus query looks back over.
+    window: "2m"
+    # `consecutiveErrorLimit: 0` makes a single Prometheus error (e.g.
+    # provider unreachable) fail the analysis. Combined with the
+    # `failureCondition: len(result) == 0` guard in the AnalysisTemplate,
+    # this closes the silent-pass loophole called out in PR #361 review.
+    consecutiveErrorLimit: 0
+    # Metric-name overrides — the chart defaults match the names emitted
+    # by `prometheus_client` / `isa_common.metrics`. If your services
+    # expose the per-service prefixed names (e.g.
+    # `isa_user_auth_service_http_requests_total`) override here.
+    # TODO(xenoISA/isA_user#350): unify metric names across services
+    # and drop this knob.
+    metricNames:
+      requests: "http_requests_total"
+      duration: "http_request_duration_seconds_bucket"
+      # Label that carries the HTTP status. `isa_common` uses
+      # `status_code`; older Prometheus instrumentation often uses
+      # `code` or `status`.
+      statusLabel: "status_code"

--- a/docs/adr/0001-canary-tooling.md
+++ b/docs/adr/0001-canary-tooling.md
@@ -1,0 +1,153 @@
+# ADR 0001 — Canary Deploy Tooling: Argo Rollouts
+
+> Status: Accepted (2026-05-04)
+> Origin: ported from xenoISA/isA_user PR #361 (issue
+> [#350](https://github.com/xenoISA/isA_user/issues/350), parent epic
+> [#345](https://github.com/xenoISA/isA_user/issues/345))
+> Sibling docs: `deployments/charts/isa-service/templates/rollout.yaml`,
+> `deployments/charts/isa-service/templates/analysis-template.yaml`,
+> `docs/runbooks/canary-deploy.md`
+
+## Context
+
+isA_user epic #345 (K8s HPA Readiness) requires a canary deploy strategy
+for platform microservices so a bad release does not reach 100% of
+traffic before metrics catch up. Issue #350 specifies:
+
+- Stage 1 replica → ≥60s health gate → 10% → 25% → 50% → 100% traffic ramp
+- Auto-rollback on error rate >1% OR p95 latency >1.5× baseline
+- Configurable Prometheus analysis queries
+- Helm-native integration with the existing deploy pipelines
+
+The platform already runs:
+
+- Kubernetes (KIND for local, managed clusters for staging/prod)
+- Helm 3 charts under `isA_Cloud/deployments/charts/`
+- Consul + APISIX (no service mesh required)
+- Prometheus for metrics (assumed present in the cluster)
+- GitHub Actions CI (per-repo `deploy.yml`)
+
+The shared `isa-service` chart in this repo is the natural home for
+the new template — it is already the chart that owns each service's
+`Deployment`, `Service`, `HorizontalPodAutoscaler`, and
+`PodDisruptionBudget`.
+
+## Options considered
+
+### Option A — Argo Rollouts (CHOSEN)
+
+CRD-driven progressive delivery controller. Replaces `Deployment` with
+`Rollout`. Native support for canary stages with traffic weights,
+per-stage pauses, and analysis runs that hit Prometheus / Datadog /
+New Relic / etc. Works without a service mesh by using the built-in
+"basic canary" mode (replica-count-based traffic split), and gains
+true L7 split when Istio / Linkerd / SMI / Gateway API / Nginx / ALB
+are present.
+
+Pros
+- First-class Kubernetes object — `kubectl argo rollouts get rollout X`
+  and a UI dashboard ship out of the box.
+- Per-stage `pause` + `setWeight` directives match the issue spec verbatim.
+- Inline `AnalysisTemplate` runs Prometheus queries during each step and
+  aborts the rollout on threshold breach (== auto-rollback).
+- Wide ecosystem adoption (CNCF Incubating). Documented for ArgoCD users
+  who likely run the rest of the platform.
+- Replicas-based canary works on a vanilla cluster — no mesh required to
+  ship the first version.
+
+Cons
+- Adds a controller dependency in every cluster (one Deployment + CRDs).
+- Replacing the existing `Deployment` shape touches the chart. We
+  mitigate by making rollout opt-in via `rollout.enabled` and gating
+  the existing `Deployment` template off when the flag is on so two
+  controllers cannot reconcile the same Pods.
+
+### Option B — Flagger
+
+Operator that drives canary rollouts using Istio / Linkerd / Contour /
+Gloo / NGINX / Skipper / Traefik / ALB. Uses the same primitives (steps,
+analysis, metric queries).
+
+Pros
+- Production-grade, similar feature set.
+- Tighter integration with service meshes when one exists.
+
+Cons
+- **Hard requirement on a service mesh or supported ingress for traffic
+  splitting.** isA_user fronts traffic with APISIX, which Flagger does
+  not list as a first-class provider — we'd need to migrate to a
+  supported mesh first.
+- Pause/promote workflow is less visible (no dedicated dashboard /
+  `kubectl` plugin equivalent to Argo's).
+
+### Option C — Custom (kubectl + Bash + Prometheus queries in CI)
+
+Bake the canary loop into the workflow itself: scale a canary Deployment,
+sleep 60s, query Prometheus, scale up, repeat.
+
+Pros
+- No new cluster dependencies.
+- Logic is auditable in the workflow file.
+
+Cons
+- Reinvents Argo Rollouts poorly. State lives in the runner, so a CI cancel
+  abandons the canary mid-stage. No UI, no `kubectl` introspection, no
+  experiments / blue-green / preview environments later. Operators who want
+  to "pause" or "promote" manually have nothing to drive.
+- Multiplies code in the workflow per service.
+
+## Decision
+
+**Adopt Argo Rollouts.** It is the only option that satisfies the issue
+acceptance criteria with reasonable operational effort and zero forced
+dependencies on a service mesh. The basic canary mode is sufficient for
+the first cut; we keep the door open to plug in APISIX or a mesh later
+purely by editing the `Rollout` `strategy.canary.trafficRouting` block.
+
+## Consequences
+
+### Positive
+
+- Stages and analysis are declarative inside the chart — diffs in git
+  show the full canary policy.
+- `kubectl argo rollouts get rollout user-auth-service -n isa-cloud-prod`
+  gives operators a live tree view during every deploy.
+- Re-uses the existing migration-job hook order: Alembic Job (pre-upgrade
+  hook) runs to completion → service `Rollout` reconciles → analysis
+  template promotes or aborts.
+- Production stays on canary; staging keeps the simpler kubectl-driven
+  rollout (faster feedback for developers) by toggling
+  `rollout.enabled=false` per environment.
+- The chart now owns BOTH the `Deployment` (rollout disabled) and the
+  `Rollout` (rollout enabled) — flipping a single value handles the
+  cutover instead of needing two charts in two repos.
+
+### Negative / Follow-ups
+
+- Cluster admins MUST install the Argo Rollouts controller before this
+  chart's `Rollout` resource can reconcile. See the runbook for the
+  install command and link to the upstream guide.
+- We do not yet have a service mesh; traffic-splitting fidelity is
+  approximate (replica-count weighted). For the spec's 10/25/50/100
+  thresholds this is acceptable because we are still gating each step on
+  a Prometheus analysis run.
+- The `setCanaryScale.matchTrafficWeight: true` step is only rendered
+  when `rollout.trafficRouting` is non-empty (it is a no-op without
+  L7 routing).
+- The AnalysisTemplate's Prometheus queries assume metrics carry an
+  `app_kubernetes_io_name` label (Prometheus's auto-conversion of
+  the pod label `app.kubernetes.io/name`). If the chart adds new
+  pod labels, keep that one or update the analysis template to match.
+- The default metric names (`http_requests_total`,
+  `http_request_duration_seconds_bucket`) match the unprefixed names
+  some services emit. `isa_common.metrics` adds an `isa_<service>_`
+  prefix; operators flipping `rollout.enabled` MUST set
+  `rollout.analysis.metricNames.*` to the actual emitted name. See
+  the TODO in the AnalysisTemplate.
+
+## Links
+
+- Argo Rollouts docs: https://argo-rollouts.readthedocs.io/
+- Install: `kubectl create namespace argo-rollouts && kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml`
+- Flagger comparison: https://argo-rollouts.readthedocs.io/en/stable/FAQ/#how-does-argo-rollouts-differ-from-flagger
+- Originating PR (closed in favor of this chart change): https://github.com/xenoISA/isA_user/pull/361

--- a/docs/runbooks/canary-deploy.md
+++ b/docs/runbooks/canary-deploy.md
@@ -30,17 +30,25 @@ consuming repo's runbook (e.g. `xenoISA/isA_user/docs/runbooks/migration-rollbac
 
 The chart renders `Rollout` and `AnalysisTemplate` CRs but does NOT
 install the Argo Rollouts controller itself. Install it once per
-cluster:
+cluster, **pinned to a specific release** so the cluster admin can
+reproduce the install on a fresh cluster and roll back deterministically
+if a controller release introduces a regression. Track the upgrade
+cadence as a normal cluster-admin chore, not via `latest`.
 
 ```bash
+# Pin to the same version we exercise in CI (the kubectl-argo-rollouts
+# plugin step in xenoISA/isA_user/.github/workflows/deploy.yml uses
+# the same tag — bump both at once).
+ARGO_ROLLOUTS_VERSION=v1.7.2
+
 kubectl create namespace argo-rollouts
 kubectl apply -n argo-rollouts \
-  -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+  -f "https://github.com/argoproj/argo-rollouts/releases/download/${ARGO_ROLLOUTS_VERSION}/install.yaml"
 
 # Optional but strongly recommended — kubectl plugin for live tree views.
 brew install argoproj/tap/kubectl-argo-rollouts   # macOS
-# or download the binary from
-#   https://github.com/argoproj/argo-rollouts/releases/latest
+# or download the pinned binary from
+#   https://github.com/argoproj/argo-rollouts/releases/tag/${ARGO_ROLLOUTS_VERSION}
 ```
 
 Upstream install guide:
@@ -98,9 +106,12 @@ kubectl argo rollouts get rollout "${SERVICE}" -n "${NAMESPACE}" --watch
 # Just the current step / weight / status:
 kubectl argo rollouts status "${SERVICE}" -n "${NAMESPACE}"
 
-# Inspect AnalysisRuns triggered during the canary.
+# Inspect AnalysisRuns triggered during the canary. Argo Rollouts emits
+# the `rollout.argoproj.io/name=<rollout-name>` label on every
+# AnalysisRun it spawns — there is no plain `rollout=` label.
 kubectl get analysisrun -n "${NAMESPACE}" \
-  -l rollout="${SERVICE}"  --sort-by=.metadata.creationTimestamp
+  -l "rollout.argoproj.io/name=${SERVICE}" \
+  --sort-by=.metadata.creationTimestamp
 ```
 
 The tree view shows:
@@ -174,9 +185,11 @@ Investigate:
 NAMESPACE=isa-cloud-prod
 SERVICE=user-auth-service
 
-# Latest AnalysisRun for this service.
+# Latest AnalysisRun for this service. The selector below matches the
+# `rollout.argoproj.io/name` label Argo Rollouts attaches to every
+# AnalysisRun (a plain `rollout=<name>` selector would match nothing).
 RUN=$(kubectl get analysisrun -n "${NAMESPACE}" \
-  -l rollout="${SERVICE}" \
+  -l "rollout.argoproj.io/name=${SERVICE}" \
   --sort-by=.metadata.creationTimestamp \
   -o jsonpath='{.items[-1:].metadata.name}')
 

--- a/docs/runbooks/canary-deploy.md
+++ b/docs/runbooks/canary-deploy.md
@@ -1,0 +1,295 @@
+# Canary Deploy Runbook
+
+> Sibling docs: `deployments/charts/isa-service/templates/rollout.yaml`,
+> `deployments/charts/isa-service/templates/analysis-template.yaml`,
+> `docs/adr/0001-canary-tooling.md`.
+>
+> Origin: ported from xenoISA/isA_user PR #361 (issue
+> [#350](https://github.com/xenoISA/isA_user/issues/350) — parent epic
+> [#345](https://github.com/xenoISA/isA_user/issues/345)).
+> Tooling: Argo Rollouts.
+
+## What this covers
+
+The shared `isa-service` chart renders an Argo Rollouts `Rollout` CR
+(instead of the standard `Deployment`) when `rollout.enabled: true`.
+Every service that consumes this chart can opt in per environment.
+This runbook explains how to:
+
+1. Verify the controller is installed in the target cluster.
+2. Watch a canary in flight.
+3. Manually promote, pause, abort, or roll back.
+4. Read the AnalysisRun output when auto-rollback fires.
+5. Migrate a service from the legacy `Deployment` to the new `Rollout`.
+
+If you are looking for the migration-Job pre-deploy gate, see the
+consuming repo's runbook (e.g. `xenoISA/isA_user/docs/runbooks/migration-rollback.md`)
+— that runs FIRST, before any canary starts.
+
+## 0. Prerequisites — install the controller
+
+The chart renders `Rollout` and `AnalysisTemplate` CRs but does NOT
+install the Argo Rollouts controller itself. Install it once per
+cluster:
+
+```bash
+kubectl create namespace argo-rollouts
+kubectl apply -n argo-rollouts \
+  -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+
+# Optional but strongly recommended — kubectl plugin for live tree views.
+brew install argoproj/tap/kubectl-argo-rollouts   # macOS
+# or download the binary from
+#   https://github.com/argoproj/argo-rollouts/releases/latest
+```
+
+Upstream install guide:
+<https://argo-rollouts.readthedocs.io/en/stable/installation/>.
+
+Verify:
+
+```bash
+kubectl get crd rollouts.argoproj.io analysistemplates.argoproj.io
+kubectl get pods -n argo-rollouts
+kubectl argo rollouts version
+```
+
+## 1. Trigger a canary deploy
+
+The CI workflow that ships images (e.g. `xenoISA/isA_user/.github/workflows/deploy.yml`)
+handles this once it has been wired to use `rollout.enabled=true`.
+Until then, push a new image tag and let `helm upgrade` reconcile the
+`Rollout` — Argo takes over from there.
+
+Sequence (per service):
+
+1. CI runs the schema migration Job (helm pre-upgrade hook). Existing
+   replicas keep serving until this Job exits 0.
+2. CI runs `helm upgrade --install <release> deployments/charts/isa-service`
+   with a values file that sets `rollout.enabled=true` and the new
+   image tag. Argo's controller reconciles the `Rollout`.
+
+Manual trigger for a single service (debugging):
+
+```bash
+NAMESPACE=isa-cloud-prod
+SERVICE=user-auth-service
+VERSION=v1.4.2
+
+kubectl argo rollouts set image "${SERVICE}" \
+  "${SERVICE}=ghcr.io/xenoisa/isa_user/${SERVICE#user-}:${VERSION}" \
+  -n "${NAMESPACE}"
+```
+
+Note: `kubectl argo rollouts set image` only fires if the new tag
+differs from the current one. CI workflows that always tag `latest`
+will not re-trigger a canary — bake a content-addressed tag (commit
+SHA) into the deploy step instead.
+
+## 2. Watch a canary in flight
+
+```bash
+NAMESPACE=isa-cloud-prod
+SERVICE=user-auth-service
+
+# Live tree view — best single command for situational awareness.
+kubectl argo rollouts get rollout "${SERVICE}" -n "${NAMESPACE}" --watch
+
+# Just the current step / weight / status:
+kubectl argo rollouts status "${SERVICE}" -n "${NAMESPACE}"
+
+# Inspect AnalysisRuns triggered during the canary.
+kubectl get analysisrun -n "${NAMESPACE}" \
+  -l rollout="${SERVICE}"  --sort-by=.metadata.creationTimestamp
+```
+
+The tree view shows:
+
+- The stable + canary ReplicaSets (with hashes).
+- Current step index and target weight.
+- Analysis pass/fail per metric.
+- Time spent paused.
+
+Default ramp from issue #350 (rendered by `templates/rollout.yaml`):
+
+| Step | Action            | Notes                              |
+|------|-------------------|------------------------------------|
+| 0    | setCanaryScale=1  | Pin canary at exactly one replica. |
+| 1    | pause 60s         | Health gate.                       |
+| 2*   | matchTrafficWeight| Only when `trafficRouting` is set. |
+| 3    | setWeight 10      |                                    |
+| 4    | analysis          | error-rate + p95 ratio.            |
+| 5    | pause 30s         | Drain analysis window.             |
+| 6    | setWeight 25      |                                    |
+| 7    | analysis          |                                    |
+| 8    | pause 30s         |                                    |
+| 9    | setWeight 50      |                                    |
+| 10   | analysis          |                                    |
+| 11   | pause 30s         |                                    |
+| —    | implicit 100%     | Argo promotes after final step.    |
+
+## 3. Manual gates — promote, pause, abort, retry
+
+```bash
+NAMESPACE=isa-cloud-prod
+SERVICE=user-auth-service
+
+# Promote past the current step (skips remaining time on a pause).
+kubectl argo rollouts promote "${SERVICE}" -n "${NAMESPACE}"
+
+# Promote past ALL remaining steps (jump straight to 100%). Use with care.
+kubectl argo rollouts promote "${SERVICE}" -n "${NAMESPACE}" --full
+
+# Abort — Argo halts the canary and routes 100% back to the stable RS.
+# Stable pods continue serving; canary RS is scaled down per
+# scaleDownDelaySeconds (default 30 in this chart).
+kubectl argo rollouts abort "${SERVICE}" -n "${NAMESPACE}"
+
+# Retry an aborted rollout (re-runs from step 0).
+kubectl argo rollouts retry rollout "${SERVICE}" -n "${NAMESPACE}"
+```
+
+Pausing with no time bound:
+
+```bash
+# Indefinite pause (no duration). Use to investigate before promoting.
+kubectl argo rollouts pause "${SERVICE}" -n "${NAMESPACE}"
+```
+
+## 4. Auto-rollback — what just happened?
+
+When a Prometheus metric breaches threshold (or returns no data — the
+template treats empty results as failure), the AnalysisRun fails and
+Argo aborts the rollout automatically. Symptoms:
+
+```bash
+$ kubectl argo rollouts status user-auth-service -n isa-cloud-prod
+Status: Degraded
+Message: RolloutAborted: Rollout aborted update to revision 12: ...
+```
+
+Investigate:
+
+```bash
+NAMESPACE=isa-cloud-prod
+SERVICE=user-auth-service
+
+# Latest AnalysisRun for this service.
+RUN=$(kubectl get analysisrun -n "${NAMESPACE}" \
+  -l rollout="${SERVICE}" \
+  --sort-by=.metadata.creationTimestamp \
+  -o jsonpath='{.items[-1:].metadata.name}')
+
+kubectl describe analysisrun "${RUN}" -n "${NAMESPACE}" | sed -n '/Status:/,$p'
+
+# Per-metric measurements (the actual Prometheus values that failed).
+kubectl get analysisrun "${RUN}" -n "${NAMESPACE}" \
+  -o jsonpath='{.status.metricResults}' | jq .
+```
+
+Common causes:
+
+| Symptom                                  | Likely root cause                              |
+|------------------------------------------|------------------------------------------------|
+| `error-rate` failed, `result[0]` ≈ 1.0   | Misconfig, exception loop, bad migration tail. |
+| `latency-p95-ratio` > 1.5                | Cold cache, GC churn, downstream slowdown.     |
+| `query did not return any results`       | Metric-name mismatch (see "Tweaking" §5).      |
+| Both metrics passing but rollout stuck   | A `pause` step with no duration — promote it.  |
+
+After triage, redeploy the previous good version (auto-rollback only
+halts traffic; image rollback is manual):
+
+```bash
+# Show recent revisions (image SHAs).
+kubectl argo rollouts history rollout "${SERVICE}" -n "${NAMESPACE}"
+
+# Roll back to the previous revision (re-runs the canary ladder).
+kubectl argo rollouts undo "${SERVICE}" -n "${NAMESPACE}"
+```
+
+## 5. Tweaking thresholds for one service
+
+Set the values at the CLI or in a per-service / per-environment values
+file:
+
+```yaml
+rollout:
+  enabled: true
+  healthGateSeconds: 120        # bake the canary longer
+  analysis:
+    errorRateThreshold: "0.005" # tighter — 0.5% triggers rollback
+    latencyRatioThreshold: "1.3"
+    metricNames:
+      # Override when the service uses isa_common.metrics with the
+      # `isa_<service>_` prefix.
+      requests: "isa_user_auth_service_http_requests_total"
+      duration: "isa_user_auth_service_http_request_duration_seconds_bucket"
+      statusLabel: "status_code"
+```
+
+CLI override:
+
+```bash
+helm upgrade --install user-auth-service \
+  ~/Documents/Fun/isA/isA_Cloud/deployments/charts/isa-service \
+  --set rollout.enabled=true \
+  --set rollout.analysis.errorRateThreshold="0.005" \
+  -n isa-cloud-prod
+```
+
+## 6. Migration path from Deployment to Rollout
+
+The chart renders EITHER a `Deployment` OR a `Rollout` (gated on
+`rollout.enabled`), so a single helm upgrade flips ownership. Two
+controllers cannot own the same Pods, so the steps below must run in
+order:
+
+```bash
+NAMESPACE=isa-cloud-prod
+SERVICE=user-auth-service
+
+# 1. Confirm the controller is installed.
+kubectl get crd rollouts.argoproj.io >/dev/null
+kubectl get deploy -n argo-rollouts argo-rollouts >/dev/null
+
+# 2. Apply with rollout enabled. Helm deletes the existing Deployment
+#    and creates the Rollout in the same release.
+helm upgrade --install "${SERVICE}" \
+  ~/Documents/Fun/isA/isA_Cloud/deployments/charts/isa-service \
+  --set rollout.enabled=true \
+  -n "${NAMESPACE}"
+
+# 3. Watch the Rollout converge.
+kubectl argo rollouts get rollout "${SERVICE}" -n "${NAMESPACE}" --watch
+
+# 4. Verify Service endpoints flipped to the Rollout-owned pods.
+kubectl get endpoints "${SERVICE}" -n "${NAMESPACE}" -o yaml | head -40
+```
+
+To revert (controller down, canary tooling broken, etc.):
+
+```bash
+helm upgrade --install "${SERVICE}" \
+  ~/Documents/Fun/isA/isA_Cloud/deployments/charts/isa-service \
+  --set rollout.enabled=false \
+  -n "${NAMESPACE}"
+```
+
+## 7. CI follow-up (deferred)
+
+The `xenoISA/isA_user/.github/workflows/deploy.yml` workflow currently
+performs a Blue-Green Deployment step. Switching it to a Canary
+Rollout step needs:
+
+- `kubectl argo rollouts set image …` against each service per ramp,
+  with content-addressed image tags (commit SHA) so each deploy
+  actually triggers a new revision.
+- `kubectl argo rollouts status --watch --timeout=…` to block on
+  promotion / abort.
+- A workflow-level timeout that fits the new serial ramp (the original
+  45m budget against 30m per-service ramps × N services will not
+  serialize). Recommend parallelizing per service via a matrix job.
+
+Tracked in the cross-repo follow-up issue (linked from the isA_Cloud
+PR description). Until that is wired in, operators canary-deploy via
+the `kubectl argo rollouts` commands in §1 / §6.


### PR DESCRIPTION
## Summary

Moves the Argo Rollouts canary work from `xenoISA/isA_user` PR #361 to
its architectural home in this repo's shared `isa-service` chart. The
`Rollout` CR replaces the `Deployment`, so it lives alongside the
existing `Deployment` template instead of in the consumer repo's chart.

When `rollout.enabled=true`, Helm renders the `Rollout` (and gates
the `Deployment` template off so two controllers do not own the same
Pods); when `false`, the chart behaves exactly as before.

Replaces xenoISA/isA_user#361 (closing in favor of this PR).

## Remediation (from /land review on PR #230)

Three follow-up fixes pushed on top of the original commit:

1. **MUST FIX — HPA `scaleTargetRef` now templated on `rollout.enabled`**
   (`deployments/charts/isa-service/templates/hpa.yaml`). Previously the
   HPA hard-coded `kind: Deployment, apiVersion: apps/v1` even when
   `rollout.enabled=true` deleted the Deployment, so autoscaling was
   silently broken on every canary'd service. Now points at
   `kind: Rollout, apiVersion: argoproj.io/v1alpha1` when the canary
   path is on (Argo Rollouts officially supports being an HPA scale
   target — see <https://argo-rollouts.readthedocs.io/en/stable/features/scaling-down/>).
   Sits inside PR #229's `(not .Values.hpa.kedaEnabled)` outer guard so
   the KEDA mutual-exclusion still holds.

2. **SHOULD FIX — Pin Argo Rollouts controller install to a tagged release**
   (`docs/runbooks/canary-deploy.md` §0 and PR description below).
   `releases/latest/download/install.yaml` made cluster-admin work
   non-reproducible; pinned to `v1.7.2` (track the same tag in the
   future kubectl-argo-rollouts plugin step in the consuming repo's
   deploy workflow so both move together).

3. **SHOULD FIX — Correct AnalysisRun label selector in runbook**
   (`docs/runbooks/canary-deploy.md` §2 and §4). The selector
   `-l rollout=<name>` matched nothing — Argo Rollouts emits
   `rollout.argoproj.io/name=<name>` on every AnalysisRun. Fixed in
   both the "watch a canary" and "auto-rollback triage" sections.

Validated with `helm lint --strict` and `helm template` across all 4
combinations of `(rollout.enabled, hpa.kedaEnabled)` — see comment on
this PR for the full render check.

## What changed

- `deployments/charts/isa-service/templates/rollout.yaml` (new) —
  `Rollout` CR mirroring `deployment.yaml`'s pod spec verbatim
  (probes, security contexts, env, observability, lifecycle) so a
  flip from Deployment -> Rollout is behaviour-preserving outside
  the canary stages it adds during image bumps.
- `deployments/charts/isa-service/templates/analysis-template.yaml`
  (new) — `AnalysisTemplate` with two Prometheus metrics
  (5xx error rate + p95 latency ratio) gating each weight bump.
- `deployments/charts/isa-service/templates/deployment.yaml` —
  wrapped in `{{- if not .Values.rollout.enabled }}` so it disappears
  when the canary path is on.
- `deployments/charts/isa-service/templates/hpa.yaml` — `scaleTargetRef`
  now points at the `Rollout` when `rollout.enabled=true`, sitting
  inside PR #229's `(not .Values.hpa.kedaEnabled)` outer guard.
- `deployments/charts/isa-service/values.yaml` — opt-in `rollout`
  block (`enabled: false` default) with all the knobs (steps,
  threshold tuning, metric-name overrides, traffic-routing hook).
- `docs/adr/0001-canary-tooling.md` (new) — Argo Rollouts vs Flagger
  vs custom rationale, ported from PR #361.
- `docs/runbooks/canary-deploy.md` (new) — operator runbook (install,
  watch, manual gates, AnalysisRun triage, Deployment->Rollout
  migration), ported from PR #361 with file:line references rewritten
  for this repo.

## Reviewer concerns from PR #361 addressed in this port

| PR #361 concern | Fix in this PR |
|---|---|
| `service=` selector did not match real pod labels | AnalysisTemplate uses `app_kubernetes_io_name=` (the K8s standard label, transcribed by Prometheus). The Rollout's pod template emits `app.kubernetes.io/name` explicitly. |
| Empty Prometheus result silently passes (defeats auto-rollback) | Added `failureCondition: len(result) == 0 || result[0] > <threshold>` AND `consecutiveErrorLimit: 0` so an empty / errored sample fails the analysis. |
| Selector collision between Deployment and Rollout | `templates/deployment.yaml` is gated off when `rollout.enabled=true`. |
| `setCanaryScale.matchTrafficWeight: true` was unconditional | Step is only rendered when `rollout.trafficRouting` is non-empty — it is a no-op otherwise. |
| `kubectl argo rollouts set image` requires a new tag | Documented in the runbook §1; the workflow follow-up issue (linked below) covers wiring content-addressed tags. |
| Workflow 45m vs serial 30m × N services | Documented in the workflow follow-up issue: parallelize via matrix job, bump timeout. |

## Deployment dependency

> **Cluster admins MUST install the Argo Rollouts controller in each
> target cluster before the chart's `Rollout` resource can reconcile.**
> The chart does NOT install it. **Pin to a specific release** so the
> install is reproducible and rollbacks are deterministic — bump the
> tag here and in the consuming repo's deploy workflow together.
>
> ```bash
> ARGO_ROLLOUTS_VERSION=v1.7.2
> kubectl create namespace argo-rollouts
> kubectl apply -n argo-rollouts \
>   -f "https://github.com/argoproj/argo-rollouts/releases/download/${ARGO_ROLLOUTS_VERSION}/install.yaml"
> ```
>
> Full operator instructions: `docs/runbooks/canary-deploy.md` §0.

## Validation

- [x] `helm lint deployments/charts/isa-service/ --strict` passes for
      all 4 combinations of `(rollout.enabled, hpa.kedaEnabled)`.
- [x] `helm template … --set rollout.enabled=true,hpa.kedaEnabled=false`
      renders Rollout + HPA(`kind=Rollout`) + AnalysisTemplate, no
      Deployment, no ScaledObject.
- [x] `helm template … --set rollout.enabled=true,hpa.kedaEnabled=true`
      renders Rollout + ScaledObject, no HPA, no Deployment.
- [x] `helm template … --set rollout.enabled=false,hpa.kedaEnabled=false`
      renders Deployment + HPA(`kind=Deployment`), no Rollout, no
      ScaledObject.
- [x] `helm template … --set rollout.enabled=false,hpa.kedaEnabled=true`
      renders Deployment + ScaledObject, no HPA, no Rollout.
- [ ] Operator: install Argo Rollouts controller in staging cluster,
      flip `rollout.enabled=true` for one canary service, deploy,
      verify `kubectl argo rollouts get rollout …` shows the ladder.
- [ ] Operator: simulate a 5% error rate against the canary RS;
      confirm AnalysisRun fails and Argo aborts the rollout.

## Unverified — needs reviewer eyes

- **Prometheus metric names.** The chart defaults to
  `http_requests_total` and `http_request_duration_seconds_bucket`
  (with label `status_code`). `isa_common.metrics` actually emits
  per-service prefixed names like
  `isa_user_auth_service_http_requests_total`. Operators flipping
  `rollout.enabled=true` MUST set `rollout.analysis.metricNames.*`
  to whatever each service actually exposes. There is a TODO in
  the AnalysisTemplate; tracked under #350 for unification.

## Cross-repo follow-ups

- **Workflow update**: xenoISA/isA_user#377 — switch
  `deploy.yml` from Blue-Green to Canary Rollout once this chart
  PR lands and the controller is installed.
- **Original PR**: xenoISA/isA_user#361 — closing in favor of
  this PR (architectural correction).

## Test plan

- [x] Helm lint passes.
- [x] Helm template renders correctly across all 4 combinations of
      `(rollout.enabled, hpa.kedaEnabled)`.
- [ ] Smoke-test in a staging cluster after the controller is
      installed there (operator task — tracked in xenoISA/isA_user#377).

Refs: xenoISA/isA_user#350 (parent epic xenoISA/isA_user#345).

Generated with [Claude Code](https://claude.com/claude-code)
