### PR TITLE
fix(consul): advertise Docker Desktop gateway for local services

### DIFF
--- a/isA_common/isa_common/consul_client.py
+++ b/isA_common/isa_common/consul_client.py
@@ -21,6 +21,8 @@ from .async_base_client import AsyncBaseClient
 
 logger = logging.getLogger(__name__)
 
+DOCKER_DESKTOP_HOST_GATEWAY_IP = "192.168.65.254"
+
 
 def _is_loopback(host: str) -> bool:
     """Return True if *host* is a loopback address (127.x.x.x, ::1, localhost)."""
@@ -80,7 +82,7 @@ def _desktop_gateway_host() -> Optional[str]:
     if sys.platform != "darwin" or os.getenv("KUBERNETES_SERVICE_HOST"):
         return None
 
-    return _first_non_loopback_ip("host.docker.internal")
+    return os.getenv("DOCKER_DESKTOP_HOST_GATEWAY_IP") or DOCKER_DESKTOP_HOST_GATEWAY_IP
 
 
 def _normalize_service_host(host: Optional[str]) -> Optional[str]:
@@ -96,6 +98,9 @@ def _normalize_service_host(host: Optional[str]) -> Optional[str]:
 
     if sys.platform != "darwin" or os.getenv("KUBERNETES_SERVICE_HOST"):
         return host
+
+    if host == "host.docker.internal":
+        return _desktop_gateway_host() or _first_non_loopback_ip(host) or host
 
     try:
         ipaddress.ip_address(host)

--- a/isA_common/tests/unit/test_async_consul_unit.py
+++ b/isA_common/tests/unit/test_async_consul_unit.py
@@ -55,13 +55,28 @@ class TestAsyncConsulRegistryInit:
             from isa_common.consul_client import AsyncConsulRegistry
 
             with patch("isa_common.consul_client.sys.platform", "darwin"), \
+                 patch("isa_common.consul_client.socket.gethostname", return_value="my-mac.local"), \
+                 patch.dict("os.environ", {}, clear=True):
+                registry = AsyncConsulRegistry(
+                    service_name="test-service",
+                    service_port=8080,
+                    lazy_connect=True,
+                )
+
+        assert registry.service_host == "192.168.65.254"
+        assert registry.service_id == "test-service-192.168.65.254-8080"
+
+    def test_init_uses_stable_desktop_gateway_even_when_host_alias_resolves_differently(self):
+        with patch("isa_common.consul_client.consul.Consul"):
+            from isa_common.consul_client import AsyncConsulRegistry
+
+            with patch("isa_common.consul_client.sys.platform", "darwin"), \
                  patch(
                      "isa_common.consul_client.socket.getaddrinfo",
                      return_value=[
-                         (2, None, None, None, ("192.168.65.254", 0)),
+                         (2, None, None, None, ("198.18.0.177", 0)),
                      ],
                  ), \
-                 patch("isa_common.consul_client.socket.gethostname", return_value="my-mac.local"), \
                  patch.dict("os.environ", {}, clear=True):
                 registry = AsyncConsulRegistry(
                     service_name="test-service",

--- a/isA_common/tests/unit/test_consul_unit.py
+++ b/isA_common/tests/unit/test_consul_unit.py
@@ -62,12 +62,6 @@ class TestConsulRegistryInit:
             from isa_common.consul_client import ConsulRegistry
 
             with patch("isa_common.consul_client.sys.platform", "darwin"), \
-                 patch(
-                     "isa_common.consul_client.socket.getaddrinfo",
-                     return_value=[
-                         (2, None, None, None, ("192.168.65.254", 0)),
-                     ],
-                 ), \
                  patch("isa_common.consul_client.socket.gethostname", return_value="my-mac.local"), \
                  patch.dict("os.environ", {}, clear=True):
                 registry = ConsulRegistry(
@@ -77,6 +71,44 @@ class TestConsulRegistryInit:
 
         assert registry.service_host == "192.168.65.254"
         assert registry.service_id == "test-service-192.168.65.254-8080"
+
+    def test_init_uses_stable_desktop_gateway_even_when_host_alias_resolves_differently(self):
+        with patch("isa_common.consul_client.consul.Consul"):
+            from isa_common.consul_client import ConsulRegistry
+
+            with patch("isa_common.consul_client.sys.platform", "darwin"), \
+                 patch(
+                     "isa_common.consul_client.socket.getaddrinfo",
+                     return_value=[
+                         (2, None, None, None, ("198.18.0.177", 0)),
+                     ],
+                 ), \
+                 patch.dict("os.environ", {}, clear=True):
+                registry = ConsulRegistry(
+                    service_name="test-service",
+                    service_port=8080,
+                )
+
+        assert registry.service_host == "192.168.65.254"
+        assert registry.service_id == "test-service-192.168.65.254-8080"
+
+    def test_init_allows_desktop_gateway_ip_override(self):
+        with patch("isa_common.consul_client.consul.Consul"):
+            from isa_common.consul_client import ConsulRegistry
+
+            with patch("isa_common.consul_client.sys.platform", "darwin"), \
+                 patch.dict(
+                     "os.environ",
+                     {"DOCKER_DESKTOP_HOST_GATEWAY_IP": "192.168.99.1"},
+                     clear=True,
+                 ):
+                registry = ConsulRegistry(
+                    service_name="test-service",
+                    service_port=8080,
+                )
+
+        assert registry.service_host == "192.168.99.1"
+        assert registry.service_id == "test-service-192.168.99.1-8080"
 
     def test_init_normalizes_service_host_alias_to_ip_for_native_macos_dev(self):
         with patch("isa_common.consul_client.consul.Consul"):


### PR DESCRIPTION
## Summary
- make native macOS Consul registrations advertise Docker Desktop's stable host gateway IP instead of host-side DNS resolution
- keep an override via DOCKER_DESKTOP_HOST_GATEWAY_IP for nonstandard Docker Desktop setups
- add sync and async ConsulRegistry regression coverage for the 198.18.x host-alias case

## Verification
- PYTHONPATH=isA_common pytest isA_common/tests/unit/test_consul_unit.py isA_common/tests/unit/test_async_consul_unit.py

Fixes #246