### PR TITLE
feat(infra): paimon-tools chart — V-2/V-3 trio completion (#243)

### DIFF
--- a/deployments/charts/paimon-tools/Chart.yaml
+++ b/deployments/charts/paimon-tools/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: paimon-tools
+description: |
+  Apache Paimon catalog config + init Job for the isA platform's
+  big-data foundation. Self-written chart per design — provides a
+  single ConfigMap with the catalog properties consumed by downstream
+  compute charts (flink-cdc-jobs, starrocks) and an optional one-shot
+  init Job that smoke-tests reachability of hive-metastore + minio.
+
+  Note: this chart does NOT deploy a long-running service. Paimon is
+  a lakehouse table format library; actual reads/writes happen on
+  Flink and StarRocks workers in their respective charts.
+
+  See xenoISA/isA_Cloud#243, xenoISA/isA_Cloud#234, and
+  xenoISA/sn-commercial-tower ADR-0002 §2.5 / 00-infra-architecture-overview.md
+  §6.1 / §1.4 risk #1 (V-3 = highest-risk gate).
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - paimon
+  - lakehouse
+  - hive-metastore
+  - s3a
+  - bigdata
+  - data-platform
+home: https://paimon.apache.org/
+sources:
+  - https://github.com/xenoISA/isA_Cloud
+  - https://github.com/apache/paimon
+maintainers:
+  - name: isA Platform

--- a/deployments/charts/paimon-tools/README.md
+++ b/deployments/charts/paimon-tools/README.md
@@ -1,0 +1,104 @@
+# paimon-tools
+
+Apache Paimon catalog config + init Job for the isA platform's big-data
+foundation. Tracking issue:
+[isA_Cloud#243](https://github.com/xenoISA/isA_Cloud/issues/243).
+
+## What this chart does
+
+Self-written, deliberately small. Renders only:
+
+- **`ConfigMap` `paimon-catalog`** — the catalog properties downstream
+  compute charts (`flink-cdc-jobs`, `starrocks`) mount and pass to
+  Paimon's `Catalog.create()`. Backed by hive-metastore Thrift + MinIO
+  S3A endpoints already deployed in the umbrella.
+- **`Job` `paimon-tools-smoke`** (optional, gated) — runs once on
+  Helm `pre-install` / `pre-upgrade`, verifies DNS + TCP reach to
+  hive-metastore + minio, and checks the `paimon` bucket exists.
+
+**No StatefulSet, no Service, no PDB.** Paimon is a lakehouse table
+format *library*, not a server — actual reads/writes happen on Flink
+and StarRocks workers in their own charts.
+
+## Why no JAR shipping?
+
+The design's "jar 注入" cue could be read as this chart shipping
+Paimon JARs. In practice modern Flink (1.18+) and StarRocks (3.2+)
+images bundle the Paimon connector — pulling extra JARs through this
+chart would just duplicate them. If a future consumer needs an explicit
+JAR-injection InitContainer pattern, that responsibility belongs to the
+*consumer chart* (so it can pin to a connector matching the runtime
+version), not here.
+
+## Consumer contract
+
+Downstream charts that read Paimon tables consume the
+`paimon-catalog` ConfigMap as follows:
+
+1. **Mount** the ConfigMap as a file:
+   ```yaml
+   volumes:
+     - name: paimon-catalog
+       configMap:
+         name: paimon-catalog
+   volumeMounts:
+     - name: paimon-catalog
+       mountPath: /etc/paimon/paimon-catalog.properties
+       subPath: paimon-catalog.properties
+   ```
+2. **Inject** S3A creds as env from `minio-credentials` Secret:
+   ```yaml
+   env:
+     - name: AWS_ACCESS_KEY_ID
+       valueFrom:
+         secretKeyRef:
+           name: minio-credentials
+           key: access-key
+     - name: AWS_SECRET_ACCESS_KEY
+       valueFrom:
+         secretKeyRef:
+           name: minio-credentials
+           key: secret-key
+   ```
+3. **Load** the catalog in Flink/StarRocks/Spark using the mounted file.
+
+The ConfigMap also exposes a `consumer-credentials-secret` block as a
+discovery hint so a consumer chart doesn't have to hardcode the Secret
+name.
+
+## Init Job intent
+
+Connectivity smoke only:
+
+1. `nslookup hive-metastore.isa-bigdata.svc.cluster.local`
+2. `nc -zv hive-metastore.isa-bigdata.svc.cluster.local 9083`
+3. `nc -zv minio.isa-bigdata.svc.cluster.local 9000`
+4. `curl … http://minio:9000/paimon/?list-type=2` — accepts `200` (public list) or `403` (auth required); fails on `404` (missing bucket)
+
+Real V-2 / V-3 read-through verification (catalog create → Paimon table
+write → StarRocks query) needs a running Flink cluster and is tracked
+as a separate story under epic #234.
+
+## Profile differential
+
+| | kind-local | dev-shared | customer-prod |
+|---|---|---|---|
+| ConfigMap | rendered | rendered | rendered |
+| Init Job | runs once | runs once | **disabled** (operator runs combined V-2/V-3 smoke through a vault-driven Job once flink lands) |
+| probeHosts override | (defaults) | (defaults) | may override for off-cluster validators |
+
+## Bumping Paimon
+
+1. Update `appVersion` in `Chart.yaml` and `paimonVersion` in `values.yaml`.
+2. Verify the consumer charts (flink, starrocks) ship a Paimon connector
+   compatible with the new version. Paimon is wire-compatible across
+   minor versions but file-format breaks happen across majors.
+3. Re-render the umbrella. The ConfigMap changes; consumers pick up the
+   new catalog options on their next deploy.
+
+## Cross-repo context
+
+- xenoISA/isA_Cloud#234 — parent epic
+- xenoISA/isA_Cloud#235 / #238 / #240 / #242 — kafka, postgres-bigdata, hive-metastore, minio (already merged)
+- xenoISA/sn-commercial-tower ADR-0002 §2.5 — chart layout
+- xenoISA/sn-commercial-tower `docs/design/00-infra-architecture-overview.md` §6.1 (W2 kind: paimon-tools jar), §1.4 risk #1 (V-3 highest-risk)

--- a/deployments/charts/paimon-tools/templates/_helpers.tpl
+++ b/deployments/charts/paimon-tools/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/*
+Common labels.
+*/}}
+{{- define "paimon-tools.labels" -}}
+app: {{ .Values.name }}
+app.kubernetes.io/name: paimon-tools
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: isa-bigdata
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{/*
+Stable selector subset.
+*/}}
+{{- define "paimon-tools.selectorLabels" -}}
+app: {{ .Values.name }}
+app.kubernetes.io/name: paimon-tools
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ConfigMap name for the catalog properties.
+*/}}
+{{- define "paimon-tools.catalogConfigMapName" -}}
+paimon-catalog
+{{- end -}}

