### PR TITLE
feat(infra): fluss chart shell — closes 11-chart inventory (#253)

### DIFF
--- a/deployments/charts/fluss/Chart.yaml
+++ b/deployments/charts/fluss/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: fluss
+description: |
+  Apache Fluss chart shell — placeholder for the W12+ Paimon 1.3
+  upgrade-path decision. Disabled by default at all profiles. Renders
+  a single placeholder ConfigMap only when `enabled=true`. Activates
+  in W12+ if the team decides to enable Fluss for real-time analytics.
+
+  See xenoISA/isA_Cloud#253, xenoISA/isA_Cloud#234, and
+  xenoISA/sn-commercial-tower ADR-0002 §A2.2 / 00-infra-architecture-overview.md
+  §6.5 (Phase 3.2 Fluss enablement decision gate).
+type: application
+version: 0.1.0
+# Sentinel appVersion. Bump to a real Fluss release tag when this
+# chart is activated and the placeholder template is replaced with
+# real StatefulSet / Service / catalog-integration manifests.
+appVersion: "0.0.0-shell"
+keywords:
+  - fluss
+  - paimon
+  - real-time
+  - bigdata
+  - data-platform
+  - shell
+home: https://fluss.apache.org/
+sources:
+  - https://github.com/xenoISA/isA_Cloud
+  - https://github.com/apache/fluss
+maintainers:
+  - name: isA Platform

--- a/deployments/charts/fluss/README.md
+++ b/deployments/charts/fluss/README.md
@@ -1,0 +1,109 @@
+# fluss (W12+ shell)
+
+Apache Fluss chart shell — deliberate placeholder for the W12+ Paimon 1.3
+upgrade-path decision. Tracking issue:
+[isA_Cloud#253](https://github.com/xenoISA/isA_Cloud/issues/253).
+
+## Why this exists today
+
+The big-data foundation in epic #234 ships an 11-chart inventory per
+design (xenoISA/sn-commercial-tower ADR-0002 §2.5 + bigdata-architecture.md §4.1).
+This is chart 11. Apache Fluss is currently incubating and not yet GA;
+the team's W12+ pilot evaluation will decide whether to enable it for
+real-time analytics atop the existing Paimon stack.
+
+Filing the chart as a shell now (vs. waiting for W12+) means:
+
+1. **Inventory completeness** — the umbrella's chart-list matches the
+   design's 11-chart spec; ops aren't confused by a missing chart.
+2. **No-op activation toggle** — when W12 evaluation says "go", flipping
+   `fluss.enabled: true` in `customer-prod` values is the only change
+   needed to render the *first* placeholder; no scaffold catch-up.
+3. **Documented contract** — this README captures activation criteria,
+   design decisions outstanding, and what to do *when* Fluss goes GA.
+
+## Current behavior
+
+- **`enabled: false` (default)** — chart renders zero resources. Fluss
+  is fully absent from `helm template` output across all 3 profiles.
+- **`enabled: true`** — chart renders a single ConfigMap named
+  `fluss-shell` with `status: shell-not-implemented`. Ops can grep
+  for that string to detect accidental early activation.
+
+## Activation gate (for the W12+ follow-up)
+
+Cannot flip `enabled: true` for production use until **all four** of
+these are true:
+
+1. **Apache Fluss is GA.** Track <https://fluss.apache.org/> for the
+   release that drops the `incubating` qualifier.
+2. **Paimon 1.3 is GA with Fluss interop verified.** The Paimon
+   project's release notes need to call out Fluss table support
+   explicitly; we don't want to ship a custom integration.
+3. **Capacity check** confirms the 3-node KSi5008U cluster (per
+   `00-infra-architecture-overview.md` §3.2) has headroom for the
+   additional Fluss workload alongside the existing big-data stack.
+4. **A follow-up ADR** records the activation decision (mirroring
+   ADR-0002 §A2.2 "B: Paimon 单层 + Fluss chart shell 预留" → "A:
+   Paimon + Fluss dual-layer activated").
+
+When all four are true:
+
+1. Replace `templates/placeholder.yaml` with real StatefulSet / Service
+   / NetworkPolicy / PDB / ServiceMonitor templates.
+2. Bump `appVersion` in `Chart.yaml` from `0.0.0-shell` to the target
+   Fluss release tag.
+3. Fill in the `image.repository`, `replicas`, `storage`,
+   `catalog.hiveMetastoreUri`, etc. fields in `values.yaml` (currently
+   stubbed with empty strings + TODO comments).
+4. Wire the per-profile `customer-prod.yaml` overrides (kind/dev stay
+   off; activation is a customer-prod decision).
+5. Add a Fluss section to `deployments/scripts/verify/verify-bigdata-charts.sh`
+   that asserts the new resources render in `customer-prod`.
+
+## Reserved values structure
+
+The following keys in `values.yaml` exist as **stubs with empty
+defaults**. They're listed so the future activation diff is legible —
+when someone fills in real values, the structure is already in place
+and `helm diff` shows just the value changes:
+
+- `image.{repository,tag,pullPolicy}` — Fluss container image
+- `replicas` — broker count (planned 1 for kind, 3 for prod, mirroring kafka)
+- `storage.{enabled,size,storageClass}` — persistence
+- `catalog.{enabled,hiveMetastoreUri}` — HMS integration so Fluss tables
+  register in the same metastore as Paimon (#240)
+- `networkPolicy.enabled` / `podDisruptionBudget.enabled` /
+  `serviceMonitor.enabled` — observability / safety toggles
+
+## Profile differential
+
+| | kind-local | dev-shared | customer-prod |
+|---|---|---|---|
+| `fluss.enabled` | **false** (umbrella default) | **false** (umbrella default) | **false** (umbrella default; flip post-W12 ADR) |
+
+All three profiles render zero Fluss resources today. This is the
+correct behavior at shell stage.
+
+## Smoke verification
+
+Standalone, with `enabled=true`, exercises the placeholder render path:
+
+```bash
+helm template fluss-test deployments/charts/fluss --set enabled=true
+# Renders one ConfigMap named fluss-shell with status: shell-not-implemented
+```
+
+The umbrella's `verify-bigdata-charts.sh` lints + templates this chart
+standalone with `--set enabled=true` to catch regressions in the
+helper / labels / placeholder ConfigMap. It does **not** assert any
+Fluss resources in umbrella renders, since the umbrella ships
+`fluss.enabled: false`.
+
+## Cross-repo context
+
+- xenoISA/isA_Cloud#234 — parent epic
+- xenoISA/isA_Cloud#235, #238, #240, #242, #244, #247, #249, #252 — the nine merged big-data charts (#235 covers 2 charts: kafka + apicurio-registry)
+- xenoISA/sn-commercial-tower ADR-0002 §A2.2 — "实时热层" decision currently parked at "B: Paimon 单层 + Fluss chart shell 预留"
+- xenoISA/sn-commercial-tower `docs/design/00-infra-architecture-overview.md` §6.5 (Phase 3.2 W12-W17 Fluss enablement decision gate)
+- xenoISA/sn-commercial-tower `docs/design/bigdata-architecture.md` §4.1 (chart inventory)

--- a/deployments/charts/fluss/templates/_helpers.tpl
+++ b/deployments/charts/fluss/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{/*
+Common labels — used by the placeholder ConfigMap and by every future
+template added when this chart is activated.
+*/}}
+{{- define "fluss.labels" -}}
+app: fluss
+app.kubernetes.io/name: fluss
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: isa-bigdata
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/deployments/charts/fluss/templates/placeholder.yaml
+++ b/deployments/charts/fluss/templates/placeholder.yaml
@@ -1,0 +1,28 @@
+{{- /*
+  Placeholder ConfigMap. Rendered ONLY when .Values.enabled = true.
+
+  This is the chart's only resource at shell stage — it exists so
+  someone who accidentally flips `fluss.enabled: true` before the W12+
+  activation decision can `kubectl get configmap fluss-shell -o yaml`
+  and immediately see why nothing else is running. The status string
+  is grep-friendly for ops dashboards and alerting.
+
+  When the W12+ activation goes through, replace this template with
+  real StatefulSet / Service / NetworkPolicy / PDB manifests and bump
+  Chart.yaml's appVersion off the `0.0.0-shell` sentinel.
+*/ -}}
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluss-shell
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "fluss.labels" . | nindent 4 }}
+data:
+  status: {{ .Values.placeholder.status | quote }}
+  reason: {{ .Values.placeholder.reason | quote }}
+  activation-criteria: |
+    See deployments/charts/fluss/README.md for the full activation gate.
+    Summary: Apache Fluss GA + Paimon 1.3 GA + 3-node capacity check + ADR.
+{{- end }}

--- a/deployments/charts/fluss/values.yaml
+++ b/deployments/charts/fluss/values.yaml
@@ -1,0 +1,67 @@
+# =============================================================================
+# fluss chart — shell defaults (xenoISA/isA_Cloud#253)
+# =============================================================================
+# Deliberately tiny. The chart renders ZERO resources by default — every
+# template file gates on `.Values.enabled`. When the W12+ activation
+# decision goes "go", this values.yaml gets fleshed out (StatefulSet
+# replicas, storage class, Fluss-Paimon catalog integration, etc.) and
+# the placeholder.yaml template is replaced with real manifests.
+#
+# Until then, the chart's value is purely structural — it lets the
+# umbrella's chart inventory match the design's 11-chart spec without
+# anyone accidentally deploying a half-built service.
+# =============================================================================
+
+# Master toggle. Default `false` — no resources render. Flip to `true`
+# only when:
+#   - Apache Fluss is GA (currently incubating)
+#   - Paimon 1.3 GA with Fluss interop verified
+#   - Capacity check confirms the 3-node KSi5008U cluster has headroom
+#   - A follow-up ADR records the activation decision
+enabled: false
+
+# Optional message embedded in the placeholder ConfigMap when
+# enabled=true. Useful for ops to grep for "shell-not-implemented" in
+# any cluster that mistakenly gets Fluss flipped on too early.
+placeholder:
+  status: "shell-not-implemented"
+  reason: "Awaiting W12+ Fluss-GA + Paimon-1.3 activation decision (xenoISA/isA_Cloud#234)"
+
+# -----------------------------------------------------------------------------
+# Fields below are RESERVED for the W12+ activation. Each entry is a
+# stub with a TODO comment to make the activation diff legible: when
+# someone fills in the real values, the structure is already in place
+# and `helm diff` shows just the value changes.
+# -----------------------------------------------------------------------------
+namespace: isa-bigdata
+
+# TODO: pick once Fluss publishes an official image
+image:
+  repository: ""           # e.g., apache/fluss
+  tag: ""                  # e.g., 0.6.0
+  pullPolicy: IfNotPresent
+
+# TODO: size when activated; sn-commercial-tower bigdata-architecture.md §4.1
+# pencils in 1 broker for kind, 3 for prod, mirroring kafka.
+replicas: 0
+
+# TODO: storage when activated; expect to mirror the kafka chart's
+# storage pattern (local-path for kind, infortrend-iscsi for prod).
+storage:
+  enabled: false
+  size: ""
+  storageClass: ""
+
+# TODO: the integration point with HMS — Fluss tables register in the
+# same Hive Metastore as Paimon does today (#240).
+catalog:
+  enabled: false
+  hiveMetastoreUri: ""
+
+# TODO: NetworkPolicy + PDB + ServiceMonitor when activated.
+networkPolicy:
+  enabled: false
+podDisruptionBudget:
+  enabled: false
+serviceMonitor:
+  enabled: false

--- a/deployments/scripts/verify/verify-bigdata-charts.sh
+++ b/deployments/scripts/verify/verify-bigdata-charts.sh
@@ -22,6 +22,7 @@ PAIMON_CHART="${DEPLOYMENTS}/charts/paimon-tools"
 STARROCKS_CHART="${DEPLOYMENTS}/charts/starrocks"
 FLINK_CHART="${DEPLOYMENTS}/charts/flink"
 FLINK_CDC_CHART="${DEPLOYMENTS}/charts/flink-cdc-jobs"
+FLUSS_CHART="${DEPLOYMENTS}/charts/fluss"
 
 PROFILES=("kind-local" "dev-shared" "customer-prod")
 
@@ -131,6 +132,7 @@ main() {
   lint_chart "${STARROCKS_CHART}"
   lint_chart "${FLINK_CHART}"
   lint_chart "${FLINK_CDC_CHART}"
+  lint_chart "${FLUSS_CHART}"
 
   template_chart "${KAFKA_CHART}"
   template_chart "${APICURIO_CHART}" --set db.auth.create=true --set db.auth.password=test
@@ -149,6 +151,10 @@ main() {
     --set 'sources[0].name=smoke' \
     --set 'sources[0].enabled=true' \
     --set 'sources[0].sql=SELECT 1;'
+  # fluss is a shell — default disabled at all profiles. Standalone
+  # template with --set enabled=true exercises the placeholder render
+  # path so helper / labels / ConfigMap regressions are caught here.
+  template_chart "${FLUSS_CHART}" --set enabled=true
 
   step "helm dependency update ${UMBRELLA}"
   helm dependency update "${UMBRELLA}"

--- a/deployments/umbrella/isa-bigdata/Chart.yaml
+++ b/deployments/umbrella/isa-bigdata/Chart.yaml
@@ -47,3 +47,6 @@ dependencies:
   - name: flink-cdc-jobs
     version: 0.1.0
     repository: file://../../charts/flink-cdc-jobs
+  - name: fluss
+    version: 0.1.0
+    repository: file://../../charts/fluss

--- a/deployments/umbrella/isa-bigdata/values.yaml
+++ b/deployments/umbrella/isa-bigdata/values.yaml
@@ -41,3 +41,8 @@ flink:
 flink-cdc-jobs:
   enabled: true
   namespace: isa-bigdata
+
+# Shell chart — disabled by default at all profiles. Flip post-W12 ADR.
+# See deployments/charts/fluss/README.md for the activation gate.
+fluss:
+  enabled: false


### PR DESCRIPTION
## Summary

Deliberate placeholder for the W12+ Paimon 1.3 upgrade-path decision. Disabled by default at all profiles; renders zero resources in umbrella templates. Only when standalone-installed with `--set enabled=true` does it produce a single placeholder `ConfigMap` named `fluss-shell` carrying a grep-friendly `shell-not-implemented` status.

Closes #253. **Closes the 11-chart big-data inventory** from xenoISA/sn-commercial-tower's design (`bigdata-architecture.md` §4.1 + `00-infra-architecture-overview.md` §4.3 大数据底座 grouping). Only `dataphin` remains, blocked on V4 vendor answers.

## Why ship a shell now (vs. wait for W12+)

Per the parent issue #253:

1. **Inventory completeness** — the umbrella's chart-list now matches the design's 11-chart spec; ops won't be confused by a missing chart.
2. **No-op activation toggle** — when W12 evaluation says "go", flipping `fluss.enabled: true` in `customer-prod` values is the only change needed; no scaffold catch-up.
3. **Documented contract** — the chart README captures activation criteria, design decisions outstanding, and what to do *when* Fluss goes GA.

## Activation gate (in `deployments/charts/fluss/README.md`)

Cannot flip `enabled: true` for production use until **all four** of these are true:

1. Apache Fluss reaches GA (currently incubating)
2. Paimon 1.3 GA with Fluss interop verified
3. Capacity check confirms the 3-node KSi5008U cluster has headroom
4. Follow-up ADR records the activation decision (mirroring ADR-0002 §A2.2 "B: Paimon 单层 + Fluss chart shell 预留")

## What's in this PR

```
deployments/
├── charts/fluss/
│   ├── Chart.yaml                          # type=application, appVersion "0.0.0-shell"
│   ├── values.yaml                         # enabled: false default + reserved-stub structure
│   ├── README.md                           # shell rationale, activation gate, design refs
│   └── templates/
│       ├── _helpers.tpl                    # labels (used only when enabled)
│       └── placeholder.yaml                # gated ConfigMap rendered ONLY when enabled=true
├── umbrella/isa-bigdata/Chart.yaml         # +1 dep (10th and last big-data chart on main)
├── umbrella/isa-bigdata/values.yaml        # passthrough fluss.enabled: false
└── scripts/verify/verify-bigdata-charts.sh # lint + standalone-with-enabled=true smoke
```

## Reserved values structure

The following keys in `values.yaml` exist as **stubs with empty defaults** so the future activation diff is legible — when someone fills in real values, the structure is already in place and `helm diff` shows just the value changes:

- `image.{repository,tag,pullPolicy}`
- `replicas` (matches kafka's pattern: 1 for kind, 3 for prod)
- `storage.{enabled,size,storageClass}`
- `catalog.{enabled,hiveMetastoreUri}` (HMS integration so Fluss tables register in the same metastore as Paimon, #240)
- `networkPolicy.enabled` / `podDisruptionBudget.enabled` / `serviceMonitor.enabled`

## Profile differential

| | kind-local | dev-shared | customer-prod |
|---|---|---|---|
| `fluss.enabled` | **false** (umbrella default) | **false** (umbrella default) | **false** (umbrella default; flip post-W12 ADR) |

All three profiles render zero Fluss resources today.

## Smoke verification

```
=== helm lint charts/fluss ===                                       0 chart(s) failed
=== helm template fluss --set enabled=true ===                       ok (renders fluss-shell ConfigMap with status: shell-not-implemented)
=== helm template fluss (default) ===                                ok (renders nothing — chart fully gated)
=== helm template umbrella -f values/{kind-local,dev-shared,customer-prod}.yaml === all 3 profiles clean, zero fluss resources rendered
=== all checks passed ===
```

## Out of scope (intentionally — this is a shell)

- Apache Fluss server / operator install
- HMS catalog integration for Fluss tables
- Storage class / sizing / NetworkPolicy / PDB
- Live verification (no V-X gate for fluss in W2 / W4 / W6)
- Anything that requires Fluss GA

## Next pivot per epic #234

After this merge, focus shifts from chart authoring to runtime work:

1. **flink-sql-runner image build pipeline** — bake the runner jar into the session cluster image so the FlinkSessionJob CRs from #252 actually execute
2. **Strimzi Operator install** — Kafka cluster CRs in #235 need the operator running to be reconciled
3. **Real V-1..V-9 verification** on a kind cluster — the `make verify-bigdata-kind` end-to-end test referenced in #234

## Test plan

- [ ] Reviewer runs `bash deployments/scripts/verify/verify-bigdata-charts.sh` → all checks pass, including the new `helm template fluss --set enabled=true` standalone case
- [ ] Reviewer renders `customer-prod.yaml` and confirms **no** fluss resources appear (`grep -c fluss` returns 0)
- [ ] Reviewer reads the chart README and confirms the activation gate is unambiguous (or files a follow-up issue suggesting changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)