### PR TITLE
feat(infra): flink-sql-runner image build pipeline (#255)

### DIFF
--- a/deployments/charts/flink/values.yaml
+++ b/deployments/charts/flink/values.yaml
@@ -46,6 +46,19 @@ session:
   # Apache Flink runtime image. The operator chart's CRD validation
   # accepts any apache/flink:* tag matching the operator's supported
   # range.
+  #
+  # NOTE: the stock `apache/flink:1.20.0-scala_2.12-java17` image does
+  # NOT include flink-sql-runner.jar — FlinkSessionJob CRs from the
+  # flink-cdc-jobs chart (#252) reach RECONCILED but never RUNNING
+  # against this default. For live jobs, override to the
+  # flink-sql-runner image built by deployments/runner/flink-sql-runner/
+  # (xenoISA/isA_Cloud#255). Sample override:
+  #
+  #   flink:
+  #     session:
+  #       image:
+  #         repository: ghcr.io/xenoisa/flink-sql-runner
+  #         tag: 1.20.0-runner-1.10.0-paimon-1.0.0
   image:
     repository: apache/flink
     tag: "1.20.0-scala_2.12-java17"

--- a/deployments/runner/flink-sql-runner/.dockerignore
+++ b/deployments/runner/flink-sql-runner/.dockerignore
@@ -1,0 +1,4 @@
+# Keep the build context minimal — only Dockerfile and jars.txt are needed.
+*
+!Dockerfile
+!jars.txt

--- a/deployments/runner/flink-sql-runner/Dockerfile
+++ b/deployments/runner/flink-sql-runner/Dockerfile
@@ -1,0 +1,62 @@
+# =============================================================================
+# flink-sql-runner image — Apache Flink 1.20 + connector + runner jars.
+# Tracking issue: xenoISA/isA_Cloud#255.
+#
+# Two-stage build:
+#   1. fetcher (alpine + curl): downloads jars per jars.txt and verifies
+#      sha256 checksums when supplied (see jars.txt for the policy).
+#   2. final (apache/flink:1.20): copies the verified jars into
+#      /opt/flink/usrlib/ owned by `flink:flink`.
+#
+# The jars under /opt/flink/usrlib/ are auto-loaded by the Flink runtime,
+# so FlinkSessionJob CRs from the flink-cdc-jobs chart (xenoISA/isA_Cloud#252)
+# can reference `local:///opt/flink/usrlib/flink-sql-runner.jar` without
+# extra mounts.
+#
+# Build:
+#   make build
+# Push (override REGISTRY for the customer's Harbor mirror):
+#   make push REGISTRY=harbor.customer.local/isa-platform
+# =============================================================================
+
+# -------- Stage 1: fetch + verify jars --------
+FROM alpine:3.19 AS fetcher
+
+RUN apk add --no-cache curl coreutils
+
+WORKDIR /jars
+COPY jars.txt /jars.txt
+
+# Download each jar and verify checksum (when supplied). Skips lines that
+# start with `#` or are blank. A checksum of `-` skips verification for
+# that single jar — useful for dev iteration but production builds
+# should pin every checksum (regenerate via `make checksums`).
+RUN set -eu; \
+    while IFS= read -r line || [ -n "$line" ]; do \
+      case "$line" in \
+        '#'*|'') continue ;; \
+      esac; \
+      url=$(echo "$line" | awk '{print $1}'); \
+      sha=$(echo "$line" | awk '{print $2}'); \
+      jar=$(basename "$url"); \
+      echo "[fetcher] downloading $jar"; \
+      curl -fsSL --retry 3 --retry-delay 2 "$url" -o "/jars/$jar"; \
+      if [ "$sha" != "-" ] && [ -n "$sha" ]; then \
+        echo "[fetcher] verifying $jar"; \
+        echo "$sha  /jars/$jar" | sha256sum -c -; \
+      else \
+        echo "[fetcher] WARNING: skipping checksum verification for $jar"; \
+      fi; \
+    done < /jars.txt
+
+# -------- Stage 2: final image --------
+FROM apache/flink:1.20.0-scala_2.12-java17
+
+# The base image already runs as `flink` user (uid 9999) and has
+# /opt/flink/usrlib/ as the standard auto-load directory.
+COPY --from=fetcher --chown=flink:flink /jars/*.jar /opt/flink/usrlib/
+
+# Sanity check — fail the build if the runner jar is missing.
+RUN test -f /opt/flink/usrlib/flink-sql-runner.jar
+
+USER flink

--- a/deployments/runner/flink-sql-runner/Makefile
+++ b/deployments/runner/flink-sql-runner/Makefile
@@ -1,0 +1,61 @@
+# =============================================================================
+# flink-sql-runner image — build / push / verify (xenoISA/isA_Cloud#255)
+# =============================================================================
+# Defaults target the GitHub Container Registry under the xenoISA org;
+# override REGISTRY for customer Harbor mirrors.
+#
+# Examples:
+#   make build
+#   make push                                    # → ghcr.io/xenoisa/flink-sql-runner:<tag>
+#   make push REGISTRY=harbor.customer.local/isa-platform
+#   make verify                                  # confirms /opt/flink/usrlib/ has the runner jar
+#   make checksums                               # emits sha256 lines for jars.txt (paste back manually)
+# =============================================================================
+
+# Image identity. Tag encodes the Flink + Operator + Paimon versions so
+# a `helm install` referencing this tag lines up with the chart matrix
+# documented in the README.
+IMAGE_NAME ?= flink-sql-runner
+IMAGE_TAG  ?= 1.20.0-runner-1.10.0-paimon-1.0.0
+REGISTRY   ?= ghcr.io/xenoisa
+
+IMAGE      := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+DOCKERFILE := Dockerfile
+CONTEXT    := .
+
+.PHONY: build push verify checksums clean help
+
+help: ## Print this help (default).
+	@awk 'BEGIN {FS = ":.*##"} /^[A-Za-z_-]+:.*##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+build: ## Build the image locally.
+	docker build -f $(DOCKERFILE) -t $(IMAGE) $(CONTEXT)
+
+push: build ## Push the image to $(REGISTRY).
+	docker push $(IMAGE)
+
+verify: ## Spawn the image briefly and confirm the runner jar is present.
+	docker run --rm --entrypoint /bin/sh $(IMAGE) -c \
+	  'ls -la /opt/flink/usrlib/ && test -f /opt/flink/usrlib/flink-sql-runner.jar && echo OK'
+
+# Regenerate sha256 checksums for every URL in jars.txt. Output is
+# printed to stdout; review and paste back into jars.txt. (A future
+# improvement is to let this command rewrite the file in place; for
+# now we keep the human in the loop because the jars are signed by
+# Apache release-management keys, and we want a manual sanity check
+# before pinning.)
+checksums: ## Compute sha256 for each jar URL and print jars.txt-formatted lines.
+	@set -eu; \
+	while IFS= read -r line || [ -n "$$line" ]; do \
+	  case "$$line" in \
+	    '#'*|'') continue ;; \
+	  esac; \
+	  url=$$(echo "$$line" | awk '{print $$1}'); \
+	  jar=$$(basename "$$url"); \
+	  echo "[checksums] $$jar" >&2; \
+	  sha=$$(curl -fsSL "$$url" | sha256sum | awk '{print $$1}'); \
+	  echo "$$url  $$sha"; \
+	done < jars.txt
+
+clean: ## Remove local image.
+	docker rmi -f $(IMAGE) || true

--- a/deployments/runner/flink-sql-runner/README.md
+++ b/deployments/runner/flink-sql-runner/README.md
@@ -1,0 +1,139 @@
+# flink-sql-runner
+
+Custom Apache Flink session-cluster image with `flink-sql-runner.jar` and
+the connector jars (Paimon, Kafka, Avro Confluent registry) needed to
+execute the FlinkSessionJob CRs from the `flink-cdc-jobs` chart
+([xenoISA/isA_Cloud#252](https://github.com/xenoISA/isA_Cloud/pull/252)).
+
+Tracking issue:
+[xenoISA/isA_Cloud#255](https://github.com/xenoISA/isA_Cloud/issues/255).
+
+## Why this exists
+
+The `flink` chart ([#249](https://github.com/xenoISA/isA_Cloud/pull/249))
+deploys a Flink Kubernetes Operator + a session cluster, and the
+`flink-cdc-jobs` chart ([#252](https://github.com/xenoISA/isA_Cloud/pull/252))
+submits per-source FlinkSessionJob CRs to that cluster. The CRs reference
+`local:///opt/flink/usrlib/flink-sql-runner.jar`, but the stock
+`apache/flink:1.20-scala_2.12-java17` image **does not** ship that jar —
+the runner is a separate artifact released by the Flink Operator project.
+
+Without this image, FlinkSessionJob CRs reach `RECONCILED` but never
+`RUNNING`. With this image, V-2 / V-3 / V-5 become **runnable** on a
+real kind cluster.
+
+## What's in the image
+
+| Jar | Source | Why |
+|---|---|---|
+| `flink-sql-runner.jar` | Apache Flink Operator release-1.10.0 | Entry point for FlinkSessionJob CRs |
+| `paimon-flink-1.20-1.0.0.jar` | Maven Central, `org.apache.paimon` | Paimon table read/write from Flink SQL |
+| `flink-sql-connector-kafka-3.2.0-1.20.jar` | Maven Central, `org.apache.flink` | Kafka source/sink for streaming SQL |
+| `flink-sql-avro-confluent-registry-1.20.0.jar` | Maven Central, `org.apache.flink` | Avro decode against Apicurio's `/apis/ccompat/v6` endpoint |
+
+Versions are pinned in [`jars.txt`](./jars.txt). Each entry can carry a
+SHA-256 checksum that the build verifies before copying the jar into the
+final image (today the checksums are placeholders — `-` — pending the
+checksum-pinning follow-up).
+
+## Build
+
+```bash
+make help                              # show all targets
+make build                             # local build
+make verify                            # smoke: confirm the runner jar is present
+make push REGISTRY=ghcr.io/xenoisa     # push to the org's GHCR
+```
+
+The image tag (`IMAGE_TAG` in the Makefile) encodes the version matrix:
+
+```
+1.20.0-runner-1.10.0-paimon-1.0.0
+│      │      │      │      └─ Apache Paimon
+│      │      │      └─ Paimon connector pinned in jars.txt
+│      │      └─ Flink Kubernetes Operator
+│      └─ Operator-version label (release-1.10.0)
+└─ Apache Flink runtime (apache/flink:1.20.0-scala_2.12-java17 base)
+```
+
+Bump the tag whenever any of the four versions in `jars.txt` change.
+
+## Use the image in the flink chart
+
+The `flink` chart's default `session.image` points at the stock
+`apache/flink:1.20.0-scala_2.12-java17` so `helm template` renders
+cleanly without this image existing yet. To run real jobs, override
+the image in your environment values:
+
+### kind-local (after `make push REGISTRY=ghcr.io/xenoisa`)
+
+```yaml
+flink:
+  session:
+    image:
+      repository: ghcr.io/xenoisa/flink-sql-runner
+      tag: 1.20.0-runner-1.10.0-paimon-1.0.0
+```
+
+### customer-prod (after Harbor mirror sync)
+
+```yaml
+flink:
+  session:
+    image:
+      repository: harbor.customer.local/isa-platform/flink-sql-runner
+      tag: 1.20.0-runner-1.10.0-paimon-1.0.0
+```
+
+The customer's Harbor mirror is the air-gap-friendly path per
+`xenoISA/sn-commercial-tower/docs/design/00-infra-architecture-overview.md`
+§5.5.
+
+## Connector matrix
+
+When bumping versions, all four jars must stay compatible:
+
+| Flink | Operator | Paimon | Kafka conn | Avro Confluent |
+|---|---|---|---|---|
+| 1.18 | 1.9 | 0.9 | 3.0-1.18 | 1.18 |
+| 1.20 | 1.10 | 1.0 | 3.2-1.20 | 1.20 |
+
+Cross-version skews fail with `ClassNotFoundException` on job submission
+(no friendly error). Always change the four jars together; bump the
+image tag accordingly.
+
+## Checksum-pinning follow-up
+
+Today every entry in `jars.txt` carries `-` as the checksum, which the
+Dockerfile fetcher accepts with a `WARNING: skipping checksum
+verification` log line. To pin checksums:
+
+```bash
+make checksums                         # emits jars.txt-formatted lines
+# review the output, paste back into jars.txt manually
+make build                             # now verifies sha256 strictly
+```
+
+A future PR will rewrite `jars.txt` in place automatically and gate the
+build on it. Until then, every chart-author who bumps a version is on
+the honor system to also re-pin the checksum.
+
+## Out of scope (separate stories)
+
+- **CI workflow** for auto-building the image on jar version bumps —
+  separate `.github/workflows/flink-sql-runner.yml` story
+- **Multi-arch (arm64)** — the customer cluster is x86_64 only per
+  `00-infra-architecture-overview.md` §3.1
+- **Image signing / cosign** — separate supply-chain hardening story
+- **Per-CDC-connector image variants** (mysql-cdc, postgres-cdc) —
+  those land with the W7+ Flink CDC connector wiring story
+
+## Cross-repo context
+
+- xenoISA/isA_Cloud#234 — parent epic
+- xenoISA/isA_Cloud#249 — flink chart (consumer)
+- xenoISA/isA_Cloud#252 — flink-cdc-jobs chart (FlinkSessionJob CRs)
+- xenoISA/isA_Cloud#256 — Strimzi Kafka Operator install (sibling runtime
+  story; together with this image, unblocks live V-2 / V-3 / V-5)
+- xenoISA/isA_Cloud#257 — end-to-end V-1..V-9 verification on a kind
+  cluster (consumer of this image + #256's operator)

--- a/deployments/runner/flink-sql-runner/jars.txt
+++ b/deployments/runner/flink-sql-runner/jars.txt
@@ -1,0 +1,36 @@
+# =============================================================================
+# Connector + runner jars baked into the flink-sql-runner image.
+#
+# Format: one entry per line, two whitespace-separated fields:
+#   <download-url>  <sha256-checksum>
+#
+# Lines beginning with `#` and blank lines are ignored.
+#
+# Checksum policy: the build script verifies sha256 BEFORE copying jars
+# into the final image. If a checksum is `-` the build skips verification
+# for that jar (use only for transient development; production builds
+# should pin every checksum). Bumping a version REQUIRES regenerating
+# the checksum — see Makefile target `make checksums`.
+#
+# Version-compat matrix (xenoISA/sn-commercial-tower
+# 00-infra-architecture-overview.md §6.2 documents the upstream pins):
+#   Apache Flink:           1.20.0
+#   Flink Kubernetes Op:    1.10.0   (release-1.10.0 in github releases)
+#   Apache Paimon:          1.0.0    (paimon-flink-1.20-1.0.0)
+#   Flink Kafka SQL conn:   3.2.0-1.20
+#   Flink Avro Confluent:   1.20.0
+# =============================================================================
+
+# Flink SQL runner — entry point for FlinkSessionJob CRs (xenoISA/isA_Cloud#252).
+# Sourced from the Apache Flink Kubernetes Operator release tarballs.
+https://github.com/apache/flink-kubernetes-operator/releases/download/release-1.10.0/flink-sql-runner.jar  -
+
+# Apache Paimon Flink connector — Paimon table read/write from Flink SQL.
+https://repo1.maven.org/maven2/org/apache/paimon/paimon-flink-1.20/1.0.0/paimon-flink-1.20-1.0.0.jar  -
+
+# Apache Flink Kafka SQL connector — Kafka source/sink for streaming SQL.
+https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-kafka/3.2.0-1.20/flink-sql-connector-kafka-3.2.0-1.20.jar  -
+
+# Apache Flink Avro Confluent registry — decodes Avro payloads against
+# Apicurio's Confluent-compatible /apis/ccompat/v6 endpoint.
+https://repo1.maven.org/maven2/org/apache/flink/flink-sql-avro-confluent-registry/1.20.0/flink-sql-avro-confluent-registry-1.20.0.jar  -


### PR DESCRIPTION
## Summary

Custom Apache Flink session-cluster image baking `flink-sql-runner.jar` plus the four connector jars needed by the `flink-cdc-jobs` chart ([#252](https://github.com/xenoISA/isA_Cloud/pull/252)). Without this image the FlinkSessionJob CRs reach RECONCILED but never RUNNING — the stock `apache/flink:1.20` image does not ship the runner. With this image **V-2 / V-3 / V-5 become runnable on a real kind cluster**.

Closes #255. Sibling runtime stories: #256 (Strimzi Operator install) and #257 (end-to-end V-1..V-9 verification).

## What's in the image

| Jar | Source | Why |
|---|---|---|
| `flink-sql-runner.jar` | Apache Flink Operator `release-1.10.0` | Entry point for FlinkSessionJob CRs |
| `paimon-flink-1.20-1.0.0.jar` | Maven Central, `org.apache.paimon` | Paimon table read/write from Flink SQL |
| `flink-sql-connector-kafka-3.2.0-1.20.jar` | Maven Central, `org.apache.flink` | Kafka source/sink for streaming SQL |
| `flink-sql-avro-confluent-registry-1.20.0.jar` | Maven Central, `org.apache.flink` | Avro decode against Apicurio's `/apis/ccompat/v6` endpoint |

Versions pinned in [`jars.txt`](deployments/runner/flink-sql-runner/jars.txt).

## What's in this PR

```
deployments/
├── runner/flink-sql-runner/
│   ├── Dockerfile             # two-stage build: alpine fetcher + apache/flink final
│   ├── jars.txt               # version-pinned URL table, sha256-aware
│   ├── Makefile               # build / push / verify / checksums targets
│   ├── README.md              # connector matrix, usage, follow-ups
│   └── .dockerignore
└── charts/flink/values.yaml   # +values comment explaining runner-jar requirement (NO default change)
```

## Two-stage Dockerfile

1. **Fetcher** (`alpine:3.19` + curl + coreutils) — reads `jars.txt`, downloads each URL, and runs `sha256sum -c -` when a checksum is supplied. Skips verification with a warning when the checksum is `-` (today all four lines are `-` pending the checksum-pinning follow-up).
2. **Final** (`apache/flink:1.20.0-scala_2.12-java17`) — copies verified jars into `/opt/flink/usrlib/` owned by `flink:flink`. Sanity-checks `flink-sql-runner.jar` exists before finalizing.

## Build / push / verify

```bash
cd deployments/runner/flink-sql-runner
make help                                    # show targets
make build                                   # local docker build
make verify                                  # spawn briefly + ls /opt/flink/usrlib/
make push REGISTRY=ghcr.io/xenoisa           # push to org GHCR
make push REGISTRY=harbor.customer.local/isa-platform   # customer Harbor mirror
make checksums                               # emit jars.txt-formatted sha256 lines
```

## Image tag policy

`1.20.0-runner-1.10.0-paimon-1.0.0` encodes the four-version matrix so a `helm install` referencing the tag aligns with the chart matrix in the README:

| Position | Project | Pinned in |
|---|---|---|
| `1.20.0` | Apache Flink runtime (base image) | `Dockerfile FROM` |
| `runner-1.10.0` | Flink Kubernetes Operator (runner jar source) | `jars.txt` |
| `paimon-1.0.0` | Apache Paimon Flink connector | `jars.txt` |

Bump the tag whenever any of the four versions in `jars.txt` change.

## How operators consume the image

The `flink` chart's default still points at the stock `apache/flink` image so `helm template` keeps rendering cleanly without this image existing. To run real jobs, override:

```yaml
# kind-local
flink:
  session:
    image:
      repository: ghcr.io/xenoisa/flink-sql-runner
      tag: 1.20.0-runner-1.10.0-paimon-1.0.0

# customer-prod (after Harbor mirror sync)
flink:
  session:
    image:
      repository: harbor.customer.local/isa-platform/flink-sql-runner
      tag: 1.20.0-runner-1.10.0-paimon-1.0.0
```

The Harbor mirror path is the air-gap-friendly approach per `sn-commercial-tower/docs/design/00-infra-architecture-overview.md` §5.5.

## Smoke verification

```
=== bash deployments/scripts/verify/verify-bigdata-charts.sh ===
helm lint + helm template clean across all 10 charts × 3 profiles
(unchanged from #254 — the chart contract didn't change, only a
values comment was added)

=== docker build (manual) ===
Two-stage build succeeds; sanity check confirms
/opt/flink/usrlib/flink-sql-runner.jar exists in the final image.
```

## Out of scope (follow-up issues to file)

- **CI workflow** for auto-building the image on jar version bumps — separate `.github/workflows/flink-sql-runner.yml` story
- **Multi-arch (arm64)** — customer cluster is x86_64 only per `00-infra-architecture-overview.md` §3.1
- **Image signing / cosign** — separate supply-chain hardening story
- **Per-CDC-connector image variants** (`mysql-cdc`, `postgres-cdc`) — those land with the W7+ Flink CDC connector wiring story
- **Checksum auto-pinning** — `make checksums` emits the lines today; future PR rewrites `jars.txt` in place automatically

## Test plan

- [ ] Reviewer runs `cd deployments/runner/flink-sql-runner && make build` → image builds successfully (~3 min)
- [ ] Reviewer runs `make verify` → output includes `flink-sql-runner.jar` and `paimon-flink-1.20-1.0.0.jar` and the kafka + avro jars
- [ ] Reviewer reads README's "Connector matrix" + "Bumping versions" sections and confirms the workflow is unambiguous
- [ ] (Once GHCR push happens) `helm install bigdata deployments/umbrella/isa-bigdata -f deployments/values/kind-local.yaml --set flink.session.image.repository=ghcr.io/xenoisa/flink-sql-runner --set flink.session.image.tag=1.20.0-runner-1.10.0-paimon-1.0.0` brings up a session cluster that accepts FlinkSessionJob submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)