### PR TITLE
feat(infra): flink-cdc-jobs chart — per-source FlinkSessionJob templates (#250)

### DIFF
--- a/deployments/charts/flink-cdc-jobs/Chart.yaml
+++ b/deployments/charts/flink-cdc-jobs/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: flink-cdc-jobs
+description: |
+  Per-source FlinkSessionJob templates for the isA platform's big-data
+  foundation. Self-written chart per design — for each source declared
+  in values.sources, renders a Flink SQL ConfigMap and a
+  FlinkSessionJob CR that submits the SQL to the long-running session
+  cluster shipped by the flink chart (#249).
+
+  V0.1 scope: the Kafka → Avro (via Apicurio) → Paimon path. Real
+  Flink CDC connector wiring (mysql-cdc, postgres-cdc) is out of scope
+  until W7+ when real DB binlog sources land.
+
+  See xenoISA/isA_Cloud#250, xenoISA/isA_Cloud#234, and
+  xenoISA/sn-commercial-tower ADR-0002 §2.5.
+type: application
+version: 0.1.0
+appVersion: "1.20.0"
+keywords:
+  - flink
+  - flink-cdc
+  - paimon
+  - kafka
+  - bigdata
+  - data-platform
+home: https://flink.apache.org/
+sources:
+  - https://github.com/xenoISA/isA_Cloud
+  - https://github.com/apache/flink-cdc
+maintainers:
+  - name: isA Platform

--- a/deployments/charts/flink-cdc-jobs/README.md
+++ b/deployments/charts/flink-cdc-jobs/README.md
@@ -1,0 +1,205 @@
+# flink-cdc-jobs (big-data foundation)
+
+Per-source FlinkSessionJob templates for the isA platform's big-data
+foundation. Tracking issue:
+[isA_Cloud#250](https://github.com/xenoISA/isA_Cloud/issues/250).
+
+## What this chart does
+
+For each entry in `values.sources`, renders:
+
+- One `ConfigMap` named `flink-cdc-<source>-sql` with the Flink SQL script
+- One `FlinkSessionJob` CR named `flink-cdc-<source>` that submits the SQL
+  to the long-running session cluster from the `flink` chart (#249)
+
+No Deployments, no StatefulSets, no Services. The session cluster's
+JM + TM pods are pre-wired with `paimon-catalog` ConfigMap mounts and
+`minio-credentials` env injection via the flink chart, so per-job
+templates don't need to repeat any of that.
+
+## V0.1 scope clarification
+
+The "cdc" in `flink-cdc-jobs` refers to the **CDC-shaped pipeline** —
+binlog/WAL/event-stream → Kafka → Flink → Paimon → HMS — NOT the Apache
+Flink CDC connector library specifically.
+
+For W2 V-2/V-3 verification, the real DB binlog sources don't exist
+yet (those land in W7+ when actual customer DBs connect). So this
+chart's V0.1 scope is the **Kafka → Avro (via Apicurio) → Paimon** path
+only:
+
+```
+Kafka topic (landing.<source>)
+  ─► Flink Avro decode via Apicurio schema (landing.<source>-value)
+    ─► Flink Paimon sink writing to s3a://paimon/warehouse/<source>
+      ─► HMS catalog entry visible to Dataphin + StarRocks
+```
+
+Real Flink CDC connector wiring (`mysql-cdc`, `postgres-cdc`,
+`mongodb-cdc`) is **out of scope** for V0.1; opens as a follow-up
+under #234 once W7+ source connections become real.
+
+## Per-source values structure
+
+```yaml
+sources:
+  - name: amazon_ads                                # required, alphanumeric+_
+    enabled: true                                   # toggle without removing the entry
+    parallelism: 2                                  # optional; defaults applied otherwise
+    upgradeMode: stateless                          # optional
+    state: running                                  # optional
+    sql: |
+      SET 'pipeline.name' = 'flink-cdc-amazon-ads';
+
+      -- Kafka source (Avro decoded via Apicurio).
+      CREATE TABLE kafka_amazon_ads (
+        profile_id     STRING,
+        campaign_id    STRING,
+        report_date    DATE,
+        impressions    BIGINT,
+        clicks         BIGINT,
+        spend          DECIMAL(18, 4),
+        attributed_sales DECIMAL(18, 4),
+        ingested_at    TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
+      ) WITH (
+        'connector' = 'kafka',
+        'topic' = 'landing.raw_amazon_ads_campaign_performance',
+        'properties.bootstrap.servers' = 'kafka-bootstrap.isa-bigdata.svc.cluster.local:9092',
+        'properties.group.id' = 'flink-cdc-amazon-ads',
+        'format' = 'avro-confluent',
+        'avro-confluent.url' = 'http://apicurio-registry.isa-bigdata.svc.cluster.local:8080/apis/ccompat/v6',
+        'avro-confluent.subject' = 'landing.raw_amazon_ads_campaign_performance-value',
+        'scan.startup.mode' = 'earliest-offset'
+      );
+
+      -- Paimon sink (catalog already loaded from /etc/paimon/paimon-catalog.properties).
+      CREATE CATALOG paimon WITH ('type' = 'paimon');
+      USE CATALOG paimon;
+
+      CREATE TABLE IF NOT EXISTS `default`.`amazon_ads` (
+        profile_id     STRING,
+        campaign_id    STRING,
+        report_date    DATE,
+        impressions    BIGINT,
+        clicks         BIGINT,
+        spend          DECIMAL(18, 4),
+        attributed_sales DECIMAL(18, 4),
+        ingested_at    TIMESTAMP_LTZ(3),
+        PRIMARY KEY (campaign_id, report_date) NOT ENFORCED
+      ) WITH (
+        'bucket' = '4',
+        'changelog-producer' = 'input'
+      );
+
+      INSERT INTO `default`.`amazon_ads`
+      SELECT * FROM default_catalog.default_database.kafka_amazon_ads;
+```
+
+## Profile differential
+
+| | kind-local | dev-shared | customer-prod |
+|---|---|---|---|
+| Sources enabled | 3 P0 (amazon_ads, walmart_connect, shopify) — all stub SQL | 3 P0 — stub SQL | full 22 from `data_platform/sources/`; **all `enabled: false` by default** |
+| Default parallelism | 1 | 2 | 4 |
+| Default upgradeMode | stateless | stateless | last-state |
+| Operators flip individual sources on as W7+ onboarding completes | n/a | n/a | yes |
+
+## Stub SQL note (V0.1)
+
+For the 3 P0 sources in kind/dev, the rendered SQL uses a `VALUES`
+literal as a stand-in source so the FlinkSessionJob can be exercised
+without real Kafka producers or per-source Avro schemas (those land in
+W7+). Concretely:
+
+```sql
+SET 'pipeline.name' = 'flink-cdc-stub-amazon-ads';
+
+CREATE CATALOG paimon WITH ('type' = 'paimon');
+
+CREATE TABLE IF NOT EXISTS paimon.`default`.`stub_amazon_ads` (...);
+
+-- VALUES literal stands in for the Kafka source until the real producer lands.
+INSERT INTO paimon.`default`.`stub_amazon_ads`
+VALUES ('STUB-CAMPAIGN', DATE '1970-01-01', 0, 0, 0.00);
+```
+
+Replace each source's `sql` field with the real Kafka source DDL once
+W7+ onboarding completes. The export bundle from
+`sn-commercial-tower#235`'s
+`scripts/dataphin/export_kafka_apicurio_bundle.py` produces the exact
+topic + subject names; a future helper script can convert the bundle
+into per-source `sql` field values automatically (separate story).
+
+## Runner-jar contract
+
+The chart's `runnerJar` value defaults to:
+
+```
+local:///opt/flink/usrlib/flink-sql-runner.jar
+```
+
+This requires the session cluster image (apache/flink:1.20.0…) to
+include the `flink-sql-runner.jar` at that path. There are three ways
+to satisfy this:
+
+1. **Custom Dockerfile** — `FROM apache/flink:1.20-scala_2.12-java17 +
+   COPY flink-sql-runner.jar /opt/flink/usrlib/`. Recommended for
+   production; pin the runner version.
+2. **Init container** — pull the jar from a remote URL into a shared
+   volume that's mounted into the JM + TM pods.
+3. **HTTP jarURI** — set `runnerJar:
+   "https://github.com/apache/flink-kubernetes-operator/releases/.../flink-sql-runner.jar"`.
+   Works for kind/dev with internet access; not air-gap-friendly.
+
+Out of scope for this chart: building/distributing the runner image.
+Track as a separate `flink-sql-runner-image` story.
+
+## Schema evolution
+
+Apicurio's BACKWARD compatibility (matches the export contract from
+`sn-commercial-tower#235`) lets producers add fields without breaking
+consumers. To survive a schema bump:
+
+1. Producer registers v2 with Apicurio (`POST .../subjects/<subject>/versions`).
+2. Apicurio enforces BACKWARD compatibility — the bump is rejected if
+   it removes/renames fields.
+3. The Flink job's `kafka_<source>` table reads the new schema on the
+   next message; missing fields default to NULL on the consumer side.
+4. The Paimon sink schema can absorb the new fields by ALTER TABLE +
+   chart re-deploy (`upgradeMode: last-state` keeps the checkpoint
+   pointer).
+
+## How to enable a customer-prod source
+
+```yaml
+# In your customer-prod overlay or Helm values:
+flink-cdc-jobs:
+  sources:
+    - name: amazon_ads
+      enabled: true        # was false
+      parallelism: 4
+      sql: |
+        # ...real W7+ DDL...
+```
+
+Re-deploy with `helm upgrade`. The chart re-renders only the touched
+source's ConfigMap + FlinkSessionJob; untouched sources stay as-is.
+
+## Out of scope (follow-ups)
+
+- **Flink CDC connector wiring** (`mysql-cdc`, `postgres-cdc`, etc.) — separate story; W7+ when real DB binlog sources land
+- **flink-sql-runner image build pipeline** — separate story
+- **Per-source schema generation from the export bundle** — automate the manual `sql` field; separate story
+- **Live V-2 / V-3 / V-5 verification** — separate story; needs the runner jar baked AND a real Kafka producer for at least one source
+- **Routine job restart / savepoint promotion ops** — separate `flink-job-ops` story
+- **Per-source autoscaling / reactive scaling** — separate perf story
+- **Dead letter Kafka topic + retry policy** — producer-side concern (ingest API), not this chart
+
+## Cross-repo context
+
+- xenoISA/isA_Cloud#234 — parent epic
+- xenoISA/isA_Cloud#235 / #238 / #240 / #242 / #244 / #247 / #249 — kafka, postgres, hms, minio, paimon-tools, starrocks, flink (already merged)
+- xenoISA/sn-commercial-tower#235 — `scripts/dataphin/export_kafka_apicurio_bundle.py` produces the per-source topic + Apicurio subject contract this chart consumes
+- xenoISA/sn-commercial-tower ADR-0002 §2.5 — chart layout
+- xenoISA/sn-commercial-tower `docs/design/bigdata-architecture.md` §3.1 (4 ingestion paths)
+- xenoISA/sn-commercial-tower `docs/design/00-infra-architecture-overview.md` §6.4 (W7-W11 onboarding cadence)

--- a/deployments/charts/flink-cdc-jobs/templates/_helpers.tpl
+++ b/deployments/charts/flink-cdc-jobs/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/*
+Common labels — applied to ConfigMaps and FlinkSessionJob CRs.
+*/}}
+{{- define "flink-cdc-jobs.labels" -}}
+app: {{ .Values.name }}
+app.kubernetes.io/name: flink-cdc-jobs
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: isa-bigdata
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{/*
+Per-source labels: same base + a source name marker.
+*/}}
+{{- define "flink-cdc-jobs.sourceLabels" -}}
+{{- $ := index . 0 -}}
+{{- $source := index . 1 -}}
+{{ include "flink-cdc-jobs.labels" $ }}
+flink-cdc-source: {{ $source.name }}
+{{- end -}}
+
+{{/*
+DNS-safe form of a source name. Source names mirror sn-commercial-tower
+data_platform/sources/ filenames which use underscores; K8s names
+follow RFC 1123 (lowercase alphanumeric + hyphens), so we transliterate.
+*/}}
+{{- define "flink-cdc-jobs.dnsName" -}}
+{{- . | lower | replace "_" "-" -}}
+{{- end -}}
+
+{{/*
+ConfigMap name for a given source.
+*/}}
+{{- define "flink-cdc-jobs.configMapName" -}}
+{{- $ := index . 0 -}}
+{{- $source := index . 1 -}}
+{{ printf "%s-%s-sql" $.Values.configMapPrefix (include "flink-cdc-jobs.dnsName" $source.name) }}
+{{- end -}}
+
+{{/*
+FlinkSessionJob name for a given source.
+*/}}
+{{- define "flink-cdc-jobs.jobName" -}}
+{{- $ := index . 0 -}}
+{{- $source := index . 1 -}}
+{{ printf "%s-%s" $.Values.jobPrefix (include "flink-cdc-jobs.dnsName" $source.name) }}
+{{- end -}}

