### PR TITLE
feat(infra): PgBouncer chart for isA_user HPA scale-out (#231)

### DIFF
--- a/deployments/charts/pgbouncer/Chart.yaml
+++ b/deployments/charts/pgbouncer/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: pgbouncer
+description: |
+  PgBouncer transaction-pooling layer that sits between isA platform services
+  and PostgreSQL. Multiplexes many client connections onto a small backend
+  pool so the application tier can HPA-scale without exhausting Postgres
+  `max_connections`. See xenoISA/isA_Cloud#231 and xenoISA/isA_user#345.
+type: application
+version: 0.1.0
+appVersion: "1.23.1"
+keywords:
+  - postgres
+  - pgbouncer
+  - connection-pooling
+  - hpa
+home: https://www.pgbouncer.org/
+sources:
+  - https://github.com/xenoISA/isA_Cloud
+  - https://github.com/pgbouncer/pgbouncer
+maintainers:
+  - name: isA Platform

--- a/deployments/charts/pgbouncer/README.md
+++ b/deployments/charts/pgbouncer/README.md
@@ -1,0 +1,191 @@
+# pgbouncer Helm Chart
+
+Transaction-pooling layer between isA platform services and Postgres.
+Tracking issue: [`xenoISA/isA_Cloud#231`](https://github.com/xenoISA/isA_Cloud/issues/231).
+Consumer-side cutover: [`xenoISA/isA_user#359`](https://github.com/xenoISA/isA_user/issues/359).
+
+## Why this chart exists
+
+`xenoISA/isA_user` PR #358 introduced replica-aware connection pool sizing.
+At HPA-max (10 replicas × 35 services × per-pod pool ≤ 11) the upper-bound
+client demand is ~3,850 connections. Production Postgres
+`max_connections=500` (`postgresql-ha.yaml:38`). PgBouncer in
+`pool_mode = transaction` multiplexes those ~3,850 client connections onto
+~100-200 backend connections — comfortably under the 500 ceiling — and
+without it Epic #345 cannot ship.
+
+## Capacity budget
+
+| | HPA-min replicas=2 | HPA-max replicas=10 | Postgres ceiling |
+|---|---|---|---|
+| Per-pod app pool | 5 | 11 | — |
+| Total client conns | 350 | 3,850 | — |
+| Backend conns through pgbouncer | ~50 | ~150 | 500 |
+
+PgBouncer's own knobs (per replica):
+
+```
+max_client_conn      = 5000          # 30% headroom over HPA-max worst case
+default_pool_size    = 25            # backend conns per database
+reserve_pool_size    = 5             # burst headroom
+pool_mode            = transaction
+```
+
+3 production replicas × 25 backend conns/db × 1 db = **75 backend conns at
+idle**, plus reserve_pool 15 = **~90 peak**. Roughly 18% of the Postgres
+500-conn ceiling.
+
+## Chart contents
+
+```
+deployments/charts/pgbouncer/
+├── Chart.yaml
+├── values.yaml
+├── README.md
+└── templates/
+    ├── _helpers.tpl
+    ├── configmap.yaml       # pgbouncer.ini
+    ├── secret.yaml          # auth (only when auth.create=true; local only)
+    ├── deployment.yaml      # pgbouncer + pgbouncer-exporter sidecar
+    ├── service.yaml         # ClusterIP on 6432 (+ 9127 metrics)
+    ├── pdb.yaml             # PodDisruptionBudget
+    ├── networkpolicy.yaml   # optional ingress allowlist
+    └── servicemonitor.yaml  # optional prometheus-operator scrape
+```
+
+## Per-environment values
+
+| Environment | Values file | Replicas | Auth source |
+|---|---|---|---|
+| Local kind | `deployments/kubernetes/local/values/pgbouncer.yaml` | 1 | rendered by chart (plaintext) |
+| Staging | `deployments/kubernetes/staging/values/pgbouncer.yaml` | 2 | pre-provisioned `pgbouncer-auth` Secret |
+| Production | `deployments/kubernetes/production/values/pgbouncer.yaml` | 3 | external-secrets → `pgbouncer-auth` Secret |
+
+## Prerequisites
+
+- A reachable Postgres backend (`postgresql` Service in local/staging,
+  `postgresql-ha-pgpool` in production).
+- For staging/production: a Kubernetes Secret named `pgbouncer-auth`
+  containing the keys below — see *Provisioning credentials*.
+- For staging/production with metrics: `prometheus-operator`
+  (`kube-prometheus-stack`) with the `release: prometheus` selector.
+
+## Install
+
+### Local (kind)
+
+```bash
+helm upgrade --install pgbouncer \
+  ~/Documents/Fun/isA/isA_Cloud/deployments/charts/pgbouncer \
+  -n isa-cloud-local \
+  -f ~/Documents/Fun/isA/isA_Cloud/deployments/kubernetes/local/values/pgbouncer.yaml \
+  --set auth.adminPassword=staging_postgres_2024 \
+  --set auth.statsPassword=staging_postgres_2024
+```
+
+### Staging / Production
+
+```bash
+# 1) Provision the auth Secret first (see "Provisioning credentials").
+# 2) Install the chart.
+helm upgrade --install pgbouncer \
+  ~/Documents/Fun/isA/isA_Cloud/deployments/charts/pgbouncer \
+  -n isa-cloud-staging \
+  -f ~/Documents/Fun/isA/isA_Cloud/deployments/kubernetes/staging/values/pgbouncer.yaml
+```
+
+## Provisioning credentials
+
+The auth Secret must contain these keys:
+
+| Key | Purpose |
+|---|---|
+| `admin-username` | PgBouncer admin role (used by the chart for the `admin_users` directive). |
+| `admin-password` | Admin password. |
+| `stats-username` | Read-only role used by the prometheus-exporter sidecar (`stats_users`). |
+| `stats-password` | Stats password. |
+| `userlist.txt` | Full pgbouncer userlist (one `"user" "hash"` row per line). MUST include the application user(s) used by isA_user services. |
+
+### Generating `userlist.txt`
+
+For SCRAM-SHA-256 (Postgres 14+ — the default for the platform), the hash
+is the literal contents of `pg_authid.rolpassword` for each role. Pull it
+straight out of Postgres:
+
+```bash
+PGPASSWORD=$ADMIN_PW psql -h <postgres-host> -U postgres -d postgres -tAc \
+  "SELECT format('\"%s\" \"%s\"', rolname, rolpassword)
+   FROM pg_authid
+   WHERE rolname IN ('isa_admin', 'pgbouncer_stats')" \
+  > userlist.txt
+```
+
+### Creating the Secret
+
+```bash
+kubectl create secret generic pgbouncer-auth \
+  -n isa-cloud-staging \
+  --from-literal=admin-username=isa_admin \
+  --from-literal=admin-password="$ADMIN_PW" \
+  --from-literal=stats-username=pgbouncer_stats \
+  --from-literal=stats-password="$STATS_PW" \
+  --from-file=userlist.txt=./userlist.txt
+```
+
+For production, drive this through `ExternalSecret` so credential rotation
+flows from the source-of-truth (Vault / AWS SM) without a manual
+`kubectl create secret`.
+
+## Operator playbook
+
+### Verifying a fresh install
+
+```bash
+# Wait for the deployment to roll.
+kubectl rollout status deploy/pgbouncer -n isa-cloud-staging
+
+# Open a port-forward and run a SHOW POOLS / SHOW STATS against pgbouncer.
+kubectl port-forward -n isa-cloud-staging svc/pgbouncer 6432:6432 &
+PGPASSWORD=$STATS_PW psql -h localhost -p 6432 -U pgbouncer_stats -d pgbouncer \
+  -c "SHOW POOLS;" -c "SHOW STATS;"
+```
+
+### Tuning `default_pool_size`
+
+`default_pool_size` is the backend-pool ceiling **per database, per
+pgbouncer replica**. The whole platform uses a single `isa_platform`
+database, so the cluster-wide backend draw is roughly
+`replicas × default_pool_size`. Total budget vs. Postgres
+`max_connections` is monitored by the `pgbouncer_pools` /
+`pgbouncer_stats_*` metrics — pull them up in Grafana before changing
+this.
+
+### Debugging "no more connections allowed" errors
+
+This is almost always one of:
+
+1. `max_client_conn` exceeded — bump it in the values file. Each idle
+   client connection costs ~2KB on the pgbouncer pod.
+2. `default_pool_size` saturated — backends are slow or too few.
+   `SHOW POOLS;` shows `cl_waiting > 0` and `sv_active = default_pool_size`.
+   Either raise `default_pool_size` or fix the slow backend query.
+3. Postgres `max_connections` hit — check
+   `kubectl logs deploy/postgresql-ha-postgresql -n isa-cloud-production`
+   for `FATAL: sorry, too many clients already`.
+
+## Out of scope for the initial chart PR
+
+- Routing isA_user services through pgbouncer
+  (`POSTGRES_HOST`/`POSTGRES_PORT` flip). Tracked separately in
+  `xenoISA/isA_user`.
+- Tuning the per-service application pool back up to 5/3 once pgbouncer
+  is in place. Tracked in the same follow-up.
+- Multi-region / geo-replicated pooling.
+
+## Related
+
+- Issue: [`xenoISA/isA_Cloud#231`](https://github.com/xenoISA/isA_Cloud/issues/231)
+- Consumer cutover: [`xenoISA/isA_user#359`](https://github.com/xenoISA/isA_user/issues/359)
+- Parent epic: [`xenoISA/isA_user#345`](https://github.com/xenoISA/isA_user/issues/345)
+- PgBouncer upstream: <https://www.pgbouncer.org/config.html>
+- Bitnami pgbouncer image: <https://hub.docker.com/r/bitnami/pgbouncer>

--- a/deployments/charts/pgbouncer/templates/_helpers.tpl
+++ b/deployments/charts/pgbouncer/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Common labels emitted on every resource.
+*/}}
+{{- define "pgbouncer.labels" -}}
+app: {{ .Values.name }}
+app.kubernetes.io/name: pgbouncer
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: isa-platform
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{/*
+Selector labels — the stable subset used in pod selectors. Must NOT change
+between revisions or the Deployment selector becomes immutable.
+*/}}
+{{- define "pgbouncer.selectorLabels" -}}
+app: {{ .Values.name }}
+app.kubernetes.io/name: pgbouncer
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Name of the auth Secret. Either rendered by this chart (auth.create=true) or
+pre-provisioned by the cluster operator and referenced via
+auth.existingSecret.
+*/}}
+{{- define "pgbouncer.authSecretName" -}}
+{{- if .Values.auth.existingSecret -}}
+{{ .Values.auth.existingSecret }}
+{{- else -}}
+{{ printf "%s-auth" .Values.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the ConfigMap name for pgbouncer.ini.
+*/}}
+{{- define "pgbouncer.configMapName" -}}
+{{ printf "%s-config" .Values.name }}
+{{- end -}}

--- a/deployments/charts/pgbouncer/templates/configmap.yaml
+++ b/deployments/charts/pgbouncer/templates/configmap.yaml
@@ -1,0 +1,61 @@
+{{- /*
+  pgbouncer.ini lives in a ConfigMap; userlist.txt lives in the auth Secret
+  and is mounted alongside it at /etc/pgbouncer. Splitting the two keeps
+  credentials out of the ConfigMap (which is world-readable to anyone with
+  namespace get) while letting `helm upgrade` re-render config without
+  touching the credential surface.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pgbouncer.configMapName" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "pgbouncer.labels" . | nindent 4 }}
+data:
+  pgbouncer.ini: |
+    [databases]
+    {{- range .Values.config.databases }}
+    {{- $host := .host | default $.Values.postgres.host }}
+    {{- $port := .port | default $.Values.postgres.port }}
+    {{ .name }} = host={{ $host }} port={{ $port }} dbname={{ .dbname | default .name }}{{- if .authUser }} auth_user={{ .authUser }}{{- end }}
+    {{- end }}
+
+    [pgbouncer]
+    listen_addr = 0.0.0.0
+    listen_port = {{ .Values.port }}
+    # Default unix_socket_dir is /tmp/.s.PGSQL.* — a writable emptyDir is
+    # mounted at /tmp so readOnlyRootFilesystem stays on.
+    unix_socket_dir = /tmp
+
+    auth_type = {{ .Values.auth.type }}
+    auth_file = /etc/pgbouncer/userlist.txt
+
+    pool_mode = {{ .Values.config.poolMode }}
+    default_pool_size = {{ .Values.config.defaultPoolSize }}
+    min_pool_size = {{ .Values.config.minPoolSize }}
+    reserve_pool_size = {{ .Values.config.reservePoolSize }}
+    reserve_pool_timeout = {{ .Values.config.reservePoolTimeout }}
+    max_client_conn = {{ .Values.config.maxClientConn }}
+    max_db_connections = {{ .Values.config.maxDbConnections }}
+
+    server_idle_timeout = {{ .Values.config.serverIdleTimeout }}
+    server_lifetime = {{ .Values.config.serverLifetime }}
+    query_wait_timeout = {{ .Values.config.queryWaitTimeout }}
+    tcp_keepalive = {{ .Values.config.tcpKeepalive }}
+
+    server_tls_sslmode = {{ .Values.config.serverTlsSslmode }}
+
+    admin_users = {{ join "," .Values.config.adminUsers }}
+    stats_users = {{ join "," .Values.config.statsUsers }}
+
+    # Logs go to stdout so kubectl/loki pick them up; PgBouncer's own log_*
+    # toggles stay at defaults.
+    logfile =
+    pidfile =
+
+    verbose = {{ .Values.config.verbose }}
+
+    # Required for transaction pooling — disable session-level features that
+    # would otherwise leak between clients sharing a backend connection.
+    ignore_startup_parameters = extra_float_digits,search_path,application_name

--- a/deployments/charts/pgbouncer/templates/deployment.yaml
+++ b/deployments/charts/pgbouncer/templates/deployment.yaml
@@ -1,0 +1,175 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "pgbouncer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "pgbouncer.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # PgBouncer loses in-flight transactions on shutdown, so spin a fresh
+      # pod up first and let the PDB+graceful drain hand off cleanly.
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "pgbouncer.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Bounce pods on config/secret changes — Helm's checksum trick.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.auth.create }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # PgBouncer benefits from a graceful drain — it stops accepting new
+      # client connections on SIGTERM but keeps existing transactions open
+      # until they commit/rollback. 30s covers typical OLTP workloads.
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: pgbouncer
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          # The edoburu image's entrypoint generates pgbouncer.ini from env
+          # vars only when /etc/pgbouncer/pgbouncer.ini does NOT already
+          # exist. We mount our chart-rendered config at that exact path,
+          # so the entrypoint skips regeneration and exec()s pgbouncer
+          # against our config verbatim.
+          env:
+            - name: AUTH_FILE
+              value: /etc/pgbouncer/userlist.txt
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: pgbouncer
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          # TCP probe — pgbouncer accepts connections as soon as it's bound.
+          # Avoids needing pg_isready (which would require auth round-trips).
+          readinessProbe:
+            tcpSocket:
+              port: pgbouncer
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: pgbouncer
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/pgbouncer/pgbouncer.ini
+              subPath: pgbouncer.ini
+              readOnly: true
+            - name: auth
+              mountPath: /etc/pgbouncer/userlist.txt
+              subPath: userlist.txt
+              readOnly: true
+            # readOnlyRootFilesystem=true blocks /tmp by default. The
+            # edoburu entrypoint's `touch userlist.txt` no-ops thanks to
+            # our subPath mount above, but pgbouncer itself may write a
+            # PID under /var/run/pgbouncer. Bind both as writable tmpfs.
+            - name: tmp
+              mountPath: /tmp
+            - name: pgbouncer-run
+              mountPath: /var/run/pgbouncer
+        {{- if .Values.exporter.enabled }}
+        - name: pgbouncer-exporter
+          image: "{{ .Values.exporter.image.registry }}/{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
+          imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1001
+          # The exporter speaks pgbouncer's stats virtual DB over a normal
+          # client connection on localhost:6432, authenticating as the stats
+          # user. Credentials come from the auth secret.
+          # NOTE on env ordering: K8s `$(VAR)` substitution only resolves
+          # against env entries defined *earlier* in the same container's
+          # env list. STATS_USER / STATS_PASSWORD must come BEFORE
+          # PGBOUNCER_EXPORTER_CONNECTION_STRING or the substitution leaves
+          # the literal `$(STATS_USER)` in the connection string and the
+          # exporter dies on first scrape.
+          env:
+            - name: STATS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgbouncer.authSecretName" . }}
+                  key: stats-username
+            - name: STATS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgbouncer.authSecretName" . }}
+                  key: stats-password
+            # prometheus-community/pgbouncer-exporter reads the connection
+            # string from PGBOUNCER_EXPORTER_CONNECTION_STRING (the default
+            # is `postgres://postgres:@localhost:6543/pgbouncer` which is
+            # wrong for our setup — pgbouncer listens on 6432 and uses a
+            # separate stats role).
+            - name: PGBOUNCER_EXPORTER_CONNECTION_STRING
+              value: "postgres://$(STATS_USER):$(STATS_PASSWORD)@127.0.0.1:{{ .Values.port }}/pgbouncer?sslmode=disable"
+          args:
+            - "--web.listen-address=:{{ .Values.exporter.port }}"
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.exporter.port }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.exporter.resources | nindent 12 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "pgbouncer.configMapName" . }}
+        - name: auth
+          secret:
+            secretName: {{ include "pgbouncer.authSecretName" . }}
+            items:
+              - key: userlist.txt
+                path: userlist.txt
+        - name: tmp
+          emptyDir: {}
+        - name: pgbouncer-run
+          emptyDir: {}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployments/charts/pgbouncer/templates/networkpolicy.yaml
+++ b/deployments/charts/pgbouncer/templates/networkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- /*
+  Optional ingress restriction. Keeps pgbouncer:6432 reachable only from
+  the listed namespaces. Egress to Postgres is left unrestricted because
+  the ServiceAccount + DNS path already enforce that boundary at the
+  cluster level.
+*/ -}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "pgbouncer.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "pgbouncer.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        {{- range .Values.networkPolicy.allowedNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.port }}
+        {{- if .Values.exporter.enabled }}
+        - protocol: TCP
+          port: {{ .Values.exporter.port }}
+        {{- end }}
+{{- end }}

--- a/deployments/charts/pgbouncer/templates/pdb.yaml
+++ b/deployments/charts/pgbouncer/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (int .Values.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "pgbouncer.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pgbouncer.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deployments/charts/pgbouncer/templates/secret.yaml
+++ b/deployments/charts/pgbouncer/templates/secret.yaml
@@ -1,0 +1,43 @@
+{{- /*
+  Auth Secret — only rendered when auth.create=true (local clusters).
+  Staging + production MUST pre-provision this Secret out-of-band (e.g.
+  external-secrets, sealed-secrets, or `kubectl create secret`) and leave
+  auth.create=false.
+
+  Required keys:
+    - admin-username / admin-password   — the [pgbouncer] admin role
+    - stats-username / stats-password   — read-only metrics scraper
+    - userlist.txt                      — full SCRAM/MD5 userlist
+
+  userlist.txt format (one row per user, double-quoted):
+    "isa_user" "SCRAM-SHA-256$4096:..."
+
+  See README.md "Provisioning credentials" for the operator workflow.
+*/ -}}
+{{- if .Values.auth.create }}
+{{- if not .Values.auth.adminPassword }}
+{{- fail "auth.adminPassword is required when auth.create=true" }}
+{{- end }}
+{{- if not .Values.auth.statsPassword }}
+{{- fail "auth.statsPassword is required when auth.create=true" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pgbouncer.authSecretName" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "pgbouncer.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  admin-username: {{ .Values.auth.adminUsername | quote }}
+  admin-password: {{ .Values.auth.adminPassword | quote }}
+  stats-username: {{ .Values.auth.statsUsername | quote }}
+  stats-password: {{ .Values.auth.statsPassword | quote }}
+  # Plaintext userlist — fine on local kind clusters where auth.type=md5
+  # and the plaintext password matches the postgres role. Production clusters
+  # MUST provide a SCRAM-hashed userlist via existingSecret.
+  userlist.txt: |
+    "{{ .Values.auth.adminUsername }}" "{{ .Values.auth.adminPassword }}"
+    "{{ .Values.auth.statsUsername }}" "{{ .Values.auth.statsPassword }}"
+{{- end }}

--- a/deployments/charts/pgbouncer/templates/service.yaml
+++ b/deployments/charts/pgbouncer/templates/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "pgbouncer.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: pgbouncer
+      port: {{ .Values.port }}
+      targetPort: pgbouncer
+      protocol: TCP
+    {{- if .Values.exporter.enabled }}
+    - name: metrics
+      port: {{ .Values.exporter.port }}
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}
+  selector:
+    {{- include "pgbouncer.selectorLabels" . | nindent 4 }}

--- a/deployments/charts/pgbouncer/templates/servicemonitor.yaml
+++ b/deployments/charts/pgbouncer/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- /*
+  Prometheus Operator ServiceMonitor — scrapes the pgbouncer-exporter
+  sidecar on port 9127. Off by default; flip via serviceMonitor.enabled
+  in environments where prometheus-operator is installed (matches the
+  pattern used by deployments/kubernetes/production/manifests/
+  prometheus-service-monitors.yaml).
+*/ -}}
+{{- if and .Values.serviceMonitor.enabled .Values.exporter.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "pgbouncer.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.namespace }}
+  selector:
+    matchLabels:
+      {{- include "pgbouncer.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deployments/charts/pgbouncer/values.yaml
+++ b/deployments/charts/pgbouncer/values.yaml
@@ -1,0 +1,242 @@
+# =============================================================================
+# pgbouncer chart — defaults (xenoISA/isA_Cloud#231)
+# =============================================================================
+# Transaction-pooling fronts the isA platform services so they can HPA-scale
+# without saturating Postgres max_connections. Defaults below target the
+# staging/local profile; production overrides live in
+# deployments/kubernetes/production/values/pgbouncer.yaml.
+#
+# Capacity math (from PgBouncer's perspective):
+#
+#   client side: max_client_conn (5000)
+#               must be >= sum(per-pod pool * pods * services)
+#               HPA-max worst case = 10 pods * 35 services * 11 = 3,850
+#               -> 5000 leaves ~30% headroom
+#
+#   backend side: replicas * (#databases) * default_pool_size
+#                = 2 * 1 * 25 = 50 backend conns at idle
+#                + reserve_pool_size (5) per db -> 60 peak per replica
+#                worst case 2 * 60 = 120 backend conns
+#                Postgres max_connections (prod) = 500 -> ~24% utilization
+#
+# Tune `default_pool_size` and `replicas` per environment; the rest of the
+# pgbouncer.ini block scales with them.
+# =============================================================================
+
+name: pgbouncer
+namespace: isa-cloud-staging
+
+image:
+  registry: docker.io
+  # edoburu/pgbouncer is the de-facto K8s pgbouncer image: small (~15MB
+  # alpine), env-var configurable, and respects a chart-mounted
+  # /etc/pgbouncer/pgbouncer.ini (its entrypoint skips re-generation when
+  # the file already exists).
+  #
+  # Bitnami's pgbouncer image was retired into the bitnamilegacy/ namespace
+  # in late 2025, so we don't pin it here.
+  repository: edoburu/pgbouncer
+  tag: "v1.25.1-p0"
+  pullPolicy: IfNotPresent
+
+# 2 replicas is the staging/HA default. Local dev overrides to 1; production
+# overrides to 3 for an extra failure-domain margin.
+replicas: 2
+
+# Listening port for application clients. PgBouncer's standard port.
+port: 6432
+
+# =============================================================================
+# Backend Postgres connection target
+# =============================================================================
+# host:port the pgbouncer pods dial out to. Override per environment.
+postgres:
+  host: postgresql.isa-cloud-staging.svc.cluster.local
+  port: 5432
+  # SSL mode for the backend connection. `prefer` works against bitnami's
+  # postgresql chart in both staging and prod-ha. Set `disable` only for
+  # local dev clusters that don't have certs.
+  sslmode: prefer
+
+# =============================================================================
+# Authentication
+# =============================================================================
+# Two auth modes are supported:
+#
+#   1. existingSecret — recommended for staging + production. Operator
+#      provisions a Secret with these keys *before* helm install:
+#        - admin-username
+#        - admin-password
+#        - stats-username
+#        - stats-password
+#        - userlist.txt   (full SCRAM/MD5 userlist for app users; templated
+#                          into /etc/pgbouncer/userlist.txt by an init job
+#                          or external-secrets, see README)
+#
+#   2. plaintext (auth.create=true) — for local kind clusters only. Renders
+#      a Secret in-cluster from the values below. NEVER use in staging/prod.
+auth:
+  # Set true to render a Secret from the plaintext credentials below. Local
+  # only. Production MUST set this to false and provide existingSecret.
+  create: false
+
+  # Name of the Secret to mount. When create=true the chart renders a Secret
+  # at this name; when create=false the operator must pre-provision it.
+  existingSecret: pgbouncer-auth
+
+  # Plaintext fallback values (only consumed when create=true).
+  adminUsername: pgbouncer
+  adminPassword: ""        # Required when create=true.
+  statsUsername: pgbouncer_stats
+  statsPassword: ""        # Required when create=true.
+
+  # SCRAM-SHA-256 is the right default for Postgres 14+. Bitnami's postgresql
+  # chart ships PG 16 by default, so SCRAM is safe. Drop to "md5" only for
+  # legacy backends < PG 14.
+  type: scram-sha-256
+
+# =============================================================================
+# pgbouncer.ini knobs (rendered into the configmap)
+# =============================================================================
+# Defaults are the issue's recommended baseline for HPA scale-out workloads
+# (transaction pooling, ~25 backend conns/db, 5000 client cap).
+config:
+  poolMode: transaction
+  defaultPoolSize: 25
+  minPoolSize: 0
+  reservePoolSize: 5
+  reservePoolTimeout: 3
+  maxClientConn: 5000
+  maxDbConnections: 0    # 0 = unlimited; bound only by default_pool_size
+  serverIdleTimeout: 600
+  serverLifetime: 3600
+  queryWaitTimeout: 30
+  tcpKeepalive: 1
+  # Stats access goes to the virtual `pgbouncer` admin DB, not the backend.
+  # Override only if you wire up additional stats consumers.
+  statsUsers:
+    - pgbouncer_stats
+  adminUsers:
+    - pgbouncer
+  # Verbose logging for diagnostics. 0 = info, 1 = debug, 2 = noisy.
+  verbose: 0
+  # Server-side TLS to the backend Postgres. Mirrors postgres.sslmode above
+  # but lives in pgbouncer.ini at the server_tls_sslmode key.
+  serverTlsSslmode: prefer
+
+  # =========================================================================
+  # Application databases routed through pgbouncer.
+  # =========================================================================
+  # Both staging and production isA_user services connect to a logical
+  # database named `isa_platform`. Map that name onto the same backend
+  # database — clients keep using `dbname=isa_platform` and pgbouncer pools
+  # transparently. Add per-service logical aliases here if a service needs
+  # a separate pool (rare; transaction pooling already isolates txns).
+  databases:
+    - name: isa_platform
+      host: ""             # blank = use top-level postgres.host
+      port: ""             # blank = use top-level postgres.port
+      dbname: isa_platform
+      # Authenticate as the platform admin user. The userlist.txt secret
+      # must include matching credentials. To pin a specific user override
+      # `authUser` per database here.
+      authUser: ""
+
+# =============================================================================
+# Observability
+# =============================================================================
+# Two layers:
+#  - serviceMonitor: pgbouncer's stats virtual DB queried via a
+#    `pgbouncer-exporter` sidecar (same release pattern as postgres-exporter).
+#  - prometheus pod-scrape annotations as a fallback.
+exporter:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: prometheuscommunity/pgbouncer-exporter
+    tag: "v0.10.2"
+    pullPolicy: IfNotPresent
+  port: 9127
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+serviceMonitor:
+  # Toggle off for environments without prometheus-operator installed.
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  # Selector label the operator uses for discovery. Matches the pattern in
+  # deployments/kubernetes/production/manifests/prometheus-service-monitors.yaml.
+  labels:
+    release: prometheus
+
+# =============================================================================
+# Network exposure
+# =============================================================================
+service:
+  type: ClusterIP
+  # Only the application namespace needs to reach this service. Cross-namespace
+  # ingress is gated by the optional NetworkPolicy below.
+  annotations: {}
+
+# =============================================================================
+# Resources / scheduling
+# =============================================================================
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+podSecurityContext:
+  # edoburu/pgbouncer is built on alpine and runs as the `postgres` user (UID 70).
+  runAsNonRoot: true
+  runAsUser: 70
+  runAsGroup: 70
+  fsGroup: 70
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  runAsUser: 70
+
+# Pod Disruption Budget — at 2 replicas we tolerate one pod down at a time
+# during a node drain. Disabled automatically when replicas <= 1.
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+
+# Spread pgbouncer pods across nodes/zones so a single node loss can't take
+# the whole pool offline.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app: pgbouncer
+
+affinity: {}
+
+# Optional ingress restriction. Off by default to match staging's permissive
+# stance; production may flip this on with a per-namespace allowlist.
+networkPolicy:
+  enabled: false
+  # Namespaces allowed to dial pgbouncer:6432.
+  allowedNamespaces:
+    - isa-cloud-staging
+
+podAnnotations: {}
+
+extraEnv: []

--- a/deployments/kubernetes/local/values/pgbouncer.yaml
+++ b/deployments/kubernetes/local/values/pgbouncer.yaml
@@ -1,0 +1,75 @@
+# =============================================================================
+# PgBouncer — LOCAL kind cluster (isa-cloud-local)
+# =============================================================================
+# Single replica, plaintext-rendered Secret, talks to the bitnami postgresql
+# Service that already runs in this namespace.
+#
+# Install:
+#   helm upgrade --install pgbouncer ~/Documents/Fun/isA/isA_Cloud/deployments/charts/pgbouncer \
+#     -n isa-cloud-local \
+#     -f ~/Documents/Fun/isA/isA_Cloud/deployments/kubernetes/local/values/pgbouncer.yaml \
+#     --set auth.adminPassword=staging_postgres_2024 \
+#     --set auth.statsPassword=staging_postgres_2024
+#
+# (The postgres password staging_postgres_2024 comes from
+# deployments/kubernetes/local/values/postgresql.yaml.)
+# =============================================================================
+
+name: pgbouncer
+namespace: isa-cloud-local
+
+replicas: 1
+
+postgres:
+  host: postgresql.isa-cloud-local.svc.cluster.local
+  port: 5432
+  # Local kind cluster has no certs — pin to disable so handshake doesn't fail.
+  sslmode: disable
+
+auth:
+  # Local-only: render a plaintext Secret in-cluster. NEVER use in staging/prod.
+  create: true
+  existingSecret: pgbouncer-auth
+  type: md5     # bitnami's local postgres uses md5 by default
+  adminUsername: postgres
+  # adminPassword + statsPassword are passed via --set on the helm command.
+  statsUsername: pgbouncer_stats
+
+config:
+  # Lighter defaults for a single-node kind cluster.
+  defaultPoolSize: 10
+  reservePoolSize: 2
+  maxClientConn: 500
+  serverTlsSslmode: disable
+  databases:
+    - name: isa_platform
+      dbname: isa_platform
+    # Keep `postgres` reachable for `psql -d postgres` admin probes.
+    - name: postgres
+      dbname: postgres
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 128Mi
+
+# Single replica — no PDB needed.
+podDisruptionBudget:
+  enabled: false
+
+# Local kind cluster has no prometheus-operator — keep ServiceMonitor off,
+# but leave the exporter sidecar on so `kubectl port-forward svc/pgbouncer 9127`
+# still surfaces metrics for ad-hoc inspection.
+exporter:
+  enabled: true
+serviceMonitor:
+  enabled: false
+
+# Single-node kind: don't enforce hostname spreading.
+topologySpreadConstraints: []
+
+networkPolicy:
+  enabled: false

--- a/deployments/kubernetes/production/values/pgbouncer.yaml
+++ b/deployments/kubernetes/production/values/pgbouncer.yaml
@@ -1,0 +1,100 @@
+# =============================================================================
+# PgBouncer — PRODUCTION (isa-cloud-production)
+# =============================================================================
+# 3 replicas, full resource limits, talks to the postgresql-ha primary
+# Service. Auth Secret MUST be provisioned via external-secrets before
+# helm install.
+#
+# Capacity math (production):
+#   * 35 services × 10 HPA-max replicas × 11 pool size = 3,850 client conns
+#   * max_client_conn = 5000 (30% headroom over worst case)
+#   * 3 pgbouncer replicas × 1 db × default_pool_size 25 = 75 backend conns
+#     (+ reserve_pool_size 5 × 3 = 15) -> ~90 peak backend conns
+#   * Postgres max_connections = 500 (postgresql-ha.yaml:38) -> ~18% used
+#
+# Pre-flight (one-time):
+#   external-secrets.io ExternalSecret should sync the credential payload
+#   from Vault/AWS Secrets Manager into the `pgbouncer-auth` Secret with the
+#   keys: admin-username, admin-password, stats-username, stats-password,
+#   userlist.txt (SCRAM-hashed). See README "Provisioning credentials".
+#
+# Install:
+#   helm upgrade --install pgbouncer ~/Documents/Fun/isA/isA_Cloud/deployments/charts/pgbouncer \
+#     -n isa-cloud-production \
+#     -f ~/Documents/Fun/isA/isA_Cloud/deployments/kubernetes/production/values/pgbouncer.yaml
+# =============================================================================
+
+name: pgbouncer
+namespace: isa-cloud-production
+
+# 3 replicas spread across nodes for an extra failure-domain margin over
+# staging's 2-replica baseline.
+replicas: 3
+
+postgres:
+  # postgresql-ha primary Service. The bitnami chart exposes the writable
+  # endpoint at the `-pgpool` Service if pgpool is enabled, or at
+  # `<release>-postgresql-ha-postgresql` for direct primary access. We dial
+  # the pgpool front-end so failover is transparent to pgbouncer.
+  host: postgresql-ha-pgpool.isa-cloud-production.svc.cluster.local
+  port: 5432
+  sslmode: require
+
+auth:
+  create: false
+  existingSecret: pgbouncer-auth
+  type: scram-sha-256
+
+config:
+  poolMode: transaction
+  defaultPoolSize: 25
+  reservePoolSize: 5
+  reservePoolTimeout: 3
+  maxClientConn: 5000
+  serverIdleTimeout: 600
+  serverLifetime: 3600
+  queryWaitTimeout: 30
+  tcpKeepalive: 1
+  serverTlsSslmode: require
+  databases:
+    # Production isA_user services connect to `isa_platform` (verified
+    # against isA_user/deployment/helm/values-production.yaml).
+    - name: isa_platform
+      dbname: isa_platform
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+podDisruptionBudget:
+  enabled: true
+  # 3 replicas — keep at least 2 up at all times.
+  minAvailable: 2
+
+exporter:
+  enabled: true
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  labels:
+    release: prometheus
+
+# Hard spread across nodes so a single node drain can't knock out a quorum.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app: pgbouncer
+
+# Application-tier ingress only — keeps the pool surface contained.
+networkPolicy:
+  enabled: true
+  allowedNamespaces:
+    - isa-cloud-production

--- a/deployments/kubernetes/staging/values/pgbouncer.yaml
+++ b/deployments/kubernetes/staging/values/pgbouncer.yaml
@@ -1,0 +1,74 @@
+# =============================================================================
+# PgBouncer — STAGING (isa-cloud-staging)
+# =============================================================================
+# 2 replicas, auth Secret pre-provisioned out-of-band by the operator.
+#
+# Pre-flight (one-time per cluster):
+#   kubectl create secret generic pgbouncer-auth \
+#     -n isa-cloud-staging \
+#     --from-literal=admin-username=isa_admin \
+#     --from-literal=admin-password='<staging-postgres-password>' \
+#     --from-literal=stats-username=pgbouncer_stats \
+#     --from-literal=stats-password='<staging-stats-password>' \
+#     --from-file=userlist.txt=/path/to/staging-userlist.txt
+#
+# Install:
+#   helm upgrade --install pgbouncer ~/Documents/Fun/isA/isA_Cloud/deployments/charts/pgbouncer \
+#     -n isa-cloud-staging \
+#     -f ~/Documents/Fun/isA/isA_Cloud/deployments/kubernetes/staging/values/pgbouncer.yaml
+# =============================================================================
+
+name: pgbouncer
+namespace: isa-cloud-staging
+
+replicas: 2
+
+postgres:
+  host: postgresql.isa-cloud-staging.svc.cluster.local
+  port: 5432
+  sslmode: prefer
+
+auth:
+  create: false
+  existingSecret: pgbouncer-auth
+  type: scram-sha-256
+
+config:
+  poolMode: transaction
+  defaultPoolSize: 25
+  reservePoolSize: 5
+  maxClientConn: 5000
+  serverTlsSslmode: prefer
+  databases:
+    - name: isa_platform
+      dbname: isa_platform
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+
+exporter:
+  enabled: true
+serviceMonitor:
+  enabled: true
+  labels:
+    release: prometheus
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app: pgbouncer
+
+networkPolicy:
+  enabled: false


### PR DESCRIPTION
## Summary

Adds a transaction-pooling PgBouncer layer between isA platform services and Postgres so the application tier can HPA-scale without saturating Postgres `max_connections`.

This is the last release blocker for `xenoISA/isA_user` Epic [#345](https://github.com/xenoISA/isA_user/issues/345). isA_user PR #358 (merged) introduced replica-aware pool sizing; at HPA-max the upper-bound client demand is ~3,850 connections. Production Postgres `max_connections=500` (`postgresql-ha.yaml:38`). PgBouncer in `pool_mode = transaction` multiplexes the client side onto ~75-150 backend connections.

## Capacity math (production)

| | HPA-min replicas=2 | HPA-max replicas=10 | Postgres ceiling |
|---|---|---|---|
| Per-pod app pool | 5 | 11 | — |
| Total client conns | 350 | 3,850 | — |
| Backend conns through pgbouncer | ~50 | ~150 | 500 |

Production knobs: 3 pgbouncer replicas × `default_pool_size = 25` × 1 db = **75 idle backend conns**, plus `reserve_pool_size = 5` per replica = **~90 peak**. Roughly **18%** of the 500-conn ceiling.

## Chart structure

```
deployments/charts/pgbouncer/
├── Chart.yaml
├── values.yaml
├── README.md
└── templates/
    ├── _helpers.tpl
    ├── configmap.yaml       # pgbouncer.ini (transaction mode, sane defaults)
    ├── secret.yaml          # auth (chart-rendered ONLY when auth.create=true; local-only)
    ├── deployment.yaml      # main container + prometheuscommunity/pgbouncer-exporter sidecar
    ├── service.yaml         # ClusterIP :6432 + :9127 metrics
    ├── pdb.yaml             # PodDisruptionBudget (auto-disabled at replicas<=1)
    ├── networkpolicy.yaml   # optional ingress allowlist
    └── servicemonitor.yaml  # optional prometheus-operator scrape
```

Per-environment values:
- `deployments/kubernetes/local/values/pgbouncer.yaml` — 1 replica, plaintext Secret, sslmode=disable, points at the `postgresql` Service in `isa-cloud-local`
- `deployments/kubernetes/staging/values/pgbouncer.yaml` — 2 replicas, existingSecret, prometheus-operator ServiceMonitor
- `deployments/kubernetes/production/values/pgbouncer.yaml` — 3 replicas, minAvailable=2 PDB, NetworkPolicy locked to `isa-cloud-production`, dials `postgresql-ha-pgpool` primary

## Image choice

Uses `edoburu/pgbouncer:v1.25.1-p0`:
- Small (~7 MB compressed), alpine-based
- Env-var configurable, but the entrypoint **respects a chart-mounted `/etc/pgbouncer/pgbouncer.ini`** (skips regeneration when the file exists), so we drive everything from the ConfigMap
- Bitnami's `pgbouncer` image was retired into the `bitnamilegacy/` namespace in late 2025 — kept off-deck to avoid the legacy supply-chain coupling

## Prereqs

- Reachable Postgres backend (already deployed in every cluster)
- Staging/production: Kubernetes Secret `pgbouncer-auth` provisioned out-of-band with `admin-username`, `admin-password`, `stats-username`, `stats-password`, `userlist.txt` — see chart README "Provisioning credentials"
- Staging/production with metrics: `prometheus-operator` (`kube-prometheus-stack`) with the `release: prometheus` selector — already in the cluster (`deployments/kubernetes/production/manifests/prometheus-service-monitors.yaml`)

## Install (per env)

```bash
# Local kind
helm upgrade --install pgbouncer deployments/charts/pgbouncer \
  -n isa-cloud-local \
  -f deployments/kubernetes/local/values/pgbouncer.yaml \
  --set auth.adminPassword=staging_postgres_2024 \
  --set auth.statsPassword=staging_postgres_2024

# Staging / production (after creating pgbouncer-auth Secret)
helm upgrade --install pgbouncer deployments/charts/pgbouncer \
  -n isa-cloud-staging \
  -f deployments/kubernetes/staging/values/pgbouncer.yaml
```

## Validation evidence

`helm lint --strict`:

```
==> Linting deployments/charts/pgbouncer/
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed
```

`helm template ... | kubectl apply --dry-run=client` for all three envs:

```
LOCAL:      secret/pgbouncer-auth created (dry run)
            configmap/pgbouncer-config created (dry run)
            service/pgbouncer created (dry run)
            deployment.apps/pgbouncer created (dry run)
STAGING:    poddisruptionbudget.policy/pgbouncer created (dry run)
            configmap/pgbouncer-config created (dry run)
            service/pgbouncer created (dry run)
            deployment.apps/pgbouncer created (dry run)
PRODUCTION: networkpolicy.networking.k8s.io/pgbouncer created (dry run)
            poddisruptionbudget.policy/pgbouncer created (dry run)
            configmap/pgbouncer-config created (dry run)
            service/pgbouncer created (dry run)
            deployment.apps/pgbouncer created (dry run)
```

(Staging/production runs `--set serviceMonitor.enabled=false` for the dry-run because the local kind cluster doesn't have the `monitoring.coreos.com/v1` CRD; the live staging/prod clusters do.)

**Live smoke test against the local kind cluster** (`isa-cloud-local` namespace, real bitnami `postgresql-0` pod):

```bash
$ helm install pgbouncer deployments/charts/pgbouncer/ -n isa-cloud-local \
    -f deployments/kubernetes/local/values/pgbouncer.yaml \
    --set auth.adminPassword=staging_postgres_2024 \
    --set auth.statsPassword=staging_postgres_2024 --wait
NAME: pgbouncer
STATUS: deployed

$ kubectl get pod -n isa-cloud-local -l app=pgbouncer
NAME                         READY   STATUS    RESTARTS   AGE
pgbouncer-6c64875467-jclqk   2/2     Running   0          33s

# pgbouncer logs (showing client login through the pool):
LOG kernel file descriptor limit: 1048576; max_client_conn: 500
LOG listening on 0.0.0.0:6432
LOG process up: PgBouncer 1.25.1, libevent 2.1.12-stable
LOG C-...: pgbouncer/pgbouncer_stats@127.0.0.1: login attempt: db=pgbouncer

$ kubectl port-forward svc/pgbouncer 16432:6432 &
$ PGPASSWORD=... psql -h 127.0.0.1 -p 16432 -U postgres -d isa_platform -c "SHOW max_connections;"
 max_connections
-----------------
 100

$ PGPASSWORD=... psql -h 127.0.0.1 -p 16432 -U pgbouncer_stats -d pgbouncer -c "SHOW POOLS;"
   database   |   user    | cl_active | sv_idle | pool_mode
--------------+-----------+-----------+---------+-------------
 isa_platform | postgres  |         0 |       1 | transaction
 pgbouncer    | pgbouncer |         2 |       0 | statement

# Exporter sidecar metrics (port 9127):
pgbouncer_up 1
pgbouncer_config_max_client_connections 500
pgbouncer_pools_client_active_connections{database="isa_platform",user="postgres"} 0
pgbouncer_pools_server_idle_connections{database="isa_platform",user="postgres"} 1
```

Local install was uninstalled before opening this PR (`helm uninstall pgbouncer -n isa-cloud-local` confirmed `No resources found`).

## Out of scope

- Routing isA_user services through PgBouncer (`POSTGRES_HOST` / `POSTGRES_PORT` flip in their helm values). That's a cross-repo cutover tracked as a follow-up in `xenoISA/isA_user`.
- Bumping the per-service application pool back up (`DB_POOL_BASE`/`DB_POOL_GROWTH`) once PgBouncer is in place — also part of the follow-up.

## Test plan

- [ ] CI helm-lint passes
- [ ] Operator provisions `pgbouncer-auth` Secret in staging from existing source-of-truth
- [ ] `helm install pgbouncer ... -n isa-cloud-staging` rolls out clean (2/2 replicas Ready)
- [ ] `psql -h pgbouncer -p 6432 -U <isa_admin> -d isa_platform -c "SELECT 1"` succeeds via in-cluster pod
- [ ] `pgbouncer_up{namespace="isa-cloud-staging"} == 1` shows up in Prometheus
- [ ] `xenoISA/isA_user#359` cutover PR (separate) flips `POSTGRES_HOST` to `pgbouncer.isa-cloud-staging.svc.cluster.local:6432` for tier-4 services first; smoke + scale-up integration test passes
- [ ] Repeat for production after staging soak

Fixes #231
Related to `xenoISA/isA_user#345`
Related to `xenoISA/isA_user#359`

🤖 Generated with [Claude Code](https://claude.com/claude-code)