### PR TITLE
chore(iceberg): clean up two Paimon comments missed in #261

### DIFF
--- a/deployments/charts/flink-cdc-jobs/Chart.yaml
+++ b/deployments/charts/flink-cdc-jobs/Chart.yaml
@@ -7,12 +7,12 @@ description: |
   FlinkSessionJob CR that submits the SQL to the long-running session
   cluster shipped by the flink chart (#249).
 
-  V0.1 scope: the Kafka → Avro (via Apicurio) → Paimon path. Real
+  V0.1 scope: the Kafka → Avro (via Apicurio) → Iceberg path. Real
   Flink CDC connector wiring (mysql-cdc, postgres-cdc) is out of scope
   until W7+ when real DB binlog sources land.
 
   See xenoISA/isA_Cloud#250, xenoISA/isA_Cloud#234, and
-  xenoISA/sn-commercial-tower ADR-0002 §2.5.
+  xenoISA/sn-commercial-tower ADR-0002 §2.5 + appendix-architecture-v3-iceberg.md.
 type: application
 version: 0.1.0
 appVersion: "1.20.0"

--- a/deployments/charts/starrocks/templates/catalog-init-job.yaml
+++ b/deployments/charts/starrocks/templates/catalog-init-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-  Paimon external catalog init Job.
+  Iceberg external catalog init Job.
 
   Runs as a Helm post-install + post-upgrade hook so the
   StarRocksCluster CR (created by the upstream chart) is applied first.
@@ -9,7 +9,7 @@
 
   Catalog properties mirror the contract in
   deployments/charts/iceberg-tools/templates/configmap.yaml so the same
-  Paimon tables that flink-cdc-jobs writes to are queryable from
+  Iceberg tables that flink-cdc-jobs writes to are queryable from
   StarRocks without any extra config.
 
   ttlSecondsAfterFinished + before-hook-creation + hook-succeeded delete


### PR DESCRIPTION
## Summary

Two prose comments still referenced Paimon after the Paimon → Iceberg migration in [#261](https://github.com/xenoISA/isA_Cloud/pull/261):

| File | Line | Before | After |
|---|---|---|---|
| `deployments/charts/flink-cdc-jobs/Chart.yaml` | 10 | "V0.1 scope: the Kafka → Avro (via Apicurio) → **Paimon** path" | "...→ **Iceberg** path" |
| `deployments/charts/starrocks/templates/catalog-init-job.yaml` | 2, 12 | "**Paimon** external catalog init Job" / "the same **Paimon** tables..." | "**Iceberg** external catalog init Job" / "the same **Iceberg** tables..." |

Functional config is unchanged — these are comment-only fixes. `helm template` + `lint` still clean across all 10 charts × 3 profiles.

The remaining Paimon refs in the repo are intentional:

- `iceberg-tools` README migration table (paimon-tools → iceberg-tools mapping for forward consumers)
- `fluss` DEPRECATED-IN-WAITING notes (Fluss is Paimon-derived; without Paimon the W12+ activation gate is moot)
- One comment in `iceberg-tools/values.yaml` explicitly referencing "the earlier paimon-tools chart" as predecessor context

## Test plan

- [ ] Reviewer runs `bash deployments/scripts/verify/verify-bigdata-charts.sh` → all checks pass
- [ ] Reviewer confirms `grep -i paimon deployments/` returns only intentional historical context

Refs #260 / #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)