--- a/deployments/charts/flink-cdc-jobs/templates/flinksessionjob.yaml
+++ b/deployments/charts/flink-cdc-jobs/templates/flinksessionjob.yaml
@@ -1,0 +1,47 @@
+{{- /*
+  Per-source FlinkSessionJob CR. Submits the SQL ConfigMap (rendered by
+  sql-configmap.yaml above) to the long-running session cluster
+  produced by the flink chart (#249).
+
+  Args reference the SQL ConfigMap's mount path inside the session
+  cluster pods. The session cluster's JM + TM podTemplate (defined in
+  #249) does NOT mount these per-job ConfigMaps automatically — the
+  flink-sql-runner is expected to fetch the script via
+  configmap:// or HTTP URI. For V0.1 we pass a configmap:// URI; the
+  runner's exact URI scheme is documented in the chart README and may
+  need profile-specific overrides as the runner image evolves.
+
+  upgradeMode `stateless` (default) does not preserve checkpoint state
+  across job upgrades. customer-prod uses `last-state` to keep the
+  checkpoint pointer across chart upgrades.
+
+  helm template renders this even if the FlinkSessionJob CRD is not
+  installed yet — `kubectl apply` enforces validation. Same caveat as
+  the FlinkDeployment in the flink chart (#249).
+*/ -}}
+{{- range .Values.sources }}
+{{- if .enabled }}
+{{- $source := . }}
+{{- $parallelism := default $.Values.defaults.parallelism .parallelism }}
+{{- $upgradeMode := default $.Values.defaults.upgradeMode .upgradeMode }}
+{{- $state := default $.Values.defaults.state .state }}
+---
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: {{ include "flink-cdc-jobs.jobName" (list $ $source) }}
+  namespace: {{ $.Values.namespace }}
+  labels:
+    {{- include "flink-cdc-jobs.sourceLabels" (list $ $source) | nindent 4 }}
+spec:
+  deploymentName: {{ $.Values.sessionDeploymentName }}
+  job:
+    jarURI: {{ $.Values.runnerJar | quote }}
+    parallelism: {{ $parallelism }}
+    upgradeMode: {{ $upgradeMode | quote }}
+    state: {{ $state | quote }}
+    args:
+      - "--scriptUri"
+      - "configmap://{{ include "flink-cdc-jobs.configMapName" (list $ $source) }}/job.sql"
+{{- end }}
+{{- end }}