--- a/deployments/charts/paimon-tools/templates/configmap.yaml
+++ b/deployments/charts/paimon-tools/templates/configmap.yaml
@@ -1,0 +1,55 @@
+{{- /*
+  paimon-catalog ConfigMap. The keys are flat properties — downstream
+  consumers (Flink table API, StarRocks external catalog DDL) read them
+  as their respective config formats.
+
+  Credentials are NOT here. The Hadoop ${env:VAR} interpolation lets
+  the same property file work whether the consumer reads
+  AWS_ACCESS_KEY_ID from a Secret-mounted env var (Flink/StarRocks
+  pods) or has it pre-set in the runtime image.
+
+  paimon-catalog.properties is the canonical Paimon catalog config
+  format consumed by `Catalog.create(properties)` calls in Flink/Spark.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "paimon-tools.catalogConfigMapName" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "paimon-tools.labels" . | nindent 4 }}
+data:
+  paimon-catalog.properties: |
+    # Paimon catalog wired to Hive Metastore + MinIO (S3A). Generated
+    # by the paimon-tools chart (xenoISA/isA_Cloud#243). Consumers should
+    # mount this file at /etc/paimon/paimon-catalog.properties (or
+    # equivalent) and pass it to Catalog.create().
+
+    catalog.type = {{ .Values.catalog.type }}
+    catalog.metastore = {{ .Values.catalog.metastore }}
+    catalog.uri = {{ .Values.catalog.uri }}
+    warehouse = {{ .Values.catalog.warehouse }}
+    {{- with .Values.catalog.defaultDatabase }}
+    default-database = {{ . }}
+    {{- end }}
+
+    # S3A backend (Hadoop-style keys; both Flink and StarRocks read
+    # these directly).
+    fs.s3a.endpoint = {{ .Values.s3a.endpoint }}
+    fs.s3a.path.style.access = {{ .Values.s3a.pathStyleAccess }}
+    fs.s3a.connection.ssl.enabled = {{ .Values.s3a.sslEnabled }}
+    fs.s3a.access.key = ${env:AWS_ACCESS_KEY_ID}
+    fs.s3a.secret.key = ${env:AWS_SECRET_ACCESS_KEY}
+    fs.s3a.impl = org.apache.hadoop.fs.s3a.S3AFileSystem
+
+    {{- range $k, $v := .Values.extraCatalogProperties }}
+    {{ $k }} = {{ $v }}
+    {{- end }}
+
+  # Sidecar block: which Secret to mount as env in consumers. Charts
+  # downstream can read this metadata from the ConfigMap rather than
+  # hardcoding the Secret name.
+  consumer-credentials-secret: |
+    secretName={{ .Values.s3a.credentialsSecret.name }}
+    accessKeyKey={{ .Values.s3a.credentialsSecret.accessKeyKey }}
+    secretKeyKey={{ .Values.s3a.credentialsSecret.secretKeyKey }}

--- a/deployments/charts/paimon-tools/templates/init-job.yaml
+++ b/deployments/charts/paimon-tools/templates/init-job.yaml
@@ -1,0 +1,81 @@
+{{- /*
+  Smoke test Job. Runs once on Helm pre-install + pre-upgrade. Verifies:
+    1. DNS for each probe host resolves
+    2. TCP port reach to each probe host
+    3. The paimon bucket on MinIO is reachable (HEAD-ish via curl)
+
+  Intentionally light. Real V-2 / V-3 verification (Paimon table create
+  → Flink write → StarRocks read) requires a running Flink cluster and
+  lives in a separate story under epic #234.
+
+  Cleanup: ttlSecondsAfterFinished + before-hook-creation +
+  hook-succeeded delete policy keep the namespace tidy across re-installs.
+*/ -}}
+{{- if .Values.init.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.name }}-smoke
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "paimon-tools.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.init.backoffLimit }}
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "paimon-tools.labels" . | nindent 8 }}
+        component: smoke
+    spec:
+      restartPolicy: OnFailure
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: smoke
+          image: "{{ .Values.init.image.registry }}/{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
+          imagePullPolicy: {{ .Values.init.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              echo "[paimon-tools/smoke] installing curl + bind-tools..."
+              apk add --quiet --no-cache curl bind-tools >/dev/null
+              echo "[paimon-tools/smoke] probing hosts..."
+              {{- range .Values.init.probeHosts }}
+              echo "  -> {{ .label }}: nslookup {{ .host }}"
+              nslookup {{ .host }} >/dev/null
+              echo "  -> {{ .label }}: nc -zv {{ .host }} {{ .port }}"
+              nc -zv -w 5 {{ .host }} {{ .port }}
+              {{- end }}
+              echo "[paimon-tools/smoke] checking {{ .Values.init.bucketProbe.bucket }} bucket on {{ .Values.init.bucketProbe.endpoint }}..."
+              # 200 (public list) or 403 (auth required) both prove the
+              # bucket exists and the endpoint is reachable. 404 means
+              # the bucket is missing — a real failure.
+              status=$(curl -fsS -o /dev/null -w "%{http_code}" "{{ .Values.init.bucketProbe.endpoint }}/{{ .Values.init.bucketProbe.bucket }}/?list-type=2" \
+                || curl -sS -o /dev/null -w "%{http_code}" "{{ .Values.init.bucketProbe.endpoint }}/{{ .Values.init.bucketProbe.bucket }}/?list-type=2")
+              echo "  -> bucket probe HTTP ${status}"
+              case "${status}" in
+                200|403) echo "[paimon-tools/smoke] PASS (bucket reachable)";;
+                404) echo "[paimon-tools/smoke] FAIL: bucket missing"; exit 1;;
+                *) echo "[paimon-tools/smoke] FAIL: unexpected ${status}"; exit 1;;
+              esac
+          resources:
+            {{- toYaml .Values.init.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/deployments/charts/paimon-tools/values.yaml
+++ b/deployments/charts/paimon-tools/values.yaml
@@ -1,0 +1,118 @@
+# =============================================================================
+# paimon-tools chart — defaults (xenoISA/isA_Cloud#243)
+# =============================================================================
+# Self-written. Renders only:
+#   - ConfigMap "paimon-catalog" with the catalog properties consumed
+#     by Flink + StarRocks once those charts land
+#   - Optional init Job that smoke-tests reachability of HMS + MinIO
+#     (DNS + nc + bucket list)
+#
+# Profile defaults below match the staging tier.
+# =============================================================================
+
+name: paimon-tools
+namespace: isa-bigdata
+
+# Paimon-aware metadata. The image below is only used by the init Job.
+# Downstream compute charts (flink-cdc-jobs, starrocks) load Paimon JARs
+# from their own images; this chart does NOT ship JARs (see README).
+paimonVersion: "1.0.0"
+
+# =============================================================================
+# Catalog properties — rendered into the paimon-catalog ConfigMap.
+# Consumers mount this ConfigMap and pass these as Flink/StarRocks
+# catalog options. Hostnames default to the in-cluster Services produced
+# by the hive-metastore + minio charts.
+# =============================================================================
+catalog:
+  type: hive
+  metastore: hive
+  uri: "thrift://hive-metastore.isa-bigdata.svc.cluster.local:9083"
+  warehouse: "s3a://paimon/warehouse/"
+  # Default database the consumers look up tables under. Optional —
+  # downstream charts may override per-job.
+  defaultDatabase: paimon_default
+
+s3a:
+  endpoint: "http://minio.isa-bigdata.svc.cluster.local:9000"
+  pathStyleAccess: true
+  sslEnabled: false
+  # Credentials are NOT in the ConfigMap. Consumer charts inject these
+  # as env vars from the minio-credentials Secret; the catalog config
+  # references them via Hadoop's ${env:VAR} interpolation.
+  credentialsSecret:
+    name: minio-credentials
+    accessKeyKey: access-key
+    secretKeyKey: secret-key
+
+# Free-form passthrough. Each entry becomes a key in the ConfigMap.
+# Useful for Paimon-specific tuning (snapshot.expire.execution-mode,
+# write-buffer-size, etc.) without re-templating.
+extraCatalogProperties: {}
+  # Example:
+  # snapshot.expire.execution-mode: sync
+  # write-buffer-size: 256MB
+
+# =============================================================================
+# Init Job — smoke test for HMS + MinIO reachability.
+#
+# Why so light: the actual V-2 / V-3 verification (Paimon table create →
+# Flink CDC write → StarRocks read) requires a running Flink cluster,
+# which is a separate chart. Until then, a lightweight DNS + nc + bucket-
+# list check catches the most common deploy mistakes (wrong host, wrong
+# port, missing bucket) without pulling a multi-hundred-MB Paimon image.
+#
+# Helm hook: pre-install + pre-upgrade. ttlSecondsAfterFinished cleans
+# the Pod after success.
+# =============================================================================
+init:
+  enabled: true
+  image:
+    registry: docker.io
+    # alpine + busybox-style tools; ~5MB and present in air-gap caches.
+    repository: alpine
+    tag: "3.19"
+    pullPolicy: IfNotPresent
+  # Hosts probed at runtime. Default to the in-cluster Service DNS for
+  # hive-metastore + minio. customer-prod can extend for off-cluster
+  # endpoints.
+  probeHosts:
+    - host: hive-metastore.isa-bigdata.svc.cluster.local
+      port: 9083
+      label: hive-metastore-thrift
+    - host: minio.isa-bigdata.svc.cluster.local
+      port: 9000
+      label: minio-s3
+  # Bucket existence check — HEAD against /<bucket>/?list-type=2 returns
+  # 200 (empty bucket) or 403 (auth required). Either is OK for a smoke
+  # test; only DNS / TCP failures block.
+  bucketProbe:
+    endpoint: "http://minio.isa-bigdata.svc.cluster.local:9000"
+    bucket: paimon
+  backoffLimit: 2
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  runAsUser: 1000
+
+priorityClassName: ""
+
+podAnnotations: {}

--- a/deployments/scripts/verify/verify-bigdata-charts.sh
+++ b/deployments/scripts/verify/verify-bigdata-charts.sh
@@ -18,6 +18,7 @@ APICURIO_CHART="${DEPLOYMENTS}/charts/apicurio-registry"
 POSTGRES_CHART="${DEPLOYMENTS}/charts/postgres-bigdata"
 HMS_CHART="${DEPLOYMENTS}/charts/hive-metastore"
 MINIO_CHART="${DEPLOYMENTS}/charts/minio"
+PAIMON_CHART="${DEPLOYMENTS}/charts/paimon-tools"
 
 PROFILES=("kind-local" "dev-shared" "customer-prod")
 
@@ -80,6 +81,10 @@ template_umbrella_with_profile() {
     echo "[fail] no minio rendering in ${profile}" >&2
     exit 4
   fi
+  if ! grep -q "paimon-catalog" <<<"${out}"; then
+    echo "[fail] no paimon-tools rendering in ${profile}" >&2
+    exit 4
+  fi
 }
 
 main() {
@@ -96,6 +101,7 @@ main() {
   lint_chart "${POSTGRES_CHART}"
   lint_chart "${HMS_CHART}"
   lint_chart "${MINIO_CHART}"
+  lint_chart "${PAIMON_CHART}"
 
   template_chart "${KAFKA_CHART}"
   template_chart "${APICURIO_CHART}" --set db.auth.create=true --set db.auth.password=test
@@ -105,6 +111,7 @@ main() {
     --set s3a.auth.create=true --set s3a.auth.accessKey=test --set s3a.auth.secretKey=test
   template_chart "${MINIO_CHART}" \
     --set auth.create=true --set auth.rootUser=test --set auth.rootPassword=testtesttest
+  template_chart "${PAIMON_CHART}"
 
   step "helm dependency update ${UMBRELLA}"
   helm dependency update "${UMBRELLA}"

--- a/deployments/umbrella/isa-bigdata/Chart.yaml
+++ b/deployments/umbrella/isa-bigdata/Chart.yaml
@@ -35,3 +35,6 @@ dependencies:
   - name: minio
     version: 0.1.0
     repository: file://../../charts/minio
+  - name: paimon-tools
+    version: 0.1.0
+    repository: file://../../charts/paimon-tools

--- a/deployments/umbrella/isa-bigdata/values.yaml
+++ b/deployments/umbrella/isa-bigdata/values.yaml
@@ -27,3 +27,7 @@ hive-metastore:
 
 minio:
   enabled: true
+
+paimon-tools:
+  enabled: true
+  namespace: isa-bigdata

--- a/deployments/values/customer-prod.yaml
+++ b/deployments/values/customer-prod.yaml
@@ -374,3 +374,11 @@ minio:
       timeoutSeconds: 5
       failureThreshold: 60
     priorityClassName: infra-critical
+
+paimon-tools:
+  # Operator runs the V-2/V-3 smoke through a dedicated vault-driven Job
+  # once flink + paimon-tools + minio are all green. Disable the chart's
+  # built-in pre-install hook so a Helm re-install doesn't race with it.
+  init:
+    enabled: false
+  priorityClassName: infra-critical

--- a/deployments/values/dev-shared.yaml
+++ b/deployments/values/dev-shared.yaml
@@ -238,3 +238,7 @@ minio:
         enabled: true
         labels:
           release: prometheus
+
+paimon-tools:
+  init:
+    enabled: true

--- a/deployments/values/kind-local.yaml
+++ b/deployments/values/kind-local.yaml
@@ -229,3 +229,7 @@ minio:
     metrics:
       serviceMonitor:
         enabled: false
+
+paimon-tools:
+  init:
+    enabled: true


### PR DESCRIPTION
## Summary

Self-written, deliberately small chart. Completes the **V-2/V-3 verification trio** alongside hive-metastore (#240) and minio (#242). Provides Apache Paimon catalog config + connectivity smoke for the big-data foundation. Closes #243.

After this lands, the only chart standing between us and runnable V-2/V-3 is `flink` (next on the critical path; substantially larger).

## What this chart does NOT do

- **No StatefulSet, Service, PDB.** Paimon is a lakehouse table format library, not a server — actual reads/writes happen on Flink and StarRocks workers in their own charts.
- **No JAR shipping.** The design's "jar 注入" cue is satisfied by Flink 1.18+ / StarRocks 3.2+ images already bundling the Paimon connector. If a future consumer needs an explicit InitContainer-based JAR-injection pattern, that responsibility belongs to the consumer chart (so it can pin a connector matching its runtime), not here.

## What this chart DOES ship

- **`ConfigMap` `paimon-catalog`** — `paimon-catalog.properties` (`catalog.uri`, `warehouse`, S3A endpoint, S3A creds via `${env:VAR}` interpolation against the `minio-credentials` Secret produced by the minio chart). Downstream compute charts mount this and pass it to Paimon's `Catalog.create()`.
- **`Job` `paimon-tools-smoke`** (gated by `init.enabled`) — runs once on Helm `pre-install` + `pre-upgrade`. Verifies DNS + `nc` TCP reach to hive-metastore (Thrift 9083) + minio (S3 9000), and confirms the `paimon` bucket exists by HTTP GET (`200`=public list, `403`=auth required: both prove reachable; `404`=bucket missing fails the Job). Light `alpine:3.19` image, ~5MB.

```
deployments/
├── charts/paimon-tools/
│   ├── Chart.yaml                      # appVersion 1.0.0 (Apache Paimon)
│   ├── values.yaml                     # catalog config + init Job toggle
│   ├── README.md                       # consumer contract for flink/starrocks
│   └── templates/
│       ├── _helpers.tpl
│       ├── configmap.yaml              # paimon-catalog.properties
│       └── init-job.yaml               # gated, pre-install/pre-upgrade
├── umbrella/isa-bigdata/Chart.yaml     # +1 dep (6th)
├── umbrella/isa-bigdata/values.yaml    # passthrough enable
├── values/{kind-local,dev-shared,customer-prod}.yaml  # paimon-tools blocks
└── scripts/verify/verify-bigdata-charts.sh # extended
```

## Profile differential

| | kind-local | dev-shared | customer-prod |
|---|---|---|---|
| ConfigMap | rendered | rendered | rendered |
| Init Job | runs once | runs once | **disabled** (operator runs combined V-2/V-3 smoke through a vault-driven Job once flink lands) |
| PriorityClass | (none) | (none) | `infra-critical` |

## Consumer contract — Flink + StarRocks

Downstream charts mount the `paimon-catalog` ConfigMap and inject `minio-credentials` Secret env-vars:

```yaml
volumes:
  - name: paimon-catalog
    configMap:
      name: paimon-catalog
volumeMounts:
  - name: paimon-catalog
    mountPath: /etc/paimon/paimon-catalog.properties
    subPath: paimon-catalog.properties
env:
  - name: AWS_ACCESS_KEY_ID
    valueFrom:
      secretKeyRef:
        name: minio-credentials
        key: access-key
  - name: AWS_SECRET_ACCESS_KEY
    valueFrom:
      secretKeyRef:
        name: minio-credentials
        key: secret-key
```

The ConfigMap also exposes a `consumer-credentials-secret` discovery block so consumer charts don't have to hardcode the Secret name.

## Smoke verification

`bash deployments/scripts/verify/verify-bigdata-charts.sh`

```
=== helm lint charts/{kafka, apicurio-registry, postgres-bigdata, hive-metastore, minio, paimon-tools} ===  0 chart(s) failed
=== helm template paimon-tools standalone ===  ok
=== helm template umbrella -f values/kind-local.yaml ===     ok (paimon-catalog ConfigMap + smoke Job)
=== helm template umbrella -f values/dev-shared.yaml ===     ok
=== helm template umbrella -f values/customer-prod.yaml ===  ok (paimon-catalog ConfigMap; NO smoke Job)
=== all checks passed ===
```

Customer-prod render shape: 4 ConfigMaps (postgres + hms + minio + paimon-catalog), 4 StatefulSets (2 postgres + hms + minio), 6 NetworkPolicies, 5 PDBs, 5 ServiceMonitors. **NO smoke Job** in prod (`init.enabled=false`). Kind-local render correctly includes both the `paimon-catalog` ConfigMap AND the `paimon-tools-smoke` Job.

## Out of scope (separate stories under epic #234)

- **Live V-2 / V-3 read-through verification** (catalog create → Paimon table write → StarRocks query) — needs flink chart first
- **Paimon catalog migration / version upgrade tooling** — separate `paimon-migrate` story
- **`paimon-shell` interactive container** — useful for ops but not blocking V-2/V-3

## Test plan

- [ ] Reviewer runs `bash deployments/scripts/verify/verify-bigdata-charts.sh` → all checks pass
- [ ] Reviewer renders `customer-prod.yaml` and confirms `paimon-catalog` ConfigMap renders but **no** smoke Job
- [ ] On a kind cluster (after `bigdata-postgresql` + `hive-metastore` + `minio` are Ready): `helm install bigdata deployments/umbrella/isa-bigdata -f deployments/values/kind-local.yaml --namespace isa-bigdata --create-namespace`. Watch the `paimon-tools-smoke` Job complete with green logs ("PASS (bucket reachable)")
- [ ] Verify the consumer contract: `kubectl -n isa-bigdata get configmap paimon-catalog -o jsonpath='{.data.paimon-catalog\.properties}'` returns the rendered properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)