### PR TITLE
fix(infra): flink-sql-runner Maven build — correct module path (#255)

### DIFF
--- a/deployments/runner/flink-sql-runner/Dockerfile
+++ b/deployments/runner/flink-sql-runner/Dockerfile
@@ -40,11 +40,23 @@ ADD https://archive.apache.org/dist/flink/flink-kubernetes-operator-${OPERATOR_V
 
 RUN set -eu; \
     tar xzf /build/operator-src.tgz -C /build; \
-    cd /build/flink-kubernetes-operator-${OPERATOR_VERSION}/flink-sql-runner-example; \
-    mvn -B package -DskipTests; \
-    # The build output is target/flink-sql-runner-${OPERATOR_VERSION}.jar
-    # (or similar). Copy it to a stable filename for stage 3.
-    JAR=$(ls target/flink-sql-runner-*.jar | head -n1); \
+    # The flink-sql-runner-example module lives under examples/ in the
+    # operator source tree. Run Maven from the project root with `-pl`
+    # + `-am` so the parent pom + any sibling deps build first.
+    cd /build/flink-kubernetes-operator-${OPERATOR_VERSION}; \
+    mvn -B -DskipTests \
+      -pl examples/flink-sql-runner-example -am \
+      package; \
+    # The build output is examples/flink-sql-runner-example/target/.
+    # Some Maven plugins also produce a `-shaded.jar` (fat jar with
+    # deps) — prefer that when present, otherwise fall back to the
+    # plain jar (excluding sources / javadoc / original).
+    cd examples/flink-sql-runner-example/target; \
+    JAR=$(ls flink-sql-runner-example-*-shaded.jar 2>/dev/null | head -n1); \
+    if [ -z "${JAR}" ]; then \
+      JAR=$(ls flink-sql-runner-example-*.jar 2>/dev/null | grep -vE "sources|javadoc|original" | head -n1); \
+    fi; \
+    test -n "${JAR}" || { echo "[runner-build] no flink-sql-runner-example-*.jar produced"; exit 1; }; \
     cp "${JAR}" /build/flink-sql-runner.jar; \
     test -f /build/flink-sql-runner.jar
 


### PR DESCRIPTION
## Summary

Follow-up to #264. First end-to-end `make build` attempt revealed two more issues that needed Dockerfile-only fixes. After this PR lands, the runner image builds successfully and `make verify` passes.

Closes the build-pipeline gap blocking V-1..V-5 verification on a real cluster.

## Bugs found running `make build`

| # | Bug | Fix |
|---|---|---|
| 1 | Module path: `flink-sql-runner-example` lives at `examples/flink-sql-runner-example/` in the operator source tree, not at the root. The Dockerfile `cd` to non-existent path → exit 2 | `cd /build/flink-kubernetes-operator-${OPERATOR_VERSION}` and use `mvn -pl examples/flink-sql-runner-example -am package` |
| 2 | Multi-module Maven dependency: building only the example module fails because it depends on sibling modules (operator-api, etc.) | `-am` flag tells Maven to build the parent + dependent modules first |
| 3 | Jar selection: build produces both a thin jar and (sometimes) a shaded fat jar. Need a deterministic pick + filter out `sources` / `javadoc` / `original` variants | Prefer `*-shaded.jar`; fall back to plain `flink-sql-runner-example-*.jar` excluding the variants |

## Verified end-to-end

```
$ make build
...
[INFO] BUILD SUCCESS
[INFO] Total time:  04:37 min
=> writing image sha256:7e8a31...
=> naming to ghcr.io/xenoisa/flink-sql-runner:1.20.0-runner-1.10.0-iceberg-1.7.2

$ make verify
total 60144
-rw-r--r-- 1 flink flink 22641805 flink-sql-avro-confluent-registry-1.20.0.jar
-rw-r--r-- 1 flink flink  5587110 flink-sql-connector-kafka-3.3.0-1.20.jar
-rw-r--r-- 1 flink flink    11721 flink-sql-runner.jar
-rw-r--r-- 1 flink flink 33333195 iceberg-flink-runtime-1.20-1.7.2.jar
OK
```

Image is ~3.3GB compressed; ready for `make push REGISTRY=harbor.customer.local/isa-platform` once the customer Harbor mirror is online.

## Build-from-source observations (worth flagging)

- **Build time**: ~5 min on Docker Desktop with first run (Maven dependency download from Maven Central). Cached builds drop to ~1.5 min.
- **Image size**: the maven build stage adds ~500MB intermediate layers; final image stays at ~3.3GB (apache/flink:1.20 base is already ~1.6GB; added jars are ~60MB total).
- **flink-sql-runner.jar size**: only 11.7 KB — it's the example app's compiled bytecode, not a fat jar. The bundled connector jars (Iceberg, Kafka, Avro) provide the actual runtime, which is what we want — they go into Flink's `/opt/flink/usrlib/` and are auto-loaded.

## Test plan

- [ ] Reviewer runs `cd deployments/runner/flink-sql-runner && make build && make verify` → both pass
- [ ] Reviewer can confirm image works in a kind cluster: `helm install bigdata deployments/umbrella/isa-bigdata -f deployments/values/kind-local.yaml --set flink.session.image.repository=ghcr.io/xenoisa/flink-sql-runner --set flink.session.image.tag=1.20.0-runner-1.10.0-iceberg-1.7.2 -n isa-bigdata --create-namespace` (after Strimzi Operator + cert-manager prerequisites are in place)

Refs #255 / #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)