--- a/deployments/charts/flink-cdc-jobs/templates/sql-configmap.yaml
+++ b/deployments/charts/flink-cdc-jobs/templates/sql-configmap.yaml
@@ -1,0 +1,22 @@
+{{- /*
+  Per-source SQL ConfigMap. Each source's `sql` block is rendered
+  verbatim. The flink-sql-runner reads the file mounted from this
+  ConfigMap at job submission time.
+*/ -}}
+{{- range .Values.sources }}
+{{- if .enabled }}
+{{- $source := . }}
+{{- $ctx := dict "Values" $.Values "Release" $.Release "Chart" $.Chart "Files" $.Files -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "flink-cdc-jobs.configMapName" (list $ $source) }}
+  namespace: {{ $.Values.namespace }}
+  labels:
+    {{- include "flink-cdc-jobs.sourceLabels" (list $ $source) | nindent 4 }}
+data:
+  job.sql: |
+{{ $source.sql | indent 4 }}
+{{- end }}
+{{- end }}

--- a/deployments/charts/flink-cdc-jobs/values.yaml
+++ b/deployments/charts/flink-cdc-jobs/values.yaml
@@ -1,0 +1,53 @@
+# =============================================================================
+# flink-cdc-jobs chart — defaults (xenoISA/isA_Cloud#250)
+# =============================================================================
+# Each entry in `sources` produces:
+#   - one ConfigMap: flink-cdc-<name>-sql        (the SQL script)
+#   - one FlinkSessionJob CR: flink-cdc-<name>   (submits to flink-session)
+#
+# The chart writes to the long-running session cluster from the flink
+# chart (#249) via FlinkSessionJob.spec.deploymentName. Per-job
+# secrets (Kafka, Apicurio, MinIO creds) are NOT rendered here — the
+# session cluster pods already have them mounted/injected by #249.
+# =============================================================================
+
+name: flink-cdc-jobs
+namespace: isa-bigdata
+
+# Session cluster the FlinkSessionJob CRs submit to. Must match
+# .Values.session.name in the flink chart.
+sessionDeploymentName: flink-session
+
+# Path to the flink-sql-runner jar, resolved INSIDE the session cluster
+# image. Out of scope of this chart: how the jar gets into the image
+# (custom Dockerfile, init container, or remote URL fetcher). Override
+# per profile if a different runner is used.
+runnerJar: "local:///opt/flink/usrlib/flink-sql-runner.jar"
+
+# Default knobs applied to each FlinkSessionJob unless the source
+# overrides them.
+defaults:
+  parallelism: 1
+  upgradeMode: stateless
+  state: running
+
+# Per-source list. Each entry produces a ConfigMap + a FlinkSessionJob.
+# The `sql` block is rendered into the ConfigMap as-is; the runner reads
+# it via --scriptUri (configmap path baked at template time).
+#
+# V0.1: SQL uses a `VALUES` literal as a stand-in source while real
+# producers + per-source Avro schemas are still being validated. Once
+# W7+ source onboarding is complete, replace each source's `sql` with
+# the real Kafka source DDL emitted from
+# sn-commercial-tower#235's scripts/dataphin/export_kafka_apicurio_bundle.py.
+sources: []
+
+# ConfigMap name prefix. Each source's ConfigMap is named
+# "<configMapPrefix>-<source.name>-sql".
+configMapPrefix: flink-cdc
+
+# Job name prefix. Each source's FlinkSessionJob is named
+# "<jobPrefix>-<source.name>".
+jobPrefix: flink-cdc
+
+podAnnotations: {}

--- a/deployments/scripts/verify/verify-bigdata-charts.sh
+++ b/deployments/scripts/verify/verify-bigdata-charts.sh
@@ -21,6 +21,7 @@ MINIO_CHART="${DEPLOYMENTS}/charts/minio"
 PAIMON_CHART="${DEPLOYMENTS}/charts/paimon-tools"
 STARROCKS_CHART="${DEPLOYMENTS}/charts/starrocks"
 FLINK_CHART="${DEPLOYMENTS}/charts/flink"
+FLINK_CDC_CHART="${DEPLOYMENTS}/charts/flink-cdc-jobs"
 
 PROFILES=("kind-local" "dev-shared" "customer-prod")
 
@@ -95,6 +96,15 @@ template_umbrella_with_profile() {
     echo "[fail] no FlinkDeployment CR in ${profile}" >&2
     exit 4
   fi
+  # FlinkSessionJob CRs only render when at least one source is enabled.
+  # kind-local + dev-shared have 3 P0 sources enabled; customer-prod has
+  # all 22 sources but disabled-by-default — treat its absence as OK.
+  if [[ "${profile}" != "customer-prod" ]]; then
+    if ! grep -q "kind: FlinkSessionJob" <<<"${out}"; then
+      echo "[fail] no FlinkSessionJob CR in ${profile}" >&2
+      exit 4
+    fi
+  fi
 }
 
 main() {
@@ -120,6 +130,7 @@ main() {
   lint_chart "${PAIMON_CHART}"
   lint_chart "${STARROCKS_CHART}"
   lint_chart "${FLINK_CHART}"
+  lint_chart "${FLINK_CDC_CHART}"
 
   template_chart "${KAFKA_CHART}"
   template_chart "${APICURIO_CHART}" --set db.auth.create=true --set db.auth.password=test
@@ -133,6 +144,11 @@ main() {
   template_chart "${STARROCKS_CHART}" \
     --set rootPassword.create=true --set rootPassword.password=test
   template_chart "${FLINK_CHART}"
+  # flink-cdc-jobs renders nothing when sources is empty; pass a smoke source.
+  template_chart "${FLINK_CDC_CHART}" \
+    --set 'sources[0].name=smoke' \
+    --set 'sources[0].enabled=true' \
+    --set 'sources[0].sql=SELECT 1;'
 
   step "helm dependency update ${UMBRELLA}"
   helm dependency update "${UMBRELLA}"

--- a/deployments/umbrella/isa-bigdata/Chart.yaml
+++ b/deployments/umbrella/isa-bigdata/Chart.yaml
@@ -44,3 +44,6 @@ dependencies:
   - name: flink
     version: 0.1.0
     repository: file://../../charts/flink
+  - name: flink-cdc-jobs
+    version: 0.1.0
+    repository: file://../../charts/flink-cdc-jobs

--- a/deployments/umbrella/isa-bigdata/values.yaml
+++ b/deployments/umbrella/isa-bigdata/values.yaml
@@ -37,3 +37,7 @@ starrocks:
 
 flink:
   enabled: true
+
+flink-cdc-jobs:
+  enabled: true
+  namespace: isa-bigdata

--- a/deployments/values/customer-prod.yaml
+++ b/deployments/values/customer-prod.yaml
@@ -490,3 +490,79 @@ flink:
     taskManager:
       enabled: true
       minAvailable: 2
+
+flink-cdc-jobs:
+  defaults:
+    parallelism: 4
+    upgradeMode: last-state
+  # All 22 sources from sn-commercial-tower data_platform/sources/.
+  # All disabled by default; operators flip individual sources on as
+  # W7+ source onboarding completes (real Kafka producer + Apicurio
+  # schema + per-source DDL replacing the stub).
+  sources:
+    - name: amazon_ads
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML for landing.raw_amazon_ads_campaign_performance"
+    - name: walmart_connect
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML for landing.raw_walmart_connect_campaign_performance"
+    - name: shopify
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML for landing.raw_shopify_catalog_products"
+    - name: amazon_spapi_listings
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: amazon_spapi_orders
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: agent_approval_execution_audit
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: agent_learner_feedback_labels
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: agent_recommendation_events
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: brand_public_narratives
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: category_market_benchmarks
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: competitor_market_observations
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: competitor_match_registry
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: ga4_channel_sessions
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: google_ads_campaign_performance
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: macro_market_context
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: marketplace_reviews_and_ratings
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: meta_ads_campaign_performance
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: public_search_interest_trends
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: search_console_queries
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: social_listening_mentions
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: tiktok_shop_orders
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"
+    - name: walmart_marketplace_inventory
+      enabled: false
+      sql: "-- W7 onboarding: replace with real DDL/DML"

--- a/deployments/values/dev-shared.yaml
+++ b/deployments/values/dev-shared.yaml
@@ -298,3 +298,60 @@ flink:
       taskmanager.memory.process.size: "4g"
   networkPolicy:
     enabled: false
+
+flink-cdc-jobs:
+  defaults:
+    parallelism: 2
+    upgradeMode: stateless
+  sources:
+    - name: amazon_ads
+      enabled: true
+      parallelism: 2
+      sql: |
+        SET 'pipeline.name' = 'flink-cdc-stub-amazon-ads';
+
+        CREATE CATALOG paimon WITH ('type' = 'paimon');
+
+        CREATE TABLE IF NOT EXISTS paimon.`default`.`stub_amazon_ads` (
+          campaign_id STRING,
+          report_date DATE,
+          impressions BIGINT,
+          PRIMARY KEY (campaign_id, report_date) NOT ENFORCED
+        ) WITH ('bucket' = '2', 'changelog-producer' = 'input');
+
+        INSERT INTO paimon.`default`.`stub_amazon_ads`
+        VALUES ('STUB-CAMPAIGN', DATE '1970-01-01', 0);
+    - name: walmart_connect
+      enabled: true
+      parallelism: 2
+      sql: |
+        SET 'pipeline.name' = 'flink-cdc-stub-walmart-connect';
+
+        CREATE CATALOG paimon WITH ('type' = 'paimon');
+
+        CREATE TABLE IF NOT EXISTS paimon.`default`.`stub_walmart_connect` (
+          campaign_id STRING,
+          report_date DATE,
+          impressions BIGINT,
+          PRIMARY KEY (campaign_id, report_date) NOT ENFORCED
+        ) WITH ('bucket' = '2', 'changelog-producer' = 'input');
+
+        INSERT INTO paimon.`default`.`stub_walmart_connect`
+        VALUES ('STUB-CAMPAIGN', DATE '1970-01-01', 0);
+    - name: shopify
+      enabled: true
+      parallelism: 2
+      sql: |
+        SET 'pipeline.name' = 'flink-cdc-stub-shopify';
+
+        CREATE CATALOG paimon WITH ('type' = 'paimon');
+
+        CREATE TABLE IF NOT EXISTS paimon.`default`.`stub_shopify` (
+          product_id STRING,
+          variant_id STRING,
+          updated_at TIMESTAMP(3),
+          PRIMARY KEY (product_id, variant_id) NOT ENFORCED
+        ) WITH ('bucket' = '2', 'changelog-producer' = 'input');
+
+        INSERT INTO paimon.`default`.`stub_shopify`
+        VALUES ('STUB-PRODUCT', 'STUB-VARIANT', TIMESTAMP '1970-01-01 00:00:00');

--- a/deployments/values/kind-local.yaml
+++ b/deployments/values/kind-local.yaml
@@ -304,3 +304,64 @@ flink:
       enabled: false
     taskManager:
       enabled: false
+
+flink-cdc-jobs:
+  defaults:
+    parallelism: 1
+    upgradeMode: stateless
+  # 3 P0 sources from sn-commercial-tower data_platform/sources/. SQL is
+  # a stub that uses VALUES literals as a stand-in for the Kafka source
+  # — proves the runner-jar + paimon-catalog mount + S3A creds path works
+  # without needing real producers. Replace with real DDL in W7+.
+  sources:
+    - name: amazon_ads
+      enabled: true
+      parallelism: 1
+      sql: |
+        SET 'pipeline.name' = 'flink-cdc-stub-amazon-ads';
+
+        CREATE CATALOG paimon WITH ('type' = 'paimon');
+
+        CREATE TABLE IF NOT EXISTS paimon.`default`.`stub_amazon_ads` (
+          campaign_id STRING,
+          report_date DATE,
+          impressions BIGINT,
+          PRIMARY KEY (campaign_id, report_date) NOT ENFORCED
+        ) WITH ('bucket' = '1', 'changelog-producer' = 'input');
+
+        INSERT INTO paimon.`default`.`stub_amazon_ads`
+        VALUES ('STUB-CAMPAIGN', DATE '1970-01-01', 0);
+    - name: walmart_connect
+      enabled: true
+      parallelism: 1
+      sql: |
+        SET 'pipeline.name' = 'flink-cdc-stub-walmart-connect';
+
+        CREATE CATALOG paimon WITH ('type' = 'paimon');
+
+        CREATE TABLE IF NOT EXISTS paimon.`default`.`stub_walmart_connect` (
+          campaign_id STRING,
+          report_date DATE,
+          impressions BIGINT,
+          PRIMARY KEY (campaign_id, report_date) NOT ENFORCED
+        ) WITH ('bucket' = '1', 'changelog-producer' = 'input');
+
+        INSERT INTO paimon.`default`.`stub_walmart_connect`
+        VALUES ('STUB-CAMPAIGN', DATE '1970-01-01', 0);
+    - name: shopify
+      enabled: true
+      parallelism: 1
+      sql: |
+        SET 'pipeline.name' = 'flink-cdc-stub-shopify';
+
+        CREATE CATALOG paimon WITH ('type' = 'paimon');
+
+        CREATE TABLE IF NOT EXISTS paimon.`default`.`stub_shopify` (
+          product_id STRING,
+          variant_id STRING,
+          updated_at TIMESTAMP(3),
+          PRIMARY KEY (product_id, variant_id) NOT ENFORCED
+        ) WITH ('bucket' = '1', 'changelog-producer' = 'input');
+
+        INSERT INTO paimon.`default`.`stub_shopify`
+        VALUES ('STUB-PRODUCT', 'STUB-VARIANT', TIMESTAMP '1970-01-01 00:00:00');


### PR DESCRIPTION
## Summary

**Last critical-path chart** for live V-2 / V-3 / V-5 verification. Self-written chart per design (bigdata-architecture.md §4.1: "self-written, template per CDC source"). For each entry in `values.sources`, renders one `ConfigMap` (Flink SQL script) and one `FlinkSessionJob` CR that submits the SQL to the long-running session cluster shipped by the `flink` chart (#249).

Closes #250. After this lands, every static and dynamic deploy artifact for the big-data foundation is on main and the W2 verification gates can be exercised end-to-end on a real kind cluster.

## V0.1 scope clarification

The "cdc" in `flink-cdc-jobs` refers to the **CDC-shaped pipeline** (Kafka → Avro → Paimon → HMS) — **NOT** the Apache Flink CDC connector library specifically. Real Flink CDC connector wiring (`mysql-cdc`, `postgres-cdc`, `mongodb-cdc`) is **OUT OF SCOPE** for V0.1; opens as a follow-up under #234 once W7+ source connections become real.

```
Kafka topic (landing.<source>)
  ─► Flink Avro decode via Apicurio schema (landing.<source>-value)
    ─► Flink Paimon sink writing to s3a://paimon/warehouse/<source>
      ─► HMS catalog entry visible to Dataphin + StarRocks
```

For W2 V-2/V-3 verification, the real DB binlog sources don't exist yet (those land in W7+). So this chart's V0.1 ships **stub SQL** for the 3 P0 sources that uses a `VALUES` literal as a stand-in for the Kafka source — proves the runner-jar + paimon-catalog mount + S3A creds path works without needing real producers.

## What's in this PR

```
deployments/
├── charts/flink-cdc-jobs/
│   ├── Chart.yaml                          # type=application, no deps
│   ├── values.yaml                         # sources[] list + defaults + runnerJar
│   ├── README.md                           # scope clarification, runner-jar contract, schema evolution
│   └── templates/
│       ├── _helpers.tpl                    # dnsName helper (RFC 1123)
│       ├── sql-configmap.yaml              # one CM per source (Flink SQL)
│       └── flinksessionjob.yaml            # one FlinkSessionJob CR per source
├── umbrella/isa-bigdata/Chart.yaml         # +1 dep (9th, last big-data chart)
├── umbrella/isa-bigdata/values.yaml        # passthrough enable
├── values/{kind-local,dev-shared,customer-prod}.yaml  # flink-cdc-jobs blocks
└── scripts/verify/verify-bigdata-charts.sh # extended (smoke source + per-profile assertion)
```

## Profile differential

| | kind-local | dev-shared | customer-prod |
|---|---|---|---|
| Sources enabled | **3 P0** (amazon_ads, walmart_connect, shopify) — stub SQL | **3 P0** — stub SQL | **0** (all 22 sources disabled-by-default) |
| Default parallelism | 1 | 2 | 4 |
| Default upgradeMode | stateless | stateless | last-state |
| Paimon `bucket` | 1 | 2 | (operator sets per-source) |
| Operators flip sources on as W7+ onboarding completes | n/a | n/a | yes |

## Caught and fixed in self-review

K8s `ConfigMap` and `Job` names follow RFC 1123 — lowercase alphanumeric plus hyphens, **no underscores**. Source names mirror `sn-commercial-tower/data_platform/sources/` filenames which use underscores (`amazon_ads`). Added a `dnsName` helper that `lower | replace "_" "-"` before name interpolation, so the rendered names are `flink-cdc-amazon-ads-sql` / `flink-cdc-amazon-ads`.

## Stub SQL

For the 3 P0 sources in kind/dev profiles:

```sql
SET 'pipeline.name' = 'flink-cdc-stub-amazon-ads';
CREATE CATALOG paimon WITH ('type' = 'paimon');
CREATE TABLE IF NOT EXISTS paimon.`default`.`stub_amazon_ads` (
  campaign_id STRING,
  report_date DATE,
  impressions BIGINT,
  PRIMARY KEY (campaign_id, report_date) NOT ENFORCED
) WITH ('bucket' = '1', 'changelog-producer' = 'input');
INSERT INTO paimon.`default`.`stub_amazon_ads`
VALUES ('STUB-CAMPAIGN', DATE '1970-01-01', 0);
```

The `VALUES` literal stands in for a real Kafka source until W7+ onboarding fills in the real DDL.

## Runner-jar contract

The chart's `runnerJar` defaults to `local:///opt/flink/usrlib/flink-sql-runner.jar` — assumes the session cluster image (apache/flink:1.20…) includes the runner at that path. There are three options for satisfying this; documented in chart README:

1. Custom Dockerfile baking the jar in (recommended for production).
2. Init container fetching the jar into a shared volume.
3. HTTP `jarURI` pointing at the upstream release (works for kind/dev with internet; not air-gap-friendly).

Out of scope of this chart: building/distributing the runner image. Track as a separate `flink-sql-runner-image` story.

## Smoke verification

`bash deployments/scripts/verify/verify-bigdata-charts.sh`

```
=== helm lint charts/{kafka, apicurio, postgres, hms, minio, paimon, starrocks, flink, flink-cdc-jobs} ===  0 chart(s) failed
=== helm template flink-cdc-jobs standalone ===   ok (with --set sources[0].name=smoke ...)
=== helm template umbrella -f values/kind-local.yaml ===     ok (3 ConfigMaps + 3 FlinkSessionJob CRs)
=== helm template umbrella -f values/dev-shared.yaml ===     ok (3 + 3)
=== helm template umbrella -f values/customer-prod.yaml ===  ok (0 + 0; all sources disabled by default)
=== all checks passed ===
```

## Out of scope (follow-up issues to file)

- **Flink CDC connector wiring** (`mysql-cdc`, `postgres-cdc`, etc.) — separate story; W7+ when real DB binlog sources land
- **flink-sql-runner image build pipeline** — separate story
- **Per-source schema generation from `sn-commercial-tower#235`'s export bundle** — automate the manual `sql` field; separate story
- **Live V-2 / V-3 / V-5 verification on a real kind cluster** — separate story; needs the runner jar baked AND a real Kafka producer for at least one source
- **Routine job restart / savepoint promotion ops** — separate `flink-job-ops` story
- **Per-source autoscaling / reactive scaling** — separate perf story
- **Dead letter Kafka topic + retry policy** — producer-side concern (ingest API), not this chart

## Test plan

- [ ] Reviewer runs `bash deployments/scripts/verify/verify-bigdata-charts.sh` → all checks pass
- [ ] Reviewer renders `kind-local.yaml` and confirms 3 ConfigMaps (`flink-cdc-amazon-ads-sql`, `flink-cdc-walmart-connect-sql`, `flink-cdc-shopify-sql`) + 3 matching FlinkSessionJob CRs all reference `deploymentName: flink-session`
- [ ] Reviewer renders `customer-prod.yaml` and confirms **no** FlinkSessionJob CRs render (all 22 sources have `enabled: false`); to enable amazon_ads in prod the operator overrides `flink-cdc-jobs.sources[0].enabled: true` and replaces the SQL placeholder
- [ ] On a kind cluster (after operator CRDs are installed and the session cluster is Running, AND the flink-sql-runner.jar is in the cluster image): `helm install bigdata deployments/umbrella/isa-bigdata -f deployments/values/kind-local.yaml --namespace isa-bigdata --create-namespace`. Watch `kubectl -n isa-bigdata get flinksessionjob` show the 3 CRs progressing to RUNNING; `kubectl -n isa-bigdata logs <jm-pod>` shows the stub jobs writing to Paimon